### PR TITLE
add optional roleArn support for scheduler schedules

### DIFF
--- a/docs/events/schedule.md
+++ b/docs/events/schedule.md
@@ -88,6 +88,9 @@ However, `AWS::Scheduler::Schedule` has much higher limits (1,000,000 events), a
 `method` can be set in order to migrate to this trigger type seamlessly. It also allows you to specify a timezone to run your event based on local time.
 The default method is `eventBus`, which configures an `AWS::Event::Rule`.
 
+By default, `scheduler` uses the function execution role as target role.
+You can provide `roleArn` to use a dedicated role for EventBridge Scheduler.
+
 ```yaml
 functions:
   foo:
@@ -95,6 +98,7 @@ functions:
     events:
       - schedule:
           method: scheduler
+          roleArn: arn:aws:iam::123456789012:role/scheduler-execution-role
           rate:
             - cron(0 0/4 ? * MON-FRI *)
           timezone: America/New_York

--- a/lib/plugins/aws/package/compile/events/schedule.js
+++ b/lib/plugins/aws/package/compile/events/schedule.js
@@ -82,6 +82,9 @@ class AwsCompileScheduledEvents {
               type: 'string',
               enum: [METHOD_EVENT_BUS, METHOD_SCHEDULER],
             },
+            roleArn: {
+              anyOf: [{ type: 'string' }, { $ref: '#/definitions/awsCfFunction' }],
+            },
             timezone: {
               type: 'string',
               pattern: '[\\w\\-\\/]+',
@@ -140,7 +143,7 @@ class AwsCompileScheduledEvents {
               const functionLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
               const functionResource = resources[functionLogicalId];
 
-              roleArn = functionResource.Properties.Role;
+              roleArn = event.schedule.roleArn || functionResource.Properties.Role;
 
               method = event.schedule.method || METHOD_EVENT_BUS;
 

--- a/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
@@ -435,4 +435,25 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
       'Fn::GetAtt': ['customRole', 'Arn'],
     });
   });
+
+  it('should pass explicit schedule roleArn to method:schedule resources', async () => {
+    const events = [
+      {
+        schedule: {
+          rate: 'rate(15 minutes)',
+          method: METHOD_SCHEDULER,
+          roleArn: 'arn:aws:iam::123456789012:role/scheduler-execution-role',
+          name: 'scheduler-scheduled-event',
+          description: 'Scheduler Scheduled Event',
+          input: '{"key":"array"}',
+        },
+      },
+    ];
+
+    const { scheduleCfResources } = await run(events, { functionRole: 'customRole' });
+
+    expect(scheduleCfResources[0].Properties.Target.RoleArn).to.equal(
+      'arn:aws:iam::123456789012:role/scheduler-execution-role'
+    );
+  });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -205,6 +205,7 @@ export interface AWS {
               };
             };
             method?: "eventBus" | "scheduler";
+            roleArn?: AwsCfFunction | string;
             timezone?: string;
           };
         }


### PR DESCRIPTION
The reason behind this PR is that my team and I identified a security issue in allowing a role that was created for a specific purpose to be modified to serve a completely different one, giving whoever assumed that role permissions beyond the minimum they should have had.

## Summary
- add optional `schedule.roleArn` support for `method: scheduler`
- keep existing behavior as default fallback to the function execution role when `roleArn` is not provided
- document the new option in schedule event docs
- update TypeScript types for schedule event configuration

## Changes
- extend schedule event schema to accept `roleArn` (string or CloudFormation function)
- set scheduler target `RoleArn` from `schedule.roleArn` when present, otherwise fallback to function role
- verifies tests for both paths:
  - explicit scheduler role
  - fallback to function role
