### PR TITLE
Align java25 runtime support and runtime docs

### DIFF
--- a/docs/cli-reference/invoke.md
+++ b/docs/cli-reference/invoke.md
@@ -126,7 +126,7 @@ This example will pass the json context in the `lib/context.json` file (relative
 
 ### Limitations
 
-Currently, `invoke local` only supports the Node.js, Python, Java and Ruby runtimes.
+`invoke local` runs Node.js, Python, Java, and Ruby runtimes directly on your machine. Other runtimes are invoked through Docker.
 
 ## Resource permissions
 

--- a/docs/events/cloudfront.md
+++ b/docs/events/cloudfront.md
@@ -21,9 +21,9 @@ Lambda@Edge has four options when the Lambda function is triggered
 
 **MEMORY AND TIMEOUT LIMITS:** According to [AWS Limits on Lambda@Edge](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-limits.html#limits-lambda-at-edge) the limits for viewer-request and viewer-response are 128MB memory and 5 seconds timeout and for origin-request and origin-response are 3008MB memory and 30 seconds timeout.
 
-**RUNTIME LIMITS:** According to [AWS Requirements on Lambda@Edge](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-requirements-limits.html) the runtimes supported by Lambda@Edge functions are: `Python 3.13`, `Python 3.12`, `Python 3.11`, `Python 3.10`, `Python 3.9`, `Python 3.8`, `Node.js 22.x`, `Node.js 20.x`.
+**RUNTIME LIMITS:** According to [AWS Requirements on Lambda@Edge](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-requirements-limits.html) Lambda@Edge supports only a subset of Lambda runtimes. See the AWS documentation for the current supported runtimes.
 
-**FUNCTION SIZE LIMITS:** According to [AWS Quotas on CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-limits.html#limits-functions), Lambda@Edge functions mustn't exceed the maximum size of 10KB. An easy way of reducing the size of a function is through bundling and minification via e.g. the plugin [serverless-esbuild](https://www.example.com/plugins/serverless-esbuild).
+**FUNCTION SIZE LIMITS:** According to [AWS Requirements on Lambda@Edge](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-requirements-limits.html) Lambda@Edge functions must stay within the current Lambda@Edge deployment package size quotas.
 
 ## Simple event definition
 

--- a/docs/guides/functions.md
+++ b/docs/guides/functions.md
@@ -437,7 +437,7 @@ Finally, `auto` and `onFunctionUpdate` can be set as the `mode` property as well
 
 ## SnapStart
 
-[Lambda SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html) for Java can improve startup performance for latency-sensitive applications.
+[Lambda SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html) can improve startup performance for latency-sensitive applications on supported runtimes.
 
 To enable SnapStart for your lambda function you can add the `snapStart` object property in the function configuration which can be put to true and will result in the value `PublishedVersions` for this function.
 
@@ -449,7 +449,7 @@ functions:
     snapStart: true
 ```
 
-**Note:** Lambda SnapStart only supports the Java 11, Java 17 and Java 21 runtimes and does not support provisioned concurrency, the arm64 architecture, the Lambda Extensions API, Amazon Elastic File System (Amazon EFS), AWS X-Ray, or ephemeral storage greater than 512 MB.
+**Note:** SnapStart support and limitations are defined by AWS and may change over time. See the [AWS SnapStart documentation](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html) for the current supported runtimes and restrictions.
 
 ## Recursive Loop Detection
 

--- a/docs/guides/serverless.yml.md
+++ b/docs/guides/serverless.yml.md
@@ -657,7 +657,8 @@ functions:
     onError: arn:aws:sns:us-east-1:XXXXXX:sns-topic
     # KMS key ARN to use for encryption for this function
     kmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash
-    # Defines if you want to make use of SnapStart, this feature can only be used in combination with a Java runtime. Configuring this property will result in either None or PublishedVersions for the Lambda function
+    # Defines if you want to make use of SnapStart on supported runtimes. Configuring this
+    # property will result in either None or PublishedVersions for the Lambda function
     snapStart: true
     # Allow or Terminate recursive invocation loops between supported AWS services (default: Terminate)
     recursiveLoop: Allow

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -630,6 +630,7 @@ class AwsProvider {
               'dotnet9',
               'dotnet10',
               'go1.x',
+              'java25',
               'java21',
               'java17',
               'java11',

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -506,15 +506,34 @@ describe('AwsInvokeLocal', () => {
       ).to.be.equal(true);
     });
 
-    it('should call invokeLocalJava when java8 runtime is set', async () => {
-      awsInvokeLocal.options.functionObj.runtime = 'java8';
+    ['java8', 'java8.al2', 'java11', 'java17', 'java21', 'java25'].forEach((runtime) => {
+      it(`should call invokeLocalJava when ${runtime} runtime is set`, async () => {
+        awsInvokeLocal.options.functionObj.runtime = runtime;
+        await awsInvokeLocal.invokeLocal();
+        expect(invokeLocalJavaStub.calledOnce).to.be.equal(true);
+        expect(
+          invokeLocalJavaStub.calledWithExactly(
+            'java',
+            'handler.hello',
+            'handleRequest',
+            undefined,
+            {},
+            undefined
+          )
+        ).to.be.equal(true);
+      });
+    });
+
+    it('should call invokeLocalJava with an explicit handler method', async () => {
+      awsInvokeLocal.options.functionObj.runtime = 'java21';
+      awsInvokeLocal.options.functionObj.handler = 'com.example.Handler::customMethod';
       await awsInvokeLocal.invokeLocal();
       expect(invokeLocalJavaStub.calledOnce).to.be.equal(true);
       expect(
         invokeLocalJavaStub.calledWithExactly(
           'java',
-          'handler.hello',
-          'handleRequest',
+          'com.example.Handler',
+          'customMethod',
           undefined,
           {},
           undefined

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1337,6 +1337,52 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
       expect(Runtime).to.equal(fooFunctionConfig.runtime);
     });
 
+    it('should accept `provider.runtime: java25`', async () => {
+      const {
+        awsNaming: localNaming,
+        cfTemplate: { Resources: localResources },
+      } = await runServerless({
+        fixture: 'function',
+        command: 'package',
+        configExt: {
+          provider: {
+            runtime: 'java25',
+          },
+        },
+      });
+
+      expect(localResources[localNaming.getLambdaLogicalId('basic')].Properties.Runtime).to.equal(
+        'java25'
+      );
+      expect(localResources[localNaming.getLambdaLogicalId('other')].Properties.Runtime).to.equal(
+        'java25'
+      );
+    });
+
+    it('should accept `functions[].runtime: java25`', async () => {
+      const {
+        awsNaming: localNaming,
+        cfTemplate: { Resources: localResources },
+      } = await runServerless({
+        fixture: 'function',
+        command: 'package',
+        configExt: {
+          functions: {
+            basic: {
+              runtime: 'java25',
+            },
+          },
+        },
+      });
+
+      expect(localResources[localNaming.getLambdaLogicalId('basic')].Properties.Runtime).to.equal(
+        'java25'
+      );
+      expect(localResources[localNaming.getLambdaLogicalId('other')].Properties.Runtime).to.equal(
+        'nodejs20.x'
+      );
+    });
+
     it('should support `provider.runtimeManagement`', () => {
       const providerConfig = serviceConfig.provider;
 

--- a/test/unit/lib/plugins/aws/package/compile/layers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/layers.test.js
@@ -189,6 +189,28 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
     expect(layerOne.Properties.CompatibleRuntimes).to.deep.equals(['nodejs20.x']);
   });
 
+  it('should accept `layers[].compatibleRuntimes: [java25]`', async () => {
+    const {
+      awsNaming,
+      cfTemplate: { Resources },
+    } = await runServerless({
+      fixture: 'layer',
+      command: 'package',
+      configExt: {
+        layers: {
+          layer: {
+            compatibleRuntimes: ['java25'],
+          },
+        },
+      },
+      awsRequestStubMap,
+    });
+
+    expect(
+      Resources[awsNaming.getLambdaLayerLogicalId('layer')].Properties.CompatibleRuntimes
+    ).to.deep.equal(['java25']);
+  });
+
   it('should support `layers[].compatibleArchitectures`', () => {
     const layerResourceName = naming.getLambdaLayerLogicalId('LayerTwo');
     const layerOne = cfResources[layerResourceName];

--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -37,6 +37,47 @@ describe('AwsProvider', () => {
   });
   afterEach(() => restoreEnv());
 
+  describe('runtime schema parity', () => {
+    it('should keep `awsLambdaRuntime` in sync with `AwsLambdaRuntime`', () => {
+      const providerPath = path.resolve(__dirname, '../../../../../lib/plugins/aws/provider.js');
+      const runtimeTypePath = path.resolve(__dirname, '../../../../../types/index.d.ts');
+      const providerSource = fs.readFileSync(providerPath, 'utf8');
+      const runtimeTypeSource = fs.readFileSync(runtimeTypePath, 'utf8');
+      const providerMatch = providerSource.match(
+        /awsLambdaRuntime:\s*\{\s*enum:\s*\[([\s\S]*?)\],\s*\},\s*awsLambdaRuntimeManagement:/
+      );
+      const runtimeTypeMatch = runtimeTypeSource.match(
+        /export type AwsLambdaRuntime =([\s\S]*?)\nexport type AwsLambdaRuntimeManagement =/
+      );
+
+      if (!providerMatch) {
+        throw new Error('Could not find awsLambdaRuntime schema definition');
+      }
+
+      if (!runtimeTypeMatch) {
+        throw new Error('Could not find AwsLambdaRuntime type declaration');
+      }
+
+      const providerRuntimes = [...providerMatch[1].matchAll(/'([^']+)'/g)]
+        .map((match) => match[1])
+        .sort();
+      const typeRuntimes = [...runtimeTypeMatch[1].matchAll(/'([^']+)'/g)]
+        .map((match) => match[1])
+        .sort();
+      const missingInTypes = providerRuntimes.filter((runtime) => !typeRuntimes.includes(runtime));
+      const missingInProvider = typeRuntimes.filter(
+        (runtime) => !providerRuntimes.includes(runtime)
+      );
+
+      expect(
+        providerRuntimes,
+        `awsLambdaRuntime mismatch:\nmissing in types: ${
+          missingInTypes.join(', ') || 'none'
+        }\nmissing in provider: ${missingInProvider.join(', ') || 'none'}`
+      ).to.deep.equal(typeRuntimes);
+    });
+  });
+
   describe('#constructor()', () => {
     it('should set Serverless instance', () => {
       expect(typeof awsProvider.serverless).to.not.equal('undefined');

--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -39,28 +39,26 @@ describe('AwsProvider', () => {
 
   describe('runtime schema parity', () => {
     it('should keep `awsLambdaRuntime` in sync with `AwsLambdaRuntime`', () => {
-      const providerPath = path.resolve(__dirname, '../../../../../lib/plugins/aws/provider.js');
+      const localServerless = new Serverless({ ...options, commands: [], options: {} });
       const runtimeTypePath = path.resolve(__dirname, '../../../../../types/index.d.ts');
-      const providerSource = fs.readFileSync(providerPath, 'utf8');
       const runtimeTypeSource = fs.readFileSync(runtimeTypePath, 'utf8');
-      const providerMatch = providerSource.match(
-        /awsLambdaRuntime:\s*\{\s*enum:\s*\[([\s\S]*?)\],\s*\},\s*awsLambdaRuntimeManagement:/
-      );
-      const runtimeTypeMatch = runtimeTypeSource.match(
-        /export type AwsLambdaRuntime =([\s\S]*?)\nexport type AwsLambdaRuntimeManagement =/
-      );
 
-      if (!providerMatch) {
-        throw new Error('Could not find awsLambdaRuntime schema definition');
-      }
+      localServerless.service.provider.name = 'aws';
+      localServerless.cli = new localServerless.classes.CLI();
+      const localAwsProvider = new AwsProvider(localServerless, options);
+      expect(localAwsProvider.serverless).to.equal(localServerless);
+
+      const runtimeTypeMatch = runtimeTypeSource.match(
+        /export type AwsLambdaRuntime =([\s\S]*?)\r?\nexport type AwsLambdaRuntimeManagement =/
+      );
 
       if (!runtimeTypeMatch) {
         throw new Error('Could not find AwsLambdaRuntime type declaration');
       }
 
-      const providerRuntimes = [...providerMatch[1].matchAll(/'([^']+)'/g)]
-        .map((match) => match[1])
-        .sort();
+      const providerRuntimes = [
+        ...localServerless.configSchemaHandler.schema.definitions.awsLambdaRuntime.enum,
+      ].sort();
       const typeRuntimes = [...runtimeTypeMatch[1].matchAll(/'([^']+)'/g)]
         .map((match) => match[1])
         .sort();

--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -49,7 +49,7 @@ describe('AwsProvider', () => {
       expect(localAwsProvider.serverless).to.equal(localServerless);
 
       const runtimeTypeMatch = runtimeTypeSource.match(
-        /export type AwsLambdaRuntime =([\s\S]*?)\r?\nexport type AwsLambdaRuntimeManagement =/
+        /export type AwsLambdaRuntime\s*=\s*([\s\S]*?);/
       );
 
       if (!runtimeTypeMatch) {


### PR DESCRIPTION
- Add java25 to the AWS runtime schema so validation matches existing typings and invoke-local support
- Add regression tests to keep runtime enums in sync and cover java25 across provider, function, layer, and Java invoke-local paths
- Update stale runtime docs for invoke local, SnapStart, and Lambda@Edge to avoid drift and incorrect recommendations