### PR TITLE
feat: add node22 lambda runtime

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -626,6 +626,7 @@ class AwsProvider {
               'nodejs16.x',
               'nodejs18.x',
               'nodejs20.x',
+              'nodejs22.x',
               'provided',
               'provided.al2',
               'provided.al2023',


### PR DESCRIPTION
Node 22 was added as an available runtime this month (Nov 2024) - https://docs.aws.amazon.com/codebuild/latest/userguide/runtime-versions.html.