### PR TITLE
AWS Lambda: Add support for Lambda Durable Functions

### DIFF
--- a/docs/cli-reference/invoke.md
+++ b/docs/cli-reference/invoke.md
@@ -21,6 +21,7 @@ serverless invoke [local] --function functionName
 - `--context` String data to be passed as a context to your function. Same like with `--data`, context included in `--contextPath` will overwrite the context you passed with `--context` flag.
 - `--type` or `-t` The type of invocation. Either `RequestResponse`, `Event` or `DryRun`. Default is `RequestResponse`.
 - `--log` or `-l` If set to `true` and invocation type is `RequestResponse`, it will output logging data of the invocation. Default is `false`.
+- `--durable-execution-name` Unique name for the durable function execution (enables idempotency). Execution names must be 1-64 characters: alphanumeric, hyphens, or underscores.
 
 ## Provided lifecycle events
 
@@ -97,6 +98,16 @@ serverless invoke --function functionName --path lib/data.json
 
 This example will pass the json data in the `lib/data.json` file (relative to the root of the service) while invoking
 the specified/deployed function.
+
+#### Function invocation with durable execution name
+
+```bash
+serverless invoke --function orderProcessor --durable-execution-name order-12345
+```
+
+This example invokes a durable function with a unique execution name. If you invoke the same function with the same execution name again, Lambda returns the cached result from the previous execution instead of re-executing the function. This enables idempotent invocations for reliable workflow orchestration.
+
+**Note:** Durable execution names must be 1-64 characters and contain only alphanumeric characters, hyphens, or underscores. See the [Functions guide](../guides/functions.md#aws-lambda-durable-functions) for more information on configuring durable functions.
 
 #### Example `data.json`
 

--- a/docs/cli-reference/invoke.md
+++ b/docs/cli-reference/invoke.md
@@ -99,16 +99,6 @@ serverless invoke --function functionName --path lib/data.json
 This example will pass the json data in the `lib/data.json` file (relative to the root of the service) while invoking
 the specified/deployed function.
 
-#### Function invocation with durable execution name
-
-```bash
-serverless invoke --function orderProcessor --durable-execution-name order-12345
-```
-
-This example invokes a durable function with a unique execution name. If you invoke the same function with the same execution name again, Lambda returns the cached result from the previous execution instead of re-executing the function. This enables idempotent invocations for reliable workflow orchestration.
-
-**Note:** Durable execution names must be 1-64 characters and contain only alphanumeric characters, hyphens, or underscores. See the [Functions guide](../guides/functions.md#aws-lambda-durable-functions) for more information on configuring durable functions.
-
 #### Example `data.json`
 
 ```json
@@ -134,6 +124,16 @@ serverless invoke local --function functionName \
 ```
 
 This example will pass the json context in the `lib/context.json` file (relative to the root of the service) while invoking the specified/deployed function.
+
+### Function invocation with durable execution name
+
+```bash
+serverless invoke --function functionName --contextPath lib/context.json --durable-execution-name order-12345
+```
+
+This example invokes a durable function with a unique execution name. If you invoke the same function with the same execution name again, Lambda returns the cached result from the previous execution instead of re-executing the function. This enables idempotent invocations for reliable workflow orchestration.
+
+**Note:** Durable execution names must be 1-64 characters and contain only alphanumeric characters, hyphens, or underscores. See the [Functions guide](../guides/functions.md#aws-lambda-durable-functions) for more information on configuring durable functions.
 
 ### Limitations
 

--- a/docs/guides/serverless.yml.md
+++ b/docs/guides/serverless.yml.md
@@ -658,6 +658,10 @@ functions:
     kmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash
     # Defines if you want to make use of SnapStart, this feature can only be used in combination with a Java runtime. Configuring this property will result in either None or PublishedVersions for the Lambda function
     snapStart: true
+    # Configure AWS Lambda Durable Functions for long-running workflows (auto-enables versioning)
+    durableConfig:
+      executionTimeout: 3600              # Required: 1-31536000 seconds
+      retentionPeriodInDays: 30           # Optional: 1-90 days
     # Disable the creation of the CloudWatch log group
     disableLogs: false
     # Duration for CloudWatch log retention (default: forever). Overrides provider setting.

--- a/lib/cli/commands-schema/aws-service.js
+++ b/lib/cli/commands-schema/aws-service.js
@@ -123,6 +123,9 @@ commands.set('invoke', {
     contextPath: {
       usage: 'Path to JSON or YAML file holding context data',
     },
+    'durable-execution-name': {
+      usage: 'Unique name for durable function execution (enables idempotency)',
+    },
   },
   lifecycleEvents: ['invoke'],
 });

--- a/lib/plugins/aws/deploy-function.js
+++ b/lib/plugins/aws/deploy-function.js
@@ -233,6 +233,15 @@ class AwsDeployFunction {
       };
     }
 
+    if (functionObj.durableConfig) {
+      params.DurableConfig = {
+        ExecutionTimeout: functionObj.durableConfig.executionTimeout,
+      };
+      if (functionObj.durableConfig.retentionPeriodInDays !== undefined) {
+        params.DurableConfig.RetentionPeriodInDays = functionObj.durableConfig.retentionPeriodInDays;
+      }
+    }
+
     if (
       functionObj.description &&
       functionObj.description !== remoteFunctionConfiguration.Description

--- a/lib/plugins/aws/invoke.js
+++ b/lib/plugins/aws/invoke.js
@@ -97,6 +97,10 @@ class AwsInvoke {
       params.Qualifier = this.options.qualifier;
     }
 
+    if (this.options['durable-execution-name']) {
+      params.DurableExecutionName = this.options['durable-execution-name'];
+    }
+
     return this.provider.request('Lambda', 'invoke', params);
   }
 

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -466,7 +466,9 @@ class AwsCompileFunctions {
     const shouldVersionFunction =
       functionObject.versionFunction != null
         ? functionObject.versionFunction
-        : this.serverless.service.provider.versionFunctions;
+        : this.serverless.service.provider.versionFunctions ||
+          // Durable Functions require versioning (qualified ARNs), so we enable it automatically
+          !!functionObject.durableConfig;
 
     if (
       shouldVersionFunction ||
@@ -630,6 +632,18 @@ class AwsCompileFunctions {
 
         cfTemplate.Resources[aliasLogicalId] = aliasResource;
       }
+    }
+
+    if (functionObject.durableConfig) {
+      const durableConfig = {
+        ExecutionTimeout: functionObject.durableConfig.executionTimeout,
+      };
+
+      if (functionObject.durableConfig.retentionPeriodInDays !== undefined) {
+        durableConfig.RetentionPeriodInDays = functionObject.durableConfig.retentionPeriodInDays;
+      }
+
+      functionResource.Properties.DurableConfig = durableConfig;
     }
 
     const logs =

--- a/lib/plugins/aws/package/lib/merge-iam-templates.js
+++ b/lib/plugins/aws/package/lib/merge-iam-templates.js
@@ -216,6 +216,28 @@ module.exports = {
       ]);
     }
 
+    // check if one of the functions contains durable configuration
+    const durableConfigProvided = this.serverless.service.getAllFunctions().some((functionName) => {
+      const functionObject = this.serverless.service.getFunction(functionName);
+      return 'durableConfig' in functionObject;
+    });
+
+    if (durableConfigProvided) {
+      // add managed iam policy for durable execution
+      this.mergeManagedPolicies([
+        {
+          'Fn::Join': [
+            '',
+            [
+              'arn:',
+              { Ref: 'AWS::Partition' },
+              ':iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy',
+            ],
+          ],
+        },
+      ]);
+    }
+
     return;
   },
 

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1489,6 +1489,15 @@ class AwsProvider {
             },
             kmsKeyArn: { $ref: '#/definitions/awsKmsArn' },
             snapStart: { type: 'boolean' },
+            durableConfig: {
+              type: 'object',
+              properties: {
+                executionTimeout: { type: 'integer', minimum: 1, maximum: 31536000 },
+                retentionPeriodInDays: { type: 'integer', minimum: 1, maximum: 90 },
+              },
+              required: ['executionTimeout'],
+              additionalProperties: false,
+            },
             layers: { $ref: '#/definitions/awsLambdaLayers' },
             logRetentionInDays: {
               $ref: '#/definitions/awsLogRetentionInDays',

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -964,6 +964,59 @@ describe('AwsCompileFunctions', () => {
 
       expect(cfTemplate.Resources.BasicLambdaFunction.Properties).to.not.have.property('SnapStart');
     });
+
+    it('should set function DurableConfig when enabled with all properties', async () => {
+      const { cfTemplate } = await runServerless({
+        fixture: 'function',
+        configExt: {
+          functions: {
+            basic: {
+              durableConfig: {
+                executionTimeout: 3600,
+                retentionPeriodInDays: 30,
+              },
+            },
+          },
+        },
+        command: 'package',
+      });
+
+      expect(cfTemplate.Resources.BasicLambdaFunction.Properties.DurableConfig).to.deep.equal({
+        ExecutionTimeout: 3600,
+        RetentionPeriodInDays: 30,
+      });
+    });
+
+    it('should set function DurableConfig with only executionTimeout', async () => {
+      const { cfTemplate } = await runServerless({
+        fixture: 'function',
+        configExt: {
+          functions: {
+            basic: {
+              durableConfig: {
+                executionTimeout: 7200,
+              },
+            },
+          },
+        },
+        command: 'package',
+      });
+
+      expect(cfTemplate.Resources.BasicLambdaFunction.Properties.DurableConfig).to.deep.equal({
+        ExecutionTimeout: 7200,
+      });
+    });
+
+    it('should not set function DurableConfig when not specified', async () => {
+      const { cfTemplate } = await runServerless({
+        fixture: 'function',
+        command: 'package',
+      });
+
+      expect(cfTemplate.Resources.BasicLambdaFunction.Properties).to.not.have.property(
+        'DurableConfig'
+      );
+    });
   });
 
   describe('#compileRole()', () => {


### PR DESCRIPTION
On December 2nd, 2025, AWS introduced Durable Lambda Executions, enabling long-running, fault-tolerant workflows without custom chaining, self-invocation, or  continuation persistence ([announcement](https://aws.amazon.com/blogs/aws/build-multi-step-applications-and-ai-workflows-with-aws-lambda-durable-functions/)).

  This PR adds support for Lambda Durable Functions :

  **Features:**
  - `durableConfig` property with `executionTimeout` (1-31536000 seconds) and `retentionPeriodInDays` (1-90 days)
  - Auto-enables versioning when `durableConfig` is present (required for qualified ARNs)
  - Automatic IAM managed policy attachment (`AWSLambdaBasicDurableExecutionRolePolicy`)
  - `--durable-execution-name` option for idempotent invocations
  -   Supported Runtimes: Node.js 22+, Python 3.13+

  **Usage:**
  ```yaml
  functions:
    orderProcessor:
      handler: handler.processOrder
      runtime: nodejs22.x
      durableConfig:
        executionTimeout: 86400        # 24 hours
        retentionPeriodInDays: 14
  ```