### PR TITLE
Re-add `${param:...}` variable

### DIFF
--- a/lib/configuration/variables/sources/instance-dependent/param.js
+++ b/lib/configuration/variables/sources/instance-dependent/param.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const _ = require('lodash');
+const memoizee = require('memoizee');
+const ensureString = require('type/string/ensure');
+const ServerlessError = require('../../../../serverless-error');
+
+const resolveParams = memoizee(async (stage, serverlessInstance) => {
+  const configParams = new Map(
+    Object.entries(_.get(serverlessInstance.configurationInput, 'params') || {})
+  );
+
+  const resultParams = Object.create(null);
+
+  for (const [name, value] of Object.entries(configParams.get(stage) || {})) {
+    if (value == null) continue;
+    if (resultParams[name] != null) continue;
+    resultParams[name] = { value, type: 'configServiceStage' };
+  }
+
+  for (const [name, value] of new Map(Object.entries(configParams.get('default') || {}))) {
+    if (value == null) continue;
+    if (resultParams[name] != null) continue;
+    resultParams[name] = { value, type: 'configService' };
+  }
+
+  return resultParams;
+});
+
+module.exports = (serverlessInstance) => {
+  return {
+    resolve: async ({ address, resolveConfigurationProperty, options }) => {
+      if (!address) {
+        throw new ServerlessError(
+          'Missing address argument in variable "param" source',
+          'MISSING_PARAM_SOURCE_ADDRESS'
+        );
+      }
+      address = ensureString(address, {
+        Error: ServerlessError,
+        errorMessage: 'Non-string address argument in variable "param" source: %v',
+        errorCode: 'INVALID_PARAM_SOURCE_ADDRESS',
+      });
+      if (!serverlessInstance) return { value: null, isPending: true };
+
+      let stage = options.stage;
+      if (!stage) stage = await resolveConfigurationProperty(['provider', 'stage']);
+      if (!stage) stage = 'dev';
+
+      const params = await resolveParams(stage, serverlessInstance);
+      const value = params[address] ? params[address].value : null;
+      const result = { value };
+
+      if (value == null) {
+        throw new ServerlessError(
+          `The param "${address}" cannot be resolved from stage params. If you are using Serverless Framework Compose, make sure to run commands via Compose so that all parameters can be resolved`,
+          'MISSING_PARAM_SOURCE_ADDRESS'
+        );
+      }
+
+      return result;
+    },
+  };
+};

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -46,7 +46,7 @@ const finalize = async ({ error, shouldBeSync } = {}) => {
   hasBeenFinalized = true;
   clearTimeout(keepAliveTimer);
   progress.clear();
-  if (error) (handleError(error, { serverless }));
+  if (error) handleError(error, { serverless });
   if (!shouldBeSync) {
     await logDeprecation.printSummary();
   }
@@ -474,11 +474,7 @@ process.once('uncaughtException', (error) => {
 
     // Names of the commands which are configured independently in root `commands` folder
     // and not in Serverless class internals
-    const notIntegratedCommands = new Set([
-      'doctor',
-      'plugin install',
-      'plugin uninstall',
-    ]);
+    const notIntegratedCommands = new Set(['doctor', 'plugin install', 'plugin uninstall']);
     const isStandaloneCommand = notIntegratedCommands.has(command);
 
     if (!isHelpRequest) {
@@ -564,6 +560,7 @@ process.once('uncaughtException', (error) => {
               self: require('../lib/configuration/variables/sources/self'),
               strToBool: require('../lib/configuration/variables/sources/str-to-bool'),
               sls: require('../lib/configuration/variables/sources/instance-dependent/get-sls')(),
+              param: require('../lib/configuration/variables/sources/instance-dependent/param')(),
             },
             options: filterSupportedOptions(options, { commandSchema, providerName }),
             fulfilledSources: new Set(['env', 'file', 'self', 'strToBool']),
@@ -588,6 +585,8 @@ process.once('uncaughtException', (error) => {
           require('../lib/configuration/variables/sources/instance-dependent/get-sls')(serverless);
         resolverConfiguration.fulfilledSources.add('sls');
 
+        resolverConfiguration.sources.param =
+          require('../lib/configuration/variables/sources/instance-dependent/param')(serverless);
         resolverConfiguration.fulfilledSources.add('param');
 
         // Register AWS provider specific variable sources

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/param.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/param.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const { expect } = require('chai');
+const _ = require('lodash');
+
+const resolveMeta = require('../../../../../../../lib/configuration/variables/resolve-meta');
+const resolve = require('../../../../../../../lib/configuration/variables/resolve');
+const selfSource = require('../../../../../../../lib/configuration/variables/sources/self');
+const getParamSource = require('../../../../../../../lib/configuration/variables/sources/instance-dependent/param');
+const Serverless = require('../../../../../../../lib/serverless');
+
+describe('test/unit/lib/configuration/variables/sources/instance-dependent/param.test.js', () => {
+  let configuration;
+  let variablesMeta;
+  let serverlessInstance;
+
+  const initializeServerless = async ({ configExt, options, setupOptions = {} } = {}) => {
+    configuration = {
+      service: 'foo',
+      provider: {
+        name: 'aws',
+        deploymentBucket: '${param:bucket}',
+        timeout: '${param:timeout}',
+      },
+      custom: {
+        missingAddress: '${param:}',
+        unsupportedAddress: '${param:foo}',
+        nonStringAddress: '${param:${self:custom.someObject}}',
+        someObject: {},
+      },
+      params: {
+        default: {
+          bucket: 'global.bucket',
+          timeout: 10,
+        },
+        dev: {
+          bucket: 'my.bucket',
+        },
+      },
+    };
+    if (configExt) {
+      configuration = _.merge(configuration, configExt);
+    }
+    variablesMeta = resolveMeta(configuration);
+    serverlessInstance = new Serverless({
+      configuration,
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      commands: ['package'],
+      options: options || {},
+    });
+    serverlessInstance.init();
+    await resolve({
+      serviceDir: process.cwd(),
+      configuration,
+      variablesMeta,
+      sources: {
+        self: selfSource,
+        param: getParamSource(setupOptions.withoutInstance ? null : serverlessInstance),
+      },
+      options: options || {},
+      fulfilledSources: new Set(['self', 'param']),
+    });
+  };
+
+  it('should resolve ${param:timeout}', async () => {
+    await initializeServerless();
+    if (variablesMeta.get('param\0timeout')) throw variablesMeta.get('param\0timeout').error;
+    expect(configuration.provider.timeout).to.equal(10);
+  });
+
+  it('should resolve ${param:bucket} for different stages', async () => {
+    // Dev by default
+    await initializeServerless();
+    expect(configuration.provider.deploymentBucket).to.equal('my.bucket');
+
+    // Forced prod
+    await initializeServerless({
+      configExt: {
+        provider: {
+          stage: 'prod',
+        },
+      },
+    });
+    expect(configuration.provider.deploymentBucket).to.equal('global.bucket');
+  });
+
+  it('should resolve ${param:bucket} when no serverless instance available', async () => {
+    await initializeServerless({ setupOptions: { withoutInstance: true } });
+    expect(variablesMeta.get('provider\0timeout')).to.have.property('variables');
+    expect(variablesMeta.get('provider\0timeout')).to.not.have.property('error');
+  });
+
+  it('should report with an error missing address', async () => {
+    await initializeServerless();
+    expect(variablesMeta.get('custom\0missingAddress').error.code).to.equal(
+      'VARIABLE_RESOLUTION_ERROR'
+    );
+  });
+
+  it('should report with an error unsupported address', async () => {
+    await initializeServerless();
+    expect(variablesMeta.get('custom\0unsupportedAddress').error.code).to.equal(
+      'VARIABLE_RESOLUTION_ERROR'
+    );
+  });
+
+  it('should report with an error a non-string address', async () => {
+    await initializeServerless();
+    expect(variablesMeta.get('custom\0nonStringAddress').error.code).to.equal(
+      'VARIABLE_RESOLUTION_ERROR'
+    );
+  });
+});


### PR DESCRIPTION
It was part of the dashboard plugin because I guess some values might come from it. I extracted only the interesting part without the dashboard stuff.

Unit tests are ok. I tested it on few projects and it works as expected.