### PR TITLE
Fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This repository contains the following differences with the original Serverless 
 - [Resources](./docs/guides/resources.md)
 - [Composing services](./docs/guides/compose.md)
 - [Workflow Tips](./docs/guides/workflow.md)
-- [Serverless.yml Reference](./docs/guides/serverless.yml)
+- [Serverless.yml Reference](./docs/guides/serverless.yml.md)
 
 # Function events
 


### PR DESCRIPTION
The link to "Serverless.yml Reference" was broken. This fixes the link.