### PR TITLE
Added back support for CLI parameters.

### DIFF
--- a/lib/configuration/variables/sources/instance-dependent/param.js
+++ b/lib/configuration/variables/sources/instance-dependent/param.js
@@ -12,6 +12,20 @@ const resolveParams = memoizee(async (stage, serverlessInstance) => {
 
   const resultParams = Object.create(null);
 
+  if (serverlessInstance.processedInput.options.param) {
+    const regex = /(?<key>[^=]+)=(?<value>.+)/;
+    for (const item of serverlessInstance.processedInput.options.param) {
+      const res = item.match(regex);
+      if (!res) {
+        throw new ServerlessError(
+          `Encountered invalid "--param" CLI option value: "${item}". Supported format: "--param='<key>=<val>'"`,
+          'INVALID_CLI_PARAM_FORMAT'
+        );
+      }
+      resultParams[res.groups.key] = { value: res.groups.value.trimEnd(), type: 'cli' };
+    }
+  }
+
   for (const [name, value] of Object.entries(configParams.get(stage) || {})) {
     if (value == null) continue;
     if (resultParams[name] != null) continue;

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/param.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/param.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { expect } = require('chai');
-const _ = require('lodash');
 
 const resolveMeta = require('../../../../../../../lib/configuration/variables/resolve-meta');
 const resolve = require('../../../../../../../lib/configuration/variables/resolve');


### PR DESCRIPTION
As part of https://github.com/oss-serverless/serverless/pull/7, `param` variables were added back into this fork as this functionality was removed due to it being part of `@serverless/dashboard-plugin`. However that PR only added back support for variables defined as stage variables in the `serverless.yml` configuration, not as CLI arguments.

This PR adds back support for passing `param` variables as CLI arguments.