### PR TITLE
feat(Runtime): Allow nodejs24 runtime

### DIFF
--- a/lib/plugins/aws/custom-resources/index.js
+++ b/lib/plugins/aws/custom-resources/index.js
@@ -162,7 +162,7 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
     });
   }
 
-  let runtimeVersion = 'nodejs22.x';
+  let runtimeVersion = 'nodejs24.x';
   const providerRuntime = awsProvider.getRuntime();
   if (providerRuntime.startsWith('nodejs')) {
     runtimeVersion = providerRuntime;

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -638,6 +638,7 @@ class AwsProvider {
               'nodejs18.x',
               'nodejs20.x',
               'nodejs22.x',
+              'nodejs24.x',
               'provided',
               'provided.al2',
               'provided.al2023',

--- a/test/unit/lib/plugins/aws/custom-resources/index.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/index.test.js
@@ -349,7 +349,7 @@ describe('#addCustomResourceToService()', () => {
   });
 
   it('should use defined runtime', async () => {
-    serverless.service.provider.runtime = 'nodejs22.x';
+    serverless.service.provider.runtime = 'nodejs24.x';
     await Promise.all([
       // add the custom S3 resource
       addCustomResourceToService(provider, 's3', [
@@ -398,13 +398,13 @@ describe('#addCustomResourceToService()', () => {
 
     expect(
       Resources.CustomDashresourceDashexistingDashs3LambdaFunction.Properties.Runtime
-    ).to.equal('nodejs22.x');
+    ).to.equal('nodejs24.x');
     expect(
       Resources.CustomDashresourceDashexistingDashcupLambdaFunction.Properties.Runtime
-    ).to.equal('nodejs22.x');
+    ).to.equal('nodejs24.x');
     expect(
       Resources.CustomDashresourceDasheventDashbridgeLambdaFunction.Properties.Runtime
-    ).to.equal('nodejs22.x');
+    ).to.equal('nodejs24.x');
   });
 });
 
@@ -428,7 +428,7 @@ describe('test/unit/lib/plugins/aws/customResources/index.test.js', () => {
     expect(properties.FunctionName.endsWith('testing-custom-resource-apigw-cw-role')).to.be.true;
   });
 
-  it('falls back to nodejs22 runtime for CW custom resource if provider runtime is not nodejs ', async () => {
+  it('falls back to nodejs24 runtime for CW custom resource if provider runtime is not nodejs ', async () => {
     const { cfTemplate } = await runServerless({
       fixture: 'api-gateway',
       command: 'package',
@@ -445,10 +445,10 @@ describe('test/unit/lib/plugins/aws/customResources/index.test.js', () => {
 
     const properties =
       cfTemplate.Resources.CustomDashresourceDashapigwDashcwDashroleLambdaFunction.Properties;
-    expect(properties.Runtime).to.equal('nodejs22.x');
+    expect(properties.Runtime).to.equal('nodejs24.x');
   });
 
-  it('falls back to nodejs22 runtime for Cognito UP custom resource if provider runtime is not nodejs ', async () => {
+  it('falls back to nodejs24 runtime for Cognito UP custom resource if provider runtime is not nodejs ', async () => {
     const { cfTemplate } = await runServerless({
       fixture: 'cognito-user-pool',
       command: 'package',
@@ -462,10 +462,10 @@ describe('test/unit/lib/plugins/aws/customResources/index.test.js', () => {
 
     const properties =
       cfTemplate.Resources.CustomDashresourceDashexistingDashcupLambdaFunction.Properties;
-    expect(properties.Runtime).to.equal('nodejs22.x');
+    expect(properties.Runtime).to.equal('nodejs24.x');
   });
 
-  it('falls back to nodejs22 runtime for Event Bridge [LEGACY] custom resource if provider runtime is not nodejs ', async () => {
+  it('falls back to nodejs24 runtime for Event Bridge [LEGACY] custom resource if provider runtime is not nodejs ', async () => {
     const { cfTemplate } = await runServerless({
       fixture: 'event-bridge',
       command: 'package',
@@ -483,10 +483,10 @@ describe('test/unit/lib/plugins/aws/customResources/index.test.js', () => {
 
     const properties =
       cfTemplate.Resources.CustomDashresourceDasheventDashbridgeLambdaFunction.Properties;
-    expect(properties.Runtime).to.equal('nodejs22.x');
+    expect(properties.Runtime).to.equal('nodejs24.x');
   });
 
-  it('falls back to nodejs22 runtime for S3 custom resource if provider runtime is not nodejs ', async () => {
+  it('falls back to nodejs24 runtime for S3 custom resource if provider runtime is not nodejs ', async () => {
     const { cfTemplate } = await runServerless({
       fixture: 's3',
       command: 'package',
@@ -500,7 +500,7 @@ describe('test/unit/lib/plugins/aws/customResources/index.test.js', () => {
 
     const properties =
       cfTemplate.Resources.CustomDashresourceDashexistingDashs3LambdaFunction.Properties;
-    expect(properties.Runtime).to.equal('nodejs22.x');
+    expect(properties.Runtime).to.equal('nodejs24.x');
   });
 
   it('correctly takes stage from config into account when constructing apiGatewayCloudWatchRole resource', async () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -64,6 +64,7 @@ export type AwsLambdaRuntime =
   | "nodejs18.x"
   | "nodejs20.x"
   | "nodejs22.x"
+  | "nodejs24.x"
   | "provided"
   | "provided.al2"
   | "provided.al2023"


### PR DESCRIPTION
NodeJS 24 is now supported in aws Lambda

https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

Might have miss some tests, i'm not very familiar with the codebase