### PR TITLE
Update custom-resources Node.js runtime from 18.x to 22.x

### DIFF
--- a/lib/plugins/aws/custom-resources/index.js
+++ b/lib/plugins/aws/custom-resources/index.js
@@ -162,7 +162,7 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
     });
   }
 
-  let runtimeVersion = 'nodejs18.x';
+  let runtimeVersion = 'nodejs22.x';
   const providerRuntime = awsProvider.getRuntime();
   if (providerRuntime.startsWith('nodejs')) {
     runtimeVersion = providerRuntime;


### PR DESCRIPTION
This pull request updates the Node.js runtime environment for the custom-resources Lambda functions from version 18.x to 22.x.

[Node.js v18 is reaching End-Of-Life on April 30, 2025.](https://nodejs.org/en/about/previous-releases#release-schedule)
AWS Lambda end of support for Node.js 18 is on September 1, 2025.


Creating a Lambda with 
```yaml
test:
  handler: src/api/v1/endpoints/test
  events:
    - s3:
        bucket: ${self:provider.stage}-bucketname
        event: s3:ObjectCreated:*
        existing: True
```
will result in a deprecation notice from AWS.

I could only test this change with the custom resource `custom-resource-existing-s3`.
Other custom resources are untested.