### PR TITLE
Update the list of AWS Lambda runtimes.

### DIFF
--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -277,7 +277,7 @@ class AwsInvokeLocal {
       );
     }
 
-    if (['java8', 'java11', 'java17', 'java21'].includes(runtime)) {
+    if (['java8', 'java8.al2', 'java11', 'java17', 'java21', 'java25'].includes(runtime)) {
       const className = handler.split('::')[0];
       const handlerName = handler.split('::')[1] || 'handleRequest';
       const artifact =

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -627,6 +627,7 @@ class AwsProvider {
             enum: [
               'dotnet6',
               'dotnet8',
+              'dotnet9',
               'go1.x',
               'java21',
               'java17',

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,7 +53,9 @@ export type AwsLambdaRole = string | AwsCfSub | AwsCfImport | AwsCfGetAtt;
 export type AwsLambdaRuntime =
   | "dotnet6"
   | "dotnet8"
+  | "dotnet9"
   | "go1.x"
+  | "java25"
   | "java21"
   | "java17"
   | "java11"


### PR DESCRIPTION
Update the list of AWS Lambda runtimes based on https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html:
- Add dotnet9
- Add java25

<img width="882" height="567" alt="image" src="https://github.com/user-attachments/assets/73502d04-dbb1-4472-a919-9b1f0b7c906c" />

**TODO:** After Jul 1, 2026, remove the following runtimes:
- Node.js: nodejs14.x/nodejs16.x/nodejs18.x
- Java: java8
- Go: go1.x
- Dotnet: dotnet6
- Python: python3.8
- Ruby: ruby2.7
- OS-only runtime: provided

<img width="1115" height="545" alt="image" src="https://github.com/user-attachments/assets/1436fe14-1656-4b6d-9c42-4b58d718c12a" />
