### PR TITLE
Issue #130: Make handlerWrapper compatible with Node.js 24

### DIFF
--- a/lib/plugins/aws/custom-resources/resources/utils.js
+++ b/lib/plugins/aws/custom-resources/resources/utils.js
@@ -74,15 +74,18 @@ function getEnvironment(context) {
 }
 
 function handlerWrapper(handler, PhysicalResourceId) {
-  return async (event, context, callback) => {
+  return async (event, context) => {
     // extend the `event` object to include the PhysicalResourceId
     event = Object.assign({}, event, { PhysicalResourceId });
-    return Promise.resolve(handler(event, context, callback))
-      .then(
-        (result) => response(event, context, 'SUCCESS', result),
-        (error) => response(event, context, 'FAILED', {}, error)
-      )
-      .then((result) => callback(null, result), callback);
+
+    try {
+      const result = await handler(event, context);
+      await response(event, context, 'SUCCESS', result);
+      return result;
+    } catch (error) {
+      await response(event, context, 'FAILED', {}, error);
+      throw error;
+    }
   };
 }
 


### PR DESCRIPTION
The changes are taken from the merge request of [shinzero999](https://github.com/shinzero999), https://github.com/oss-serverless/serverless/pull/131. The old code commented out has been removed.

Callback-based function handlers are not allowed any more with nodejs 24.