### PR TITLE
update hardcoded node18.x runtime to node20.x

### DIFF
--- a/docs/cli-reference/print.md
+++ b/docs/cli-reference/print.md
@@ -30,7 +30,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 functions:
   hello:
@@ -53,7 +53,7 @@ custom:
   bucketName: test
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   stage: dev # <-- Resolved
 functions:
   hello:

--- a/docs/events/apigateway.md
+++ b/docs/events/apigateway.md
@@ -1456,7 +1456,7 @@ service: my-api
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   stage: dev
   region: eu-west-2
 
@@ -1645,7 +1645,7 @@ Resource policies are policy documents that are used to control the invocation o
 ```yml
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
   apiGateway:
     resourcePolicy:

--- a/docs/events/websocket.md
+++ b/docs/events/websocket.md
@@ -61,7 +61,7 @@ service: serverless-ws-test
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   websocketsApiName: custom-websockets-api-name
   websocketsApiRouteSelectionExpression: $request.body.action # custom routes are selected by the value of the action property in the body
   websocketsDescription: Custom Serverless Websockets

--- a/docs/guides/credentials.md
+++ b/docs/guides/credentials.md
@@ -127,7 +127,7 @@ You can even set up different profiles for different accounts, which can be used
 service: new-service
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   stage: dev
   profile: devProfile
 ```
@@ -175,7 +175,7 @@ This example `serverless.yml` snippet will load the profile depending upon the s
 service: new-service
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   profile: ${self:custom.profiles.${sls:stage}}
 custom:
   profiles:

--- a/docs/guides/functions.md
+++ b/docs/guides/functions.md
@@ -12,7 +12,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   runtimeManagement: auto # optional, set how Lambda controls all functions runtime. AWS default is auto; this can either be 'auto' or 'onFunctionUpdate'. For 'manual', see example in hello function below (syntax for both is identical)
   memorySize: 512 # optional, in MB, default is 1024
   timeout: 10 # optional, in seconds, default is 6
@@ -52,7 +52,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 functions:
   functionOne:
@@ -72,7 +72,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   memorySize: 512 # will be inherited by all functions
 
 functions:
@@ -88,7 +88,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 functions:
   functionOne:
@@ -124,7 +124,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   iam:
     role:
       statements: # permissions for all of your functions can be set here
@@ -727,7 +727,7 @@ service: service
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 functions:
   hello:
@@ -780,7 +780,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   tracing:
     lambda: true
 ```

--- a/docs/guides/serverless.yml.md
+++ b/docs/guides/serverless.yml.md
@@ -101,7 +101,7 @@ Some function settings can be defined for all functions inside the `provider` ke
 # serverless.yml
 
 provider:
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   runtimeManagement: auto # optional, set how Lambda controls all functions runtime. AWS default is auto; this can either be 'auto' or 'onFunctionUpdate'. For 'manual', see example in hello function below (syntax for both is identical
   # Default memory size for functions (default: 1024MB)
   memorySize: 512
@@ -607,7 +607,7 @@ functions:
     # Container image to use. Cannot be used with 'handler'.
     # Can be the URI of an image in ECR, or the name of an image defined in 'provider.ecr.images'
     image: baseimage
-    runtime: nodejs18.x
+    runtime: nodejs20.x
     runtimeManagement:
       mode: manual # syntax required for manual, mode property also supports 'auto' or 'onFunctionUpdate' (see provider.runtimeManagement)
       arn: <aws runtime arn> # required when mode is manual

--- a/docs/guides/services.md
+++ b/docs/guides/services.md
@@ -85,7 +85,7 @@ service: users
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   stage: dev # Set the default stage used. Default is dev
   region: us-east-1 # Overwrite the default region used. Default is us-east-1
   profile: production # The default profile to use with this service
@@ -164,7 +164,7 @@ service: users
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   memorySize: 512
 
 …
@@ -181,7 +181,7 @@ service: users
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   memorySize: 512
 
 …

--- a/docs/guides/variables.md
+++ b/docs/guides/variables.md
@@ -199,7 +199,7 @@ You can add such custom output to CloudFormation stack. For example:
 service: another-service
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   region: ap-northeast-1
   memorySize: 512
 functions:

--- a/lib/plugins/aws/custom-resources/index.js
+++ b/lib/plugins/aws/custom-resources/index.js
@@ -162,7 +162,7 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
     });
   }
 
-  let runtimeVersion = 'nodejs18.x';
+  let runtimeVersion = 'nodejs20.x';
   const providerRuntime = awsProvider.getRuntime();
   if (providerRuntime.startsWith('nodejs')) {
     runtimeVersion = providerRuntime;

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1825,7 +1825,7 @@ class AwsProvider {
   }
 
   getRuntime(runtime) {
-    const defaultRuntime = 'nodejs20.x';
+    const defaultRuntime = 'nodejs18.x';
     const runtimeSourceValue = this.getRuntimeSourceValue();
     return runtime || runtimeSourceValue.value || defaultRuntime;
   }

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1825,7 +1825,7 @@ class AwsProvider {
   }
 
   getRuntime(runtime) {
-    const defaultRuntime = 'nodejs18.x';
+    const defaultRuntime = 'nodejs20.x';
     const runtimeSourceValue = this.getRuntimeSourceValue();
     return runtime || runtimeSourceValue.value || defaultRuntime;
   }

--- a/lib/plugins/package/lib/package-service.js
+++ b/lib/plugins/package/lib/package-service.js
@@ -29,7 +29,7 @@ module.exports = {
   },
 
   getRuntime(runtime) {
-    const defaultRuntime = 'nodejs18.x';
+    const defaultRuntime = 'nodejs20.x';
     return runtime || this.serverless.service.provider.runtime || defaultRuntime;
   },
 

--- a/test/fixtures/cli/variables/serverless.yml
+++ b/test/fixtures/cli/variables/serverless.yml
@@ -3,7 +3,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 custom:
   importedFile: ${file(config.json)}

--- a/test/fixtures/programmatic/api-gateway-extended/serverless.yml
+++ b/test/fixtures/programmatic/api-gateway-extended/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
   apiGateway:
     shouldStartNameWithService: true

--- a/test/fixtures/programmatic/api-gateway/serverless.yml
+++ b/test/fixtures/programmatic/api-gateway/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   apiGateway:
     shouldStartNameWithService: true
 

--- a/test/fixtures/programmatic/check-for-changes/serverless.yml
+++ b/test/fixtures/programmatic/check-for-changes/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 functions:
   fn1:

--- a/test/fixtures/programmatic/cognito-user-pool/serverless.yml
+++ b/test/fixtures/programmatic/cognito-user-pool/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/config-schema-extensions-error/serverless.yml
+++ b/test/fixtures/programmatic/config-schema-extensions-error/serverless.yml
@@ -2,7 +2,7 @@ service: configSchemaExtensionsError
 
 provider:
   name: someProvider
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 configValidationMode: error
 frameworkVersion: '*'

--- a/test/fixtures/programmatic/curated-plugins/serverless.yml
+++ b/test/fixtures/programmatic/curated-plugins/serverless.yml
@@ -10,7 +10,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 functions:
   function:

--- a/test/fixtures/programmatic/ecr/serverless.yml
+++ b/test/fixtures/programmatic/ecr/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   ecr:
     images:
       baseimage:

--- a/test/fixtures/programmatic/event-bridge/serverless.yml
+++ b/test/fixtures/programmatic/event-bridge/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/function-active-mq/serverless.yml
+++ b/test/fixtures/programmatic/function-active-mq/serverless.yml
@@ -8,7 +8,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/function-cloud-front/serverless.yml
+++ b/test/fixtures/programmatic/function-cloud-front/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 functions:
   foo:

--- a/test/fixtures/programmatic/function-efs/serverless.yml
+++ b/test/fixtures/programmatic/function-efs/serverless.yml
@@ -7,7 +7,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/function-layers/serverless.yml
+++ b/test/fixtures/programmatic/function-layers/serverless.yml
@@ -1,7 +1,7 @@
 service: service
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 layers:
   testLayer:

--- a/test/fixtures/programmatic/function-msk/serverless.yml
+++ b/test/fixtures/programmatic/function-msk/serverless.yml
@@ -8,7 +8,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/function-rabbit-mq/serverless.yml
+++ b/test/fixtures/programmatic/function-rabbit-mq/serverless.yml
@@ -8,7 +8,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/function/serverless.yml
+++ b/test/fixtures/programmatic/function/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 functions:
   basic:

--- a/test/fixtures/programmatic/http-api-catch-all/serverless.yml
+++ b/test/fixtures/programmatic/http-api-catch-all/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 functions:
   foo:

--- a/test/fixtures/programmatic/http-api-export/serverless.yml
+++ b/test/fixtures/programmatic/http-api-export/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 resources:
   Resources:

--- a/test/fixtures/programmatic/http-api/serverless.yml
+++ b/test/fixtures/programmatic/http-api/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   logRetentionInDays: 14
 
 functions:

--- a/test/fixtures/programmatic/invocation/serverless.yml
+++ b/test/fixtures/programmatic/invocation/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 functions:
   callback:

--- a/test/fixtures/programmatic/iot-fleet-provisioning/serverless.yml
+++ b/test/fixtures/programmatic/iot-fleet-provisioning/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/iot/serverless.yml
+++ b/test/fixtures/programmatic/iot/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/layer/serverless.yml
+++ b/test/fixtures/programmatic/layer/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 functions:
   function:

--- a/test/fixtures/programmatic/multi-service/service-a/serverless.yml
+++ b/test/fixtures/programmatic/multi-service/service-a/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 custom:
   env: ${env:ENV_SOURCE_TEST, null}

--- a/test/fixtures/programmatic/package-artifact-in-serverless-dir/serverless.yml
+++ b/test/fixtures/programmatic/package-artifact-in-serverless-dir/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 plugins:
   # Mutates `package.artifact` to point to copied `.serverless/NAME.zip`

--- a/test/fixtures/programmatic/package-artifact/serverless.yml
+++ b/test/fixtures/programmatic/package-artifact/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 package:
   artifact: artifact.zip

--- a/test/fixtures/programmatic/packaging/serverless.yml
+++ b/test/fixtures/programmatic/packaging/serverless.yml
@@ -6,7 +6,7 @@ disabledDeprecations: LOAD_VARIABLES_FROM_ENV_FILES
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 functions:
   fnService:

--- a/test/fixtures/programmatic/plugin/serverless.yml
+++ b/test/fixtures/programmatic/plugin/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 plugins:
   - ./plugin

--- a/test/fixtures/programmatic/provisioned-concurrency/serverless.yml
+++ b/test/fixtures/programmatic/provisioned-concurrency/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/request-parameters/serverless.yml
+++ b/test/fixtures/programmatic/request-parameters/serverless.yml
@@ -2,7 +2,7 @@ service: service
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 functions:
   target:

--- a/test/fixtures/programmatic/request-schema/serverless.yml
+++ b/test/fixtures/programmatic/request-schema/serverless.yml
@@ -2,7 +2,7 @@ service: service
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   apiGateway:
     request:
       schemas:

--- a/test/fixtures/programmatic/s3/serverless.yml
+++ b/test/fixtures/programmatic/s3/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
   s3:
     customBucket:

--- a/test/fixtures/programmatic/schedule/serverless.yml
+++ b/test/fixtures/programmatic/schedule/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/sns/serverless.yml
+++ b/test/fixtures/programmatic/sns/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/sqs/serverless.yml
+++ b/test/fixtures/programmatic/sqs/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/stream/serverless.yml
+++ b/test/fixtures/programmatic/stream/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/variables-legacy/serverless.yml
+++ b/test/fixtures/programmatic/variables-legacy/serverless.yml
@@ -2,7 +2,7 @@ service: service
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 custom:
   importedFile: ${file(config.json)}

--- a/test/fixtures/programmatic/websocket-external-auth/serverless.yml
+++ b/test/fixtures/programmatic/websocket-external-auth/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/websocket/serverless.yml
+++ b/test/fixtures/programmatic/websocket/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   versionFunctions: false
   logs:
     websocket: true

--- a/test/integration-package/cloudformation.tests.js
+++ b/test/integration-package/cloudformation.tests.js
@@ -44,7 +44,7 @@ describe('Integration test - Packaging - CloudFormation', () => {
         Role: {
           'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'],
         },
-        Runtime: 'nodejs18.x',
+        Runtime: 'nodejs20.x',
         Timeout: 6,
       },
       DependsOn: ['HelloLogGroup'],
@@ -75,7 +75,7 @@ describe('Integration test - Packaging - CloudFormation', () => {
         Role: {
           'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'],
         },
-        Runtime: 'nodejs18.x',
+        Runtime: 'nodejs20.x',
         Timeout: 6,
       },
       DependsOn: ['HelloLogGroup'],
@@ -109,7 +109,7 @@ describe('Integration test - Packaging - CloudFormation', () => {
         Role: {
           'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'],
         },
-        Runtime: 'nodejs18.x',
+        Runtime: 'nodejs20.x',
         Timeout: 6,
       },
       DependsOn: ['HelloLogGroup'],

--- a/test/integration-package/fixtures/artifact/serverless.yml
+++ b/test/integration-package/fixtures/artifact/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 functions:
   hello:

--- a/test/integration-package/fixtures/individually-function/serverless.yml
+++ b/test/integration-package/fixtures/individually-function/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 functions:
   hello:

--- a/test/integration-package/fixtures/individually/serverless.yml
+++ b/test/integration-package/fixtures/individually/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 package:
   individually: true

--- a/test/integration-package/fixtures/regular/serverless.yml
+++ b/test/integration-package/fixtures/regular/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
 
 functions:
   hello:

--- a/test/unit/lib/plugins/aws/custom-resources/index.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/index.test.js
@@ -109,7 +109,7 @@ describe('#addCustomResourceToService()', () => {
         Role: {
           'Fn::GetAtt': ['IamRoleCustomResourcesLambdaExecution', 'Arn'],
         },
-        Runtime: 'nodejs18.x',
+        Runtime: 'nodejs20.x',
         Timeout: 180,
       },
       DependsOn: ['IamRoleCustomResourcesLambdaExecution'],
@@ -128,7 +128,7 @@ describe('#addCustomResourceToService()', () => {
         Role: {
           'Fn::GetAtt': ['IamRoleCustomResourcesLambdaExecution', 'Arn'],
         },
-        Runtime: 'nodejs18.x',
+        Runtime: 'nodejs20.x',
         Timeout: 180,
       },
       DependsOn: ['IamRoleCustomResourcesLambdaExecution'],
@@ -147,7 +147,7 @@ describe('#addCustomResourceToService()', () => {
         Role: {
           'Fn::GetAtt': ['IamRoleCustomResourcesLambdaExecution', 'Arn'],
         },
-        Runtime: 'nodejs18.x',
+        Runtime: 'nodejs20.x',
         Timeout: 180,
       },
       DependsOn: ['IamRoleCustomResourcesLambdaExecution'],

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -421,7 +421,7 @@ describe('AwsInvokeLocal', () => {
         it(`should call invokeLocalNodeJs for any node.js runtime version for ${item.path}`, async () => {
           awsInvokeLocal.options.functionObj.handler = item.path;
 
-          awsInvokeLocal.options.functionObj.runtime = 'nodejs18.x';
+          awsInvokeLocal.options.functionObj.runtime = 'nodejs20.x';
           await awsInvokeLocal.invokeLocal();
           expect(invokeLocalNodeJsStub.calledOnce).to.be.equal(true);
           expect(
@@ -563,8 +563,8 @@ describe('AwsInvokeLocal', () => {
       expect(invokeLocalDockerStub.calledWithExactly()).to.be.equal(true);
     });
 
-    it('should call invokeLocalDocker if using --docker option with nodejs18.x', async () => {
-      awsInvokeLocal.options.functionObj.runtime = 'nodejs18.x';
+    it('should call invokeLocalDocker if using --docker option with nodejs20.x', async () => {
+      awsInvokeLocal.options.functionObj.runtime = 'nodejs20.x';
       awsInvokeLocal.options.functionObj.handler = 'handler.foobar';
       awsInvokeLocal.options.docker = true;
       await awsInvokeLocal.invokeLocal();
@@ -706,7 +706,7 @@ describe('AwsInvokeLocal', () => {
           handler: 'handler.hello',
           name: 'hello',
           timeout: 4,
-          runtime: 'nodejs18.x',
+          runtime: 'nodejs20.x',
           environment: {
             functionVar: 'functionValue',
           },
@@ -734,7 +734,7 @@ describe('AwsInvokeLocal', () => {
       expect(spawnExtStub.getCall(0).args).to.deep.equal(['docker', ['version']]);
       expect(spawnExtStub.getCall(1).args).to.deep.equal([
         'docker',
-        ['images', '-q', 'lambci/lambda:nodejs18.x'],
+        ['images', '-q', 'lambci/lambda:nodejs20.x'],
       ]);
       expect(spawnExtStub.getCall(3).args).to.deep.equal([
         'docker',
@@ -765,7 +765,7 @@ describe('AwsInvokeLocal', () => {
           'commandLineEnvVar=commandLineEnvVarValue',
           '-p',
           '9292:9292',
-          'sls-docker-nodejs18.x',
+          'sls-docker-nodejs20.x',
           'handler.hello',
           '{}',
         ],
@@ -1059,7 +1059,7 @@ describe('test/unit/lib/plugins/aws/invokeLocal/index.test.js', () => {
           },
           configExt: {
             provider: {
-              runtime: 'nodejs18.x',
+              runtime: 'nodejs20.x',
               environment: {
                 PROVIDER_LEVEL_VAR: 'PROVIDER_LEVEL_VAR_VALUE',
                 NULL_VAR: null,

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -335,7 +335,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs18.x',
+          Runtime: 'nodejs20.x',
           Timeout: 6,
         },
       };
@@ -395,7 +395,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs18.x',
+              Runtime: 'nodejs20.x',
               Timeout: 6,
               DeadLetterConfig: {
                 TargetArn: 'arn:aws:sns:region:accountid:foo',
@@ -446,7 +446,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs18.x',
+              Runtime: 'nodejs20.x',
               Timeout: 6,
               DeadLetterConfig: {
                 TargetArn: {
@@ -488,7 +488,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs18.x',
+              Runtime: 'nodejs20.x',
               Timeout: 6,
               DeadLetterConfig: {
                 TargetArn: {
@@ -530,7 +530,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs18.x',
+              Runtime: 'nodejs20.x',
               Timeout: 6,
               DeadLetterConfig: {
                 TargetArn: {
@@ -572,7 +572,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs18.x',
+              Runtime: 'nodejs20.x',
               Timeout: 6,
               DeadLetterConfig: {
                 TargetArn: 'arn:aws:sns:region:accountid:foo',
@@ -639,7 +639,7 @@ describe('AwsCompileFunctions', () => {
               Handler: 'func.function.handler',
               MemorySize: 1024,
               Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-              Runtime: 'nodejs18.x',
+              Runtime: 'nodejs20.x',
               Timeout: 6,
               TracingConfig: {
                 Mode: 'Active',
@@ -696,7 +696,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs18.x',
+          Runtime: 'nodejs20.x',
           Timeout: 6,
           Environment: {
             Variables: {
@@ -763,7 +763,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 128,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs18.x',
+          Runtime: 'nodejs20.x',
           Timeout: 10,
         },
       };
@@ -862,7 +862,7 @@ describe('AwsCompileFunctions', () => {
           MemorySize: 1024,
           ReservedConcurrentExecutions: 5,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs18.x',
+          Runtime: 'nodejs20.x',
           Timeout: 6,
         },
       };
@@ -918,7 +918,7 @@ describe('AwsCompileFunctions', () => {
           MemorySize: 1024,
           ReservedConcurrentExecutions: 0,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs18.x',
+          Runtime: 'nodejs20.x',
           Timeout: 6,
         },
       };
@@ -991,7 +991,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs18.x',
+          Runtime: 'nodejs20.x',
           Timeout: 6,
         },
       };
@@ -1029,7 +1029,7 @@ describe('AwsCompileFunctions', () => {
           Handler: 'func.function.handler',
           MemorySize: 1024,
           Role: { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'] },
-          Runtime: 'nodejs18.x',
+          Runtime: 'nodejs20.x',
           Timeout: 6,
           Layers: ['arn:aws:xxx:*:*'],
         },
@@ -1116,7 +1116,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
               providerCfIfEnvVar: { 'Fn::If': ['cond', 'first', 'second'] },
             },
             memorySize: 4096,
-            runtime: 'nodejs18.x',
+            runtime: 'nodejs20.x',
             runtimeManagement: {
               mode: 'manual',
               arn: 'arn:aws:lambda:us-east-1:111111111111::runtime:7b620fc2e66107a1046b140b9d320295811af3ad5d4c6a011fad1fa65127e9e6I',
@@ -1139,7 +1139,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
                 sharedEnvVar: 'valueFromFunction',
               },
               memorySize: 2048,
-              runtime: 'nodejs18.x',
+              runtime: 'nodejs20.x',
               runtimeManagement: 'onFunctionUpdate',
               versionFunction: true,
             },
@@ -1743,7 +1743,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
               ExternalLambdaLayer: {
                 Type: 'AWS::Lambda::LayerVersion',
                 Properties: {
-                  CompatibleRuntimes: ['nodejs18.x'],
+                  CompatibleRuntimes: ['nodejs20.x'],
                   Content: {
                     S3Bucket: 'bucket',
                     S3Key: 'key',
@@ -1872,9 +1872,9 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
       // https://github.com/serverless/serverless/blob/d8527d8b57e7e5f0b94ba704d9f53adb34298d99/lib/plugins/aws/package/compile/functions/index.test.js#L1784-L1820
     });
 
-    it('should default to "nodejs18.x" runtime`', () => {
+    it('should default to "nodejs20.x" runtime`', () => {
       const funcResource = cfResources[naming.getLambdaLogicalId('target')];
-      expect(funcResource.Properties.Runtime).to.equal('nodejs18.x');
+      expect(funcResource.Properties.Runtime).to.equal('nodejs20.x');
     });
 
     it.skip('TODO: should support `functions[].runtime`', () => {

--- a/test/unit/lib/plugins/aws/package/compile/layers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/layers.test.js
@@ -48,7 +48,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
           layerTwo: {
             description: 'Layer two example',
             path: 'layer',
-            compatibleRuntimes: ['nodejs18.x'],
+            compatibleRuntimes: ['nodejs20.x'],
             compatibleArchitectures: ['arm64'],
             licenseInfo: 'GPL',
             allowedAccounts: ['123456789012', '123456789013'],
@@ -186,7 +186,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
     const layerOne = cfResources[layerResourceName];
 
     expect(layerOne.Type).to.equals('AWS::Lambda::LayerVersion');
-    expect(layerOne.Properties.CompatibleRuntimes).to.deep.equals(['nodejs18.x']);
+    expect(layerOne.Properties.CompatibleRuntimes).to.deep.equals(['nodejs20.x']);
   });
 
   it('should support `layers[].compatibleArchitectures`', () => {

--- a/test/unit/lib/plugins/aws/package/lib/strip-null-props-from-template-resources.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/strip-null-props-from-template-resources.test.js
@@ -43,7 +43,7 @@ describe('test/unit/lib/plugins/aws/package/lib/stripNullPropsFromTemplateResour
                 Code: {
                   S3Bucket: 's3-containing-lambda',
                 },
-                Runtime: 'nodejs18.x',
+                Runtime: 'nodejs20.x',
               },
             },
             resourceWithNullProperties: {


### PR DESCRIPTION
### Problem

AWS will deprecate the nodejs18.x runtime starting April 30, 2025. It has already starting notifying account about this change:

    We are contacting you as we have identified that your AWS Account currently has one or more AWS Lambda functions using the Node.js 18 runtime.
    
    We are ending support for Node.js 18 in Lambda on September 1, 2025. This follows Node.js 18 End-Of-Life (EOL) reached on April 30, 2025 [1]. End of support does not impact function execution. Your functions will continue to run. However, they will be running on an unsupported runtime which is no longer maintained or patched by the AWS Lambda team.
 
When using the serverless framework to deploy a project, a "custom-resource-apigw-cw-role" lambda gets created. The runtime of this lambda is hardcoded in `lib/plugins/aws/custom-resources/index.js` and it can't be changed or configured through the main serverless.yml configuration file (see https://github.com/serverless/serverless/issues/12307 as a reference).

### Solution

This PR updates all the hardcoded runtime versions to nodejs20.x in order to avoid the deprecation warning.


