### PR TITLE
Add `python3.13` runtime

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -635,6 +635,7 @@ class AwsProvider {
               'python3.10',
               'python3.11',
               'python3.12',
+              'python3.13',
               'ruby2.7',
               'ruby3.2',
               'ruby3.3',


### PR DESCRIPTION
Available since last week: https://aws.amazon.com/fr/blogs/compute/python-3-13-runtime-now-available-in-aws-lambda/