### PR TITLE
Fix support for Serverless Compose

### DIFF
--- a/bin/serverless.js
+++ b/bin/serverless.js
@@ -41,7 +41,7 @@ require('../lib/cli/triage')().then((cliName) => {
     case 'serverless':
       require('../scripts/serverless');
       return;
-    case '@serverless/compose':
+    case '@osls/compose':
       require('../lib/cli/run-compose')().catch((error) => {
         // Expose eventual resolution error as regular crash, and not unhandled rejection
         process.nextTick(() => {

--- a/docs/guides/compose.md
+++ b/docs/guides/compose.md
@@ -215,8 +215,6 @@ The `serverless-compose.yml` and `serverless.yml` files have different syntaxes 
 
 Unless documented here, expect `serverless.yml` features to not be supported in `serverless-compose.yml`. For example, it is not possible to include plugins or use most `serverless.yml` variables (like `${self:`, `${opt:`, etc.) inside `serverless-compose.yml`.
 
-You can [open feature requests](https://github.com/serverless/compose) if you need features that aren't supported in `serverless-compose.yml`.
-
 ## Refreshing outputs
 
 The outputs of a service are stored locally (in the `.serverless/` directory). If a colleague deployed changes that changed the outputs of a service, you can refresh your local state via the `refresh-outputs` command:

--- a/lib/cli/run-compose.js
+++ b/lib/cli/run-compose.js
@@ -7,7 +7,7 @@ const fsp = require('fs').promises;
 const spawn = require('child-process-ext/spawn');
 const inquirer = require('@serverless/utils/inquirer');
 
-const relativeBinPath = '@serverless/compose/bin/serverless-compose';
+const relativeBinPath = '@osls/compose/bin/serverless-compose';
 
 // Logic inspired by `@serverless/utils` which is not used as it currently
 // requires logger setup which is not needed when running Compose CLI
@@ -73,7 +73,7 @@ module.exports = async () => {
       )}\n`
     );
 
-    // In this situation, we want to ask user for installing the `@serverless/compose`
+    // In this situation, we want to ask user for installing the `@osls/compose`
     // and adding it to `devDependencies` of `package.json`
 
     let promptMessage = 'Do you want to install Serverless Compose locally with "npm"?';
@@ -116,13 +116,13 @@ module.exports = async () => {
         }
 
         try {
-          await spawn('npm', ['install', '--save-dev', '@serverless/compose']);
+          await spawn('npm', ['install', '--save-dev', '@osls/compose']);
         } catch {
           process.stdout.write(
             `${[
               '',
               'Could not install Serverless Compose CLI locally.',
-              'Please install it manually with "npm i --save-dev @serverless/compose" and run this command again.',
+              'Please install it manually with "npm i --save-dev @osls/compose" and run this command again.',
             ].join('\n')}\n`
           );
           return;
@@ -135,7 +135,7 @@ module.exports = async () => {
       process.stdout.write(
         `${[
           '',
-          'Please install it manually with "npm i --save-dev @serverless/compose" and run this command again.',
+          'Please install it manually with "npm i --save-dev @osls/compose" and run this command again.',
         ].join('\n')}\n`
       );
       return;
@@ -143,20 +143,20 @@ module.exports = async () => {
   } else {
     // Non-interactive scenario
 
-    // Here, we want to check if user has `@serverless/compose` in `devDependencies` of `package.json`
+    // Here, we want to check if user has `@osls/compose` in `devDependencies` of `package.json`
     // If that is the case, we want to run `npm install` to ensure it's installed
-    // In all other scenarios, we want to inform user that `@serverless/compose` needs to be installed first (and/or added to "package.json")
+    // In all other scenarios, we want to inform user that `@osls/compose` needs to be installed first (and/or added to "package.json")
     process.stdout.write(`${['', 'Installing Serverless Compose CLI via NPM'].join('\n')}\n`);
 
     const failedInstallationErrorMessage = `${[
       '',
-      'Installation failed. Make sure the "@serverless/compose" package is required in "package.json" in the current directory so that Serverless Framework installs Compose automatically.',
-      'Alternatively you can install the "@serverless/compose" package manually via NPM.',
+      'Installation failed. Make sure the "@osls/compose" package is required in "package.json" in the current directory so that Serverless Framework installs Compose automatically.',
+      'Alternatively you can install the "@osls/compose" package manually via NPM.',
     ].join('\n')}\n`;
 
-    if (_.get(packageJsonContent, 'devDependencies.@serverless/compose')) {
+    if (_.get(packageJsonContent, 'devDependencies.@osls/compose')) {
       try {
-        await spawn('npm', ['install', '--no-save', '--no-package-lock', '@serverless/compose']);
+        await spawn('npm', ['install', '--no-save', '--no-package-lock', '@osls/compose']);
         hasInstalledCompose = true;
       } catch {
         process.stdout.write(failedInstallationErrorMessage);

--- a/lib/cli/triage.js
+++ b/lib/cli/triage.js
@@ -53,7 +53,7 @@ module.exports = async () => {
         )
       ).some(Boolean)
     ) {
-      return '@serverless/compose';
+      return '@osls/compose';
     }
   }
 

--- a/test/unit/lib/cli/triage/index.test.js
+++ b/test/unit/lib/cli/triage/index.test.js
@@ -37,7 +37,7 @@ describe('test/unit/lib/cli/triage/index.test.js', () => {
     });
     after(() => restoreArgv());
 
-    for (const cliName of ['serverless', '@serverless/compose']) {
+    for (const cliName of ['serverless', '@osls/compose']) {
       for (const extension of fs.readdirSync(path.resolve(fixturesDirname, cliName))) {
         for (const fixtureName of fs.readdirSync(
           path.resolve(fixturesDirname, cliName, extension)
@@ -64,9 +64,9 @@ describe('test/unit/lib/cli/triage/index.test.js', () => {
       });
       after(() => restoreArgv());
 
-      it('should not resolve to `@serverless/compose` with compose config present when command should be ignored', async () => {
+      it('should not resolve to `@osls/compose` with compose config present when command should be ignored', async () => {
         await overrideCwd(
-          path.resolve(fixturesDirname, '@serverless/compose', 'yml', 'project'),
+          path.resolve(fixturesDirname, '@osls/compose', 'yml', 'project'),
           async () => {
             expect(await triage()).to.equal('serverless');
           }
@@ -81,11 +81,11 @@ describe('test/unit/lib/cli/triage/index.test.js', () => {
       });
       after(() => restoreArgv());
 
-      it('should resolve to `@serverless/compose` with `--help` when compose config present', async () => {
+      it('should resolve to `@osls/compose` with `--help` when compose config present', async () => {
         await overrideCwd(
-          path.resolve(fixturesDirname, '@serverless/compose', 'yml', 'project'),
+          path.resolve(fixturesDirname, '@osls/compose', 'yml', 'project'),
           async () => {
-            expect(await triage()).to.equal('@serverless/compose');
+            expect(await triage()).to.equal('@osls/compose');
           }
         );
       });


### PR DESCRIPTION
Fix #27 

They indeed took the open-source project offline, that's not cool if you ask me. I managed to retrieve an older version that I have restored under the same license at https://github.com/oss-serverless/compose

Here are the changes to use that new package.