### PR TITLE
Fix issue with ssm variables not found

### DIFF
--- a/lib/configuration/variables/sources/instance-dependent/get-ssm.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-ssm.js
@@ -37,7 +37,12 @@ module.exports = (serverlessInstance) => {
           );
         } catch (error) {
           // Check for normalized error code instead of native one
-          if (error.code === 'AWS_S_S_M_GET_PARAMETER_PARAMETER_NOT_FOUND' || error.code === 'ParameterNotFound') return null;
+          if (
+            error.code === 'AWS_S_S_M_GET_PARAMETER_PARAMETER_NOT_FOUND' ||
+            error.code === 'ParameterNotFound'
+          ) {
+            return null;
+          }
           throw error;
         }
       })();


### PR DESCRIPTION
The variable resolution for ssm has the possibility when a parameter is not found to use a fallback value, that is based on the error code. The V3 error code is not the same as the v2 one, for the ease I just check also for the v3 code, as it is the only place in the core code to check for the that kind of code