### PR TITLE
feat(rest-api): SecurityPolicy & EndpointAccessMode support

### DIFF
--- a/docs/events/apigateway.md
+++ b/docs/events/apigateway.md
@@ -739,6 +739,43 @@ provider:
     - vpce-456
 ```
 
+### Security Policy
+
+You can configure the TLS version for your API Gateway REST API by setting the `securityPolicy` property under `apiGateway` in the `provider` block. This maps directly to the [SecurityPolicy](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-securitypolicy) property of the `AWS::ApiGateway::RestApi` CloudFormation resource.
+Specific explanation about Security Policy types and structure can be found [here](https://aws.amazon.com/blogs/compute/enhancing-api-security-with-amazon-api-gateway-tls-security-policies/)
+
+```yml
+service: my-service
+provider:
+  name: aws
+  apiGateway:
+    securityPolicy: TLS_1_2
+functions:
+  hello:
+    events:
+      - http:
+          path: user/create
+          method: get
+```
+
+### Endpoint Access Mode
+
+You can control how clients access your API Gateway endpoint by setting the `endpointAccessMode` property under `apiGateway` in the `provider` block. Valid values are `STRICT` and `BASIC`. This maps directly to the [EndpointAccessMode](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-apigateway-restapi.html#cfn-apigateway-restapi-endpointaccessmode) property of the `AWS::ApiGateway::RestApi` CloudFormation resource. According to AWS documentation, if a security policy is configured with a legacy template (that doesn't have the `SecurityPolicy_` prefix) access Mode should be empty)
+
+```yml
+service: my-service
+provider:
+  name: aws
+  apiGateway:
+    endpointAccessMode: STRICT
+functions:
+  hello:
+    events:
+      - http:
+          path: user/create
+          method: get
+```
+
 ### Request Parameters
 
 To pass optional and required parameters to your functions, so you can use them in API Gateway tests and SDK generation, marking them as `true` will make them required, `false` will make them optional.

--- a/lib/plugins/aws/custom-resources/resources/api-gateway-cloud-watch-role/handler.js
+++ b/lib/plugins/aws/custom-resources/resources/api-gateway-cloud-watch-role/handler.js
@@ -58,10 +58,7 @@ async function create(event, context) {
         return (await iam.send(new ListAttachedRolePoliciesCommand({ RoleName: roleName })))
           .AttachedPolicies;
       } catch (error) {
-        if (
-          error.code === 'NoSuchEntity' ||
-          error.message.includes('cannot be found')
-        ) {
+        if (error.code === 'NoSuchEntity' || error.message.includes('cannot be found')) {
           // Role doesn't exist yet, create;
           await iam.send(
             new CreateRoleCommand({

--- a/lib/plugins/aws/package/compile/events/api-gateway/lib/rest-api.js
+++ b/lib/plugins/aws/package/compile/events/api-gateway/lib/rest-api.js
@@ -57,7 +57,7 @@ module.exports = {
       BinaryMediaTypes,
       DisableExecuteApiEndpoint,
       EndpointConfiguration,
-      SecurityPolicy
+      SecurityPolicy,
     };
 
     // Tags

--- a/lib/plugins/aws/package/compile/events/api-gateway/lib/rest-api.js
+++ b/lib/plugins/aws/package/compile/events/api-gateway/lib/rest-api.js
@@ -18,12 +18,17 @@ module.exports = {
     let vpcEndpointIds;
     let BinaryMediaTypes;
     let SecurityPolicy;
+    let EndpointAccessMode;
     if (apiGateway.binaryMediaTypes) {
       BinaryMediaTypes = apiGateway.binaryMediaTypes;
     }
 
     if (apiGateway.securityPolicy) {
       SecurityPolicy = apiGateway.securityPolicy;
+    }
+
+    if (apiGateway.endpointAccessMode) {
+      EndpointAccessMode = apiGateway.endpointAccessMode.toUpperCase();
     }
 
     if (this.serverless.service.provider.endpointType) {
@@ -58,6 +63,7 @@ module.exports = {
       DisableExecuteApiEndpoint,
       EndpointConfiguration,
       SecurityPolicy,
+      EndpointAccessMode,
     };
 
     // Tags

--- a/lib/plugins/aws/package/compile/events/api-gateway/lib/rest-api.js
+++ b/lib/plugins/aws/package/compile/events/api-gateway/lib/rest-api.js
@@ -17,8 +17,13 @@ module.exports = {
     let endpointType = 'EDGE';
     let vpcEndpointIds;
     let BinaryMediaTypes;
+    let SecurityPolicy;
     if (apiGateway.binaryMediaTypes) {
       BinaryMediaTypes = apiGateway.binaryMediaTypes;
+    }
+
+    if (apiGateway.securityPolicy) {
+      SecurityPolicy = apiGateway.securityPolicy;
     }
 
     if (this.serverless.service.provider.endpointType) {
@@ -52,6 +57,7 @@ module.exports = {
       BinaryMediaTypes,
       DisableExecuteApiEndpoint,
       EndpointConfiguration,
+      SecurityPolicy
     };
 
     // Tags

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -852,8 +852,7 @@ class AwsProvider {
                   type: 'string',
                 },
                 endpointAccessMode: {
-                  type: 'string',
-                  enum: ['strict', 'basic', ''].map(caseInsensitive),
+                  anyOf: ['strict', 'basic', ''].map(caseInsensitive),
                 },
                 description: { type: 'string' },
                 disableDefaultEndpoint: { type: 'boolean' },

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -851,6 +851,10 @@ class AwsProvider {
                 securityPolicy: {
                   type: 'string',
                 },
+                endpointAccessMode: {
+                  type: 'string',
+                  enum: ['strict', 'basic', ''].map(caseInsensitive),
+                },
                 description: { type: 'string' },
                 disableDefaultEndpoint: { type: 'boolean' },
                 metrics: { type: 'boolean' },

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -849,7 +849,7 @@ class AwsProvider {
                   items: { type: 'string', pattern: '^\\S+\\/\\S+$' },
                 },
                 securityPolicy: {
-                  type: 'string'
+                  type: 'string',
                 },
                 description: { type: 'string' },
                 disableDefaultEndpoint: { type: 'boolean' },

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -848,6 +848,9 @@ class AwsProvider {
                   type: 'array',
                   items: { type: 'string', pattern: '^\\S+\\/\\S+$' },
                 },
+                securityPolicy: {
+                  type: 'string'
+                },
                 description: { type: 'string' },
                 disableDefaultEndpoint: { type: 'boolean' },
                 metrics: { type: 'boolean' },

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/rest-api.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/rest-api.test.js
@@ -51,6 +51,30 @@ describe('#compileRestApi()', () => {
         EndpointConfiguration: {
           Types: ['EDGE'],
         },
+        SecurityPolicy: undefined,
+        Policy: '',
+      },
+    });
+  });
+
+  it('should create a REST API resource with security policy', () => {
+    awsCompileApigEvents.serverless.service.provider.apiGateway = {
+      securityPolicy: 'SecurityPolicy_TLS13_1_3_2025_09'
+    }
+    awsCompileApigEvents.compileRestApi();
+    const resources =
+      awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+
+    expect(resources.ApiGatewayRestApi).to.deep.equal({
+      Type: 'AWS::ApiGateway::RestApi',
+      Properties: {
+        BinaryMediaTypes: undefined,
+        DisableExecuteApiEndpoint: undefined,
+        Name: 'dev-new-service',
+        EndpointConfiguration: {
+          Types: ['EDGE'],
+        },
+        SecurityPolicy: 'SecurityPolicy_TLS13_1_3_2025_09',
         Policy: '',
       },
     });
@@ -75,6 +99,7 @@ describe('#compileRestApi()', () => {
         EndpointConfiguration: {
           Types: ['EDGE'],
         },
+        SecurityPolicy: undefined,
         Policy: '',
         Tags: [
           { Key: 'tagKey1', Value: 'tagValue1' },
@@ -113,6 +138,7 @@ describe('#compileRestApi()', () => {
         EndpointConfiguration: {
           Types: ['EDGE'],
         },
+        SecurityPolicy: undefined,
         Policy: {
           Version: '2012-10-17',
           Statement: [
@@ -148,6 +174,7 @@ describe('#compileRestApi()', () => {
           Types: ['EDGE'],
         },
         Policy: '',
+        SecurityPolicy: undefined,
       },
     });
   });
@@ -181,6 +208,7 @@ describe('#compileRestApi()', () => {
         },
         Name: 'dev-new-service',
         Policy: '',
+        SecurityPolicy: undefined,
       },
     });
   });

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/rest-api.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/rest-api.test.js
@@ -52,6 +52,7 @@ describe('#compileRestApi()', () => {
           Types: ['EDGE'],
         },
         SecurityPolicy: undefined,
+        EndpointAccessMode: undefined,
         Policy: '',
       },
     });
@@ -75,6 +76,31 @@ describe('#compileRestApi()', () => {
           Types: ['EDGE'],
         },
         SecurityPolicy: 'SecurityPolicy_TLS13_1_3_2025_09',
+        EndpointAccessMode: undefined,
+        Policy: '',
+      },
+    });
+  });
+
+  it('should create a REST API resource with endpoint access mode', () => {
+    awsCompileApigEvents.serverless.service.provider.apiGateway = {
+      endpointAccessMode: 'STRICT',
+    };
+    awsCompileApigEvents.compileRestApi();
+    const resources =
+      awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+
+    expect(resources.ApiGatewayRestApi).to.deep.equal({
+      Type: 'AWS::ApiGateway::RestApi',
+      Properties: {
+        BinaryMediaTypes: undefined,
+        DisableExecuteApiEndpoint: undefined,
+        Name: 'dev-new-service',
+        EndpointConfiguration: {
+          Types: ['EDGE'],
+        },
+        SecurityPolicy: undefined,
+        EndpointAccessMode: 'STRICT',
         Policy: '',
       },
     });
@@ -100,6 +126,7 @@ describe('#compileRestApi()', () => {
           Types: ['EDGE'],
         },
         SecurityPolicy: undefined,
+        EndpointAccessMode: undefined,
         Policy: '',
         Tags: [
           { Key: 'tagKey1', Value: 'tagValue1' },
@@ -139,6 +166,7 @@ describe('#compileRestApi()', () => {
           Types: ['EDGE'],
         },
         SecurityPolicy: undefined,
+        EndpointAccessMode: undefined,
         Policy: {
           Version: '2012-10-17',
           Statement: [
@@ -175,6 +203,7 @@ describe('#compileRestApi()', () => {
         },
         Policy: '',
         SecurityPolicy: undefined,
+        EndpointAccessMode: undefined,
       },
     });
   });
@@ -209,6 +238,7 @@ describe('#compileRestApi()', () => {
         Name: 'dev-new-service',
         Policy: '',
         SecurityPolicy: undefined,
+        EndpointAccessMode: undefined,
       },
     });
   });

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/rest-api.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/rest-api.test.js
@@ -59,8 +59,8 @@ describe('#compileRestApi()', () => {
 
   it('should create a REST API resource with security policy', () => {
     awsCompileApigEvents.serverless.service.provider.apiGateway = {
-      securityPolicy: 'SecurityPolicy_TLS13_1_3_2025_09'
-    }
+      securityPolicy: 'SecurityPolicy_TLS13_1_3_2025_09',
+    };
     awsCompileApigEvents.compileRestApi();
     const resources =
       awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;


### PR DESCRIPTION
## Summary
- Add support for securityPolicy property under provider.apiGateway to configure TLS version on REST APIs
- Add support for endpointAccessMode property under provider.apiGateway to control API endpoint access mode (STRICT or BASIC)
- Add documentation for both new properties in docs/events/apigateway.md

Fixes oss-serverless/serverless#133

Example of usage:

```yml
provider:
  name: aws
  apiGateway:
    securityPolicy: SecurityPolicy_TLS13_2025_EDGE  # Recommended: Use TLS 1.2 or higher
    endpointAccessMode: STRICT
```

important notice:

both `securityPolicy` and `endpointAccessMode` configs are available only for AWS REST API Gateways, which are created when `http`events are used:

```yml
functions:
  testFunctionAwsRest:
    handler: index.handler
    events:
      - http:
          path: /test
          method: get
 ```
 
These properties have no effect if `httpApi` events are being used since this creates an AWS HTTP API (v2) in the CloudFormation stack:

```yml
# securityPolicy and endpointAccessMode configs wont have any effect because of httpApi event config
functions:
  testFunctionAwsHttp:
    handler: index.handler
    events:
      - httpApi:
          # ...
 ```