### PR TITLE
Fix async v3 credential hydration for SSM resolution

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1802,11 +1802,9 @@ class AwsProvider {
    */
   async _requestV3(service, method, params = {}, options = {}) {
     try {
-      if (!this.clientFactory) {
-        this.clientFactory = new AWSClientFactory(this._getV3BaseConfig());
-      }
+      await this._ensureV3ClientFactory();
 
-      const clientConfig = this._buildV3ClientConfig(service, method, options);
+      const clientConfig = await this._buildV3ClientConfig(service, method, options);
 
       const command = createCommand(service, method, params);
 
@@ -1823,30 +1821,28 @@ class AwsProvider {
    * @param {Object} options - Client configuration options
    * @returns {Object} AWS SDK v3 client instance
    */
-  getV3Client(service, options = {}) {
-    if (!this.clientFactory) {
-      this.clientFactory = new AWSClientFactory(this._getV3BaseConfig());
+  async getV3Client(service, options = {}) {
+    await this._ensureV3ClientFactory();
+
+    const clientConfig = await this._buildV3ClientConfig(service, null, options);
+    return this.clientFactory.getClient(service, clientConfig);
+  }
+
+  async _ensureV3ClientFactory() {
+    if (this.clientFactory) {
+      return;
     }
 
-    const clientConfig = this._buildV3ClientConfig(service, null, options);
-    return this.clientFactory.getClient(service, clientConfig);
+    const baseConfig = await this._getV3BaseConfig();
+    this.clientFactory = new AWSClientFactory(baseConfig);
   }
 
   /**
    * Build base configuration for AWS SDK v3 clients
    * @private
    */
-  _getV3BaseConfig() {
-    // Convert v2 credentials format to v3 format
-    const { credentials: v2Creds } = this.getCredentials();
-    const credentials =
-      v2Creds && v2Creds.accessKeyId
-        ? {
-            accessKeyId: v2Creds.accessKeyId,
-            secretAccessKey: v2Creds.secretAccessKey,
-            sessionToken: v2Creds.sessionToken,
-          }
-        : undefined;
+  async _getV3BaseConfig() {
+    const credentials = await this._resolveV2CredentialsForV3();
 
     return buildClientConfig({
       region: this.getRegion(),
@@ -1854,12 +1850,36 @@ class AwsProvider {
     });
   }
 
+  async _resolveV2CredentialsForV3() {
+    const { credentials: v2Creds } = this.getCredentials();
+    if (!v2Creds) {
+      return undefined;
+    }
+
+    // Hydrate lazy v2 credentials before copying
+    if (typeof v2Creds.getPromise === 'function') {
+      await v2Creds.getPromise();
+    } else if (typeof v2Creds.refreshPromise === 'function') {
+      await v2Creds.refreshPromise();
+    }
+
+    if (!v2Creds.accessKeyId || !v2Creds.secretAccessKey) {
+      return undefined;
+    }
+
+    return {
+      accessKeyId: v2Creds.accessKeyId,
+      secretAccessKey: v2Creds.secretAccessKey,
+      sessionToken: v2Creds.sessionToken,
+    };
+  }
+
   /**
    * Build client-specific configuration for AWS SDK v3
    * @private
    */
-  _buildV3ClientConfig(service, method, options) {
-    const baseConfig = this._getV3BaseConfig();
+  async _buildV3ClientConfig(service, method, options) {
+    const baseConfig = await this._getV3BaseConfig();
     const requestOptions = _.isObject(options) ? options : {};
 
     // Override region if specified


### PR DESCRIPTION
# Summary
- Fixes #132 
- Deployment with `SLS_AWS_SDK_V3=1` was failing `${ssm:...}` resolution with `UnrecognizedClientException` because Serverless forced early resolution of AWS SDK v2 credentials and copied them into SDK v3. Since credentials sourced from environment variables were not valid at that point in execution, the resolved credentials were incorrect and then reused by SDK v3.
- We now `await getPromise`/`refreshPromise` (when present) in `_resolveV2CredentialsForV3`, so the v3 client config receives real `accessKeyId`,`secretAccessKey` and `sessionToken`. If no keys are available, we return undefined and allow SDK v3 to fall back to its own credential provider chain
