### PR TITLE
fix: Ensure custom resource runtime is at least Node 18

### DIFF
--- a/lib/plugins/aws/custom-resources/index.js
+++ b/lib/plugins/aws/custom-resources/index.js
@@ -164,7 +164,8 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
 
   let runtimeVersion = 'nodejs22.x';
   const providerRuntime = awsProvider.getRuntime();
-  if (providerRuntime.startsWith('nodejs')) {
+  // AWS SDK v3 is only bundled with Node.js 18 and up
+  if (providerRuntime.startsWith('nodejs') && Number(providerRuntime.substring(6, 8)) >= 18) {
     runtimeVersion = providerRuntime;
   }
 


### PR DESCRIPTION
Reopens #60

While the default custom resources runtime version has been bumped to Node 22, the plugin still does not make sure that the provider runtime version is at least Node 18.

AWS only includes AWS SDK [v2 for Node <= 16 and v3 for Node >= 18](https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/) on Lambda. Without this check, the custom resources invocations will fail if the provider runtime is set to Node 16 or lower.