### PR TITLE
adding osls bin for ease of npx usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "types": "types/index.d.ts",
   "bin": {
     "serverless": "./bin/serverless.js",
-    "sls": "./bin/serverless.js"
+    "sls": "./bin/serverless.js",
+    "osls": "./bin/serverless.js"
   },
   "dependencies": {
     "@aws-sdk/client-api-gateway": "^3.588.0",


### PR DESCRIPTION
we use npx for most CI tasks, so adding a bin entry that matches the package name makes things much easier.