### PR TITLE
Update `child-process-ext` to 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bluebird": "^3.7.2",
     "cachedir": "^2.3.0",
     "chalk": "^4.1.2",
-    "child-process-ext": "^2.1.1",
+    "child-process-ext": "^3.0.2",
     "ci-info": "^3.9.0",
     "cli-progress-footer": "^2.3.2",
     "d": "^1.0.1",


### PR DESCRIPTION
The 3.0 BC was to drop Node < v8.
This will upgrade `cross-spawn` to v7.