### PR TITLE
fix: enable compatibility for loading native ES modules with require

### DIFF
--- a/lib/utils/require-with-import-fallback.js
+++ b/lib/utils/require-with-import-fallback.js
@@ -2,7 +2,8 @@
 
 module.exports = async (modPath) => {
   try {
-    return require(modPath);
+    const mod = require(modPath);
+    return mod && mod.default ? mod.default : mod;
   } catch (error) {
     // Fallback to import() if the runtime supports native ESM
     if (error.code === 'ERR_REQUIRE_ESM') {


### PR DESCRIPTION
Back port https://github.com/serverless/serverless/commit/8b960a2e92364149e463c274172dc9d08a37a836 which is linked to https://github.com/serverless/serverless/issues/12936