### PR TITLE
Move to head bucket to ensure a deployment bucket is in the right region

### DIFF
--- a/lib/plugins/aws/deploy/lib/ensure-valid-bucket-exists.js
+++ b/lib/plugins/aws/deploy/lib/ensure-valid-bucket-exists.js
@@ -27,7 +27,7 @@ module.exports = {
     if (this.serverless.service.provider.deploymentBucket) {
       let result;
       try {
-        result = await this.provider.request('S3', 'getBucketLocation', {
+        result = await this.provider.request('S3', 'headBucket', {
           Bucket: this.bucketName,
         });
       } catch (err) {
@@ -37,9 +37,8 @@ module.exports = {
         );
       }
 
-      if (result.LocationConstraint === '') result.LocationConstraint = 'us-east-1';
-      if (result.LocationConstraint === 'EU') result.LocationConstraint = 'eu-west-1';
-      if (result.LocationConstraint !== this.provider.getRegion()) {
+      if (result.BucketRegion === 'EU') result.BucketRegion = 'eu-west-1';
+      if (result.BucketRegion !== this.provider.getRegion()) {
         throw new ServerlessError(
           'Deployment bucket is not in the same region as the lambda function',
           'DEPLOYMENT_BUCKET_INVALID_REGION'

--- a/test/unit/lib/plugins/aws/deploy/index.test.js
+++ b/test/unit/lib/plugins/aws/deploy/index.test.js
@@ -112,10 +112,14 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
           deleteObjects: deleteObjectsStub,
           listObjectsV2: { Contents: [] },
           upload: s3UploadStub,
-          headBucket: {},
           getBucketLocation: () => {
             return {
               LocationConstraint: 'us-east-1',
+            };
+          },
+          headBucket: () => {
+            return {
+              BucketRegion: 'us-east-1',
             };
           },
         },
@@ -523,10 +527,14 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
           deleteObjects: deleteObjectsStub,
           listObjectsV2: { Contents: [] },
           upload: s3UploadStub,
-          headBucket: {},
           getBucketLocation: () => {
             return {
               LocationConstraint: 'us-east-1',
+            };
+          },
+          headBucket: () => {
+            return {
+              BucketRegion: 'us-east-1',
             };
           },
         },
@@ -1206,6 +1214,9 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
         getBucketLocation: () => {
           throw new Error();
         },
+        headBucket: () => {
+          throw new Error();
+        },
       },
       CloudFormation: {
         describeStacks: { Stacks: [{}] },
@@ -1240,6 +1251,11 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
         getBucketLocation: () => {
           return {
             LocationConstraint: 'us-west-1',
+          };
+        },
+        headBucket: () => {
+          return {
+            BucketRegion: 'us-west-1',
           };
         },
       },


### PR DESCRIPTION
When the bucket is in `us-east-1`, aws sdk v3 returns for `getBucketLocation` no value as it is null, aws sdk v2 returned an empty string moving to `headBucket` a region is always returned https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html