### PR TITLE
Adding `lambda:InvokeFunction` permission for function url with `NONE` auth type

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -541,6 +541,9 @@ module.exports = {
   getLambdaHttpApiPermissionLogicalId(functionName) {
     return `${this.getNormalizedFunctionName(functionName)}LambdaPermissionHttpApi`;
   },
+  getLambdaFnPermissionLogicalId(functionName) {
+    return `${this.getNormalizedFunctionName(functionName)}LambdaPermissionFn`;
+  },
   getLambdaFnUrlPermissionLogicalId(functionName) {
     return `${this.getNormalizedFunctionName(functionName)}LambdaPermissionFnUrl`;
   },

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -723,6 +723,16 @@ class AwsCompileFunctions {
         },
         DependsOn: _.get(functionObject.targetAlias, 'logicalId'),
       };
+      cfTemplate.Resources[this.provider.naming.getLambdaFnPermissionLogicalId(functionName)] = {
+        Type: 'AWS::Lambda::Permission',
+        Properties: {
+          FunctionName: resolveLambdaTarget(functionName, functionObject),
+          Action: 'lambda:InvokeFunction',
+          Principal: '*',
+          InvokedViaFunctionUrl: true,
+        },
+        DependsOn: _.get(functionObject.targetAlias, 'logicalId'),
+      };
     }
   }
 

--- a/test/unit/lib/plugins/aws/lib/naming.test.js
+++ b/test/unit/lib/plugins/aws/lib/naming.test.js
@@ -1064,6 +1064,14 @@ describe('#naming()', () => {
     });
   });
 
+  describe('#getLambdaFnPermissionLogicalId()', () => {
+    it('should normalize the name and append correct suffix', () => {
+      expect(sdk.naming.getLambdaFnPermissionLogicalId('fnName')).to.equal(
+        'FnNameLambdaPermissionFn'
+      );
+    });
+  });
+
   describe('#getHttpApiName()', () => {
     it('should return the composition of service & stage name if custom name not provided and shouldStartNameWithService is true', () => {
       serverless.service.service = 'myService';

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1958,6 +1958,14 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
         FunctionUrlAuthType: 'NONE',
         Principal: '*',
       });
+      expect(cfResources[naming.getLambdaFnPermissionLogicalId('fnUrl')].Properties).to.deep.equal({
+        Action: 'lambda:InvokeFunction',
+        FunctionName: {
+          'Fn::GetAtt': ['FnUrlLambdaFunction', 'Arn'],
+        },
+        InvokedViaFunctionUrl: true,
+        Principal: '*',
+      });
     });
 
     it('should support `functions[].url` set to `true` with provisionedConcurrency set', () => {


### PR DESCRIPTION
Starting in October 2025, new function URLs will require both `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction` permissions.

This PR is the `NONE` auth type implementation, following [AWS documentation](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html#urls-auth-none).

