### PR TITLE
fix: Update custom resource runtime

### DIFF
--- a/lib/plugins/aws/custom-resources/index.js
+++ b/lib/plugins/aws/custom-resources/index.js
@@ -162,9 +162,9 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
     });
   }
 
-  let runtimeVersion = 'nodejs18.x';
+  let runtimeVersion = 'nodejs22.x';
   const providerRuntime = awsProvider.getRuntime();
-  if (providerRuntime.startsWith('nodejs')) {
+  if (providerRuntime.startsWith('nodejs') && Number(providerRuntime.substring(4, 6)) >= 18) {
     runtimeVersion = providerRuntime;
   }
 


### PR DESCRIPTION
- Node.JS 18 has reached EOL and [will be deprecateed soon](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported).
- Added a check to ensure that it will not use a version older than Node 18 while trying to match the provider runtime version.