### PR TITLE
feat(AWS Lambda): Add support for dotnet10 runtime

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -628,6 +628,7 @@ class AwsProvider {
               'dotnet6',
               'dotnet8',
               'dotnet9',
+              'dotnet10',
               'go1.x',
               'java21',
               'java17',

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,6 +54,7 @@ export type AwsLambdaRuntime =
   | "dotnet6"
   | "dotnet8"
   | "dotnet9"
+  | "dotnet10"
   | "go1.x"
   | "java25"
   | "java21"


### PR DESCRIPTION
Support just released: https://aws.amazon.com/blogs/compute/net-10-runtime-now-available-in-aws-lambda/

Note that dotnet 6 is deprecated, but not yet blocked until June/July: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-deprecated