### PR TITLE
feat: add custom runtime support based on the defined runtime

### DIFF
--- a/lib/plugins/aws/custom-resources/index.js
+++ b/lib/plugins/aws/custom-resources/index.js
@@ -164,7 +164,7 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
 
   let runtimeVersion = 'nodejs18.x';
   const providerRuntime = awsProvider.getRuntime();
-  if (providerRuntime.indexOf('nodejs') !== -1) {
+  if (providerRuntime.startsWith('nodejs')) {
     runtimeVersion = providerRuntime;
   }
 

--- a/lib/plugins/aws/custom-resources/index.js
+++ b/lib/plugins/aws/custom-resources/index.js
@@ -162,6 +162,8 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
     });
   }
 
+  const runtimeVersion = providerConfig.runtime ? providerConfig.runtime : 'nodejs18.x';
+
   const customResourceFunction = {
     Type: 'AWS::Lambda::Function',
     Properties: {
@@ -172,7 +174,7 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
       FunctionName: absoluteFunctionName,
       Handler,
       MemorySize: 1024,
-      Runtime: 'nodejs18.x',
+      Runtime: runtimeVersion,
       Timeout: 180,
     },
     DependsOn: [],

--- a/lib/plugins/aws/custom-resources/index.js
+++ b/lib/plugins/aws/custom-resources/index.js
@@ -162,7 +162,11 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
     });
   }
 
-  const runtimeVersion = providerConfig.runtime ? providerConfig.runtime : 'nodejs18.x';
+  let runtimeVersion = 'nodejs18.x';
+  const providerRuntime = awsProvider.getRuntime();
+  if (providerRuntime.indexOf('nodejs') !== -1) {
+    runtimeVersion = providerRuntime;
+  }
 
   const customResourceFunction = {
     Type: 'AWS::Lambda::Function',

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1822,7 +1822,7 @@ class AwsProvider {
   }
 
   getRuntime(runtime) {
-    const defaultRuntime = 'nodejs16.x';
+    const defaultRuntime = 'nodejs18.x';
     const runtimeSourceValue = this.getRuntimeSourceValue();
     return runtime || runtimeSourceValue.value || defaultRuntime;
   }

--- a/lib/plugins/package/lib/package-service.js
+++ b/lib/plugins/package/lib/package-service.js
@@ -29,7 +29,7 @@ module.exports = {
   },
 
   getRuntime(runtime) {
-    const defaultRuntime = 'nodejs16.x';
+    const defaultRuntime = 'nodejs18.x';
     return runtime || this.serverless.service.provider.runtime || defaultRuntime;
   },
 

--- a/test/fixtures/cli/variables/serverless.yml
+++ b/test/fixtures/cli/variables/serverless.yml
@@ -3,7 +3,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 custom:
   importedFile: ${file(config.json)}

--- a/test/fixtures/programmatic/api-gateway-extended/serverless.yml
+++ b/test/fixtures/programmatic/api-gateway-extended/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
   apiGateway:
     shouldStartNameWithService: true

--- a/test/fixtures/programmatic/api-gateway/serverless.yml
+++ b/test/fixtures/programmatic/api-gateway/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   apiGateway:
     shouldStartNameWithService: true
 

--- a/test/fixtures/programmatic/check-for-changes/serverless.yml
+++ b/test/fixtures/programmatic/check-for-changes/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 functions:
   fn1:

--- a/test/fixtures/programmatic/cognito-user-pool/serverless.yml
+++ b/test/fixtures/programmatic/cognito-user-pool/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/config-schema-extensions-error/serverless.yml
+++ b/test/fixtures/programmatic/config-schema-extensions-error/serverless.yml
@@ -2,7 +2,7 @@ service: configSchemaExtensionsError
 
 provider:
   name: someProvider
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 configValidationMode: error
 frameworkVersion: '*'

--- a/test/fixtures/programmatic/curated-plugins/serverless.yml
+++ b/test/fixtures/programmatic/curated-plugins/serverless.yml
@@ -10,7 +10,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 functions:
   function:

--- a/test/fixtures/programmatic/ecr/serverless.yml
+++ b/test/fixtures/programmatic/ecr/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   ecr:
     images:
       baseimage:

--- a/test/fixtures/programmatic/event-bridge/serverless.yml
+++ b/test/fixtures/programmatic/event-bridge/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/function-active-mq/serverless.yml
+++ b/test/fixtures/programmatic/function-active-mq/serverless.yml
@@ -8,7 +8,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/function-cloud-front/serverless.yml
+++ b/test/fixtures/programmatic/function-cloud-front/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 functions:
   foo:

--- a/test/fixtures/programmatic/function-efs/serverless.yml
+++ b/test/fixtures/programmatic/function-efs/serverless.yml
@@ -7,7 +7,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/function-layers/serverless.yml
+++ b/test/fixtures/programmatic/function-layers/serverless.yml
@@ -1,7 +1,7 @@
 service: service
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 layers:
   testLayer:

--- a/test/fixtures/programmatic/function-msk/serverless.yml
+++ b/test/fixtures/programmatic/function-msk/serverless.yml
@@ -8,7 +8,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/function-rabbit-mq/serverless.yml
+++ b/test/fixtures/programmatic/function-rabbit-mq/serverless.yml
@@ -8,7 +8,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/function/serverless.yml
+++ b/test/fixtures/programmatic/function/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 functions:
   basic:

--- a/test/fixtures/programmatic/http-api-catch-all/serverless.yml
+++ b/test/fixtures/programmatic/http-api-catch-all/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 functions:
   foo:

--- a/test/fixtures/programmatic/http-api-export/serverless.yml
+++ b/test/fixtures/programmatic/http-api-export/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 resources:
   Resources:

--- a/test/fixtures/programmatic/http-api/serverless.yml
+++ b/test/fixtures/programmatic/http-api/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   logRetentionInDays: 14
 
 functions:

--- a/test/fixtures/programmatic/invocation/serverless.yml
+++ b/test/fixtures/programmatic/invocation/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 functions:
   callback:

--- a/test/fixtures/programmatic/iot-fleet-provisioning/serverless.yml
+++ b/test/fixtures/programmatic/iot-fleet-provisioning/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/iot/serverless.yml
+++ b/test/fixtures/programmatic/iot/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/layer/serverless.yml
+++ b/test/fixtures/programmatic/layer/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 functions:
   function:

--- a/test/fixtures/programmatic/multi-service/service-a/serverless.yml
+++ b/test/fixtures/programmatic/multi-service/service-a/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 custom:
   env: ${env:ENV_SOURCE_TEST, null}

--- a/test/fixtures/programmatic/package-artifact-in-serverless-dir/serverless.yml
+++ b/test/fixtures/programmatic/package-artifact-in-serverless-dir/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 plugins:
   # Mutates `package.artifact` to point to copied `.serverless/NAME.zip`

--- a/test/fixtures/programmatic/package-artifact/serverless.yml
+++ b/test/fixtures/programmatic/package-artifact/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 package:
   artifact: artifact.zip

--- a/test/fixtures/programmatic/packaging/serverless.yml
+++ b/test/fixtures/programmatic/packaging/serverless.yml
@@ -6,7 +6,7 @@ disabledDeprecations: LOAD_VARIABLES_FROM_ENV_FILES
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 functions:
   fnService:

--- a/test/fixtures/programmatic/plugin/serverless.yml
+++ b/test/fixtures/programmatic/plugin/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 plugins:
   - ./plugin

--- a/test/fixtures/programmatic/provisioned-concurrency/serverless.yml
+++ b/test/fixtures/programmatic/provisioned-concurrency/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/request-parameters/serverless.yml
+++ b/test/fixtures/programmatic/request-parameters/serverless.yml
@@ -2,7 +2,7 @@ service: service
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 functions:
   target:

--- a/test/fixtures/programmatic/request-schema/serverless.yml
+++ b/test/fixtures/programmatic/request-schema/serverless.yml
@@ -2,7 +2,7 @@ service: service
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   apiGateway:
     request:
       schemas:

--- a/test/fixtures/programmatic/s3/serverless.yml
+++ b/test/fixtures/programmatic/s3/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
   s3:
     customBucket:

--- a/test/fixtures/programmatic/schedule/serverless.yml
+++ b/test/fixtures/programmatic/schedule/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/sns/serverless.yml
+++ b/test/fixtures/programmatic/sns/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/sqs/serverless.yml
+++ b/test/fixtures/programmatic/sqs/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/stream/serverless.yml
+++ b/test/fixtures/programmatic/stream/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/variables-legacy/serverless.yml
+++ b/test/fixtures/programmatic/variables-legacy/serverless.yml
@@ -2,7 +2,7 @@ service: service
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 custom:
   importedFile: ${file(config.json)}

--- a/test/fixtures/programmatic/websocket-external-auth/serverless.yml
+++ b/test/fixtures/programmatic/websocket-external-auth/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/websocket/serverless.yml
+++ b/test/fixtures/programmatic/websocket/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   versionFunctions: false
   logs:
     websocket: true

--- a/test/integration-package/cloudformation.tests.js
+++ b/test/integration-package/cloudformation.tests.js
@@ -44,7 +44,7 @@ describe('Integration test - Packaging - CloudFormation', () => {
         Role: {
           'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'],
         },
-        Runtime: 'nodejs16.x',
+        Runtime: 'nodejs18.x',
         Timeout: 6,
       },
       DependsOn: ['HelloLogGroup'],
@@ -75,7 +75,7 @@ describe('Integration test - Packaging - CloudFormation', () => {
         Role: {
           'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'],
         },
-        Runtime: 'nodejs16.x',
+        Runtime: 'nodejs18.x',
         Timeout: 6,
       },
       DependsOn: ['HelloLogGroup'],
@@ -109,7 +109,7 @@ describe('Integration test - Packaging - CloudFormation', () => {
         Role: {
           'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'],
         },
-        Runtime: 'nodejs16.x',
+        Runtime: 'nodejs18.x',
         Timeout: 6,
       },
       DependsOn: ['HelloLogGroup'],

--- a/test/integration-package/fixtures/artifact/serverless.yml
+++ b/test/integration-package/fixtures/artifact/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 functions:
   hello:

--- a/test/integration-package/fixtures/individually-function/serverless.yml
+++ b/test/integration-package/fixtures/individually-function/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 functions:
   hello:

--- a/test/integration-package/fixtures/individually/serverless.yml
+++ b/test/integration-package/fixtures/individually/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 package:
   individually: true

--- a/test/integration-package/fixtures/regular/serverless.yml
+++ b/test/integration-package/fixtures/regular/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
 
 functions:
   hello:

--- a/test/unit/lib/plugins/aws/custom-resources/index.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/index.test.js
@@ -396,9 +396,15 @@ describe('#addCustomResourceToService()', () => {
 
     const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
 
-    expect(Resources.CustomDashresourceDashexistingDashs3LambdaFunction.Properties.Runtime).to.equal('nodejs22.x');
-    expect(Resources.CustomDashresourceDashexistingDashcupLambdaFunction.Properties.Runtime).to.equal('nodejs22.x');
-    expect(Resources.CustomDashresourceDasheventDashbridgeLambdaFunction.Properties.Runtime).to.equal('nodejs22.x');
+    expect(
+      Resources.CustomDashresourceDashexistingDashs3LambdaFunction.Properties.Runtime
+    ).to.equal('nodejs22.x');
+    expect(
+      Resources.CustomDashresourceDashexistingDashcupLambdaFunction.Properties.Runtime
+    ).to.equal('nodejs22.x');
+    expect(
+      Resources.CustomDashresourceDasheventDashbridgeLambdaFunction.Properties.Runtime
+    ).to.equal('nodejs22.x');
   });
 });
 

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -335,7 +335,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs16.x',
+          Runtime: 'nodejs18.x',
           Timeout: 6,
         },
       };
@@ -395,7 +395,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs16.x',
+              Runtime: 'nodejs18.x',
               Timeout: 6,
               DeadLetterConfig: {
                 TargetArn: 'arn:aws:sns:region:accountid:foo',
@@ -446,7 +446,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs16.x',
+              Runtime: 'nodejs18.x',
               Timeout: 6,
               DeadLetterConfig: {
                 TargetArn: {
@@ -488,7 +488,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs16.x',
+              Runtime: 'nodejs18.x',
               Timeout: 6,
               DeadLetterConfig: {
                 TargetArn: {
@@ -530,7 +530,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs16.x',
+              Runtime: 'nodejs18.x',
               Timeout: 6,
               DeadLetterConfig: {
                 TargetArn: {
@@ -572,7 +572,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs16.x',
+              Runtime: 'nodejs18.x',
               Timeout: 6,
               DeadLetterConfig: {
                 TargetArn: 'arn:aws:sns:region:accountid:foo',
@@ -639,7 +639,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs16.x',
+              Runtime: 'nodejs18.x',
               Timeout: 6,
               TracingConfig: {
                 Mode: 'Active',
@@ -696,7 +696,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs16.x',
+          Runtime: 'nodejs18.x',
           Timeout: 6,
           Environment: {
             Variables: {
@@ -763,7 +763,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 128,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs16.x',
+          Runtime: 'nodejs18.x',
           Timeout: 10,
         },
       };
@@ -862,7 +862,7 @@ describe('AwsCompileFunctions', () => {
           MemorySize: 1024,
           ReservedConcurrentExecutions: 5,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs16.x',
+          Runtime: 'nodejs18.x',
           Timeout: 6,
         },
       };
@@ -918,7 +918,7 @@ describe('AwsCompileFunctions', () => {
           MemorySize: 1024,
           ReservedConcurrentExecutions: 0,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs16.x',
+          Runtime: 'nodejs18.x',
           Timeout: 6,
         },
       };
@@ -991,7 +991,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs16.x',
+          Runtime: 'nodejs18.x',
           Timeout: 6,
         },
       };
@@ -1029,7 +1029,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs16.x',
+          Runtime: 'nodejs18.x',
           Timeout: 6,
           Layers: ['arn:aws:xxx:*:*'],
         },
@@ -1116,7 +1116,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
               providerCfIfEnvVar: { 'Fn::If': ['cond', 'first', 'second'] },
             },
             memorySize: 4096,
-            runtime: 'nodejs16.x',
+            runtime: 'nodejs18.x',
             runtimeManagement: {
               mode: 'manual',
               arn: 'arn:aws:lambda:us-east-1:111111111111::runtime:7b620fc2e66107a1046b140b9d320295811af3ad5d4c6a011fad1fa65127e9e6I',
@@ -1139,7 +1139,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
                 sharedEnvVar: 'valueFromFunction',
               },
               memorySize: 2048,
-              runtime: 'nodejs16.x',
+              runtime: 'nodejs18.x',
               runtimeManagement: 'onFunctionUpdate',
               versionFunction: true,
             },
@@ -1743,7 +1743,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
               ExternalLambdaLayer: {
                 Type: 'AWS::Lambda::LayerVersion',
                 Properties: {
-                  CompatibleRuntimes: ['nodejs16.x'],
+                  CompatibleRuntimes: ['nodejs18.x'],
                   Content: {
                     S3Bucket: 'bucket',
                     S3Key: 'key',
@@ -1872,9 +1872,9 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
       // https://github.com/serverless/serverless/blob/d8527d8b57e7e5f0b94ba704d9f53adb34298d99/lib/plugins/aws/package/compile/functions/index.test.js#L1784-L1820
     });
 
-    it('should default to "nodejs16.x" runtime`', () => {
+    it('should default to "nodejs18.x" runtime`', () => {
       const funcResource = cfResources[naming.getLambdaLogicalId('target')];
-      expect(funcResource.Properties.Runtime).to.equal('nodejs16.x');
+      expect(funcResource.Properties.Runtime).to.equal('nodejs18.x');
     });
 
     it.skip('TODO: should support `functions[].runtime`', () => {

--- a/test/unit/lib/plugins/aws/package/compile/layers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/layers.test.js
@@ -48,7 +48,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
           layerTwo: {
             description: 'Layer two example',
             path: 'layer',
-            compatibleRuntimes: ['nodejs16.x'],
+            compatibleRuntimes: ['nodejs18.x'],
             compatibleArchitectures: ['arm64'],
             licenseInfo: 'GPL',
             allowedAccounts: ['123456789012', '123456789013'],
@@ -186,7 +186,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
     const layerOne = cfResources[layerResourceName];
 
     expect(layerOne.Type).to.equals('AWS::Lambda::LayerVersion');
-    expect(layerOne.Properties.CompatibleRuntimes).to.deep.equals(['nodejs16.x']);
+    expect(layerOne.Properties.CompatibleRuntimes).to.deep.equals(['nodejs18.x']);
   });
 
   it('should support `layers[].compatibleArchitectures`', () => {


### PR DESCRIPTION
When creating custom resource functions, try to use the defined runtime of the serverless config. This is useful when your project is already running on a new(er) Node version.