### PR TITLE
Fix link to serverless yml docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@
 - [Resources](./guides/resources.md)
 - [Composing services](./guides/compose.md)
 - [Workflow Tips](./guides/workflow.md)
-- [Serverless.yml Reference](./guides/serverless.yml)
+- [Serverless.yml Reference](./guides/serverless.yml.md)
 
 # Function events
 


### PR DESCRIPTION
This corrects the broken link in the docs, for the serverless.yml reference.