### PR TITLE
fix(aws/custom-resources): propagate provider.architecture to custom resource Lambda

### DIFF
--- a/lib/plugins/aws/custom-resources/index.js
+++ b/lib/plugins/aws/custom-resources/index.js
@@ -183,6 +183,11 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
     },
     DependsOn: [],
   };
+
+  if (providerConfig.architecture) {
+    customResourceFunction.Properties.Architectures = [providerConfig.architecture];
+  }
+
   Resources[customResourceFunctionLogicalId] = customResourceFunction;
 
   if (customDeploymentRole) {

--- a/test/unit/lib/plugins/aws/custom-resources/index.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/index.test.js
@@ -406,6 +406,25 @@ describe('#addCustomResourceToService()', () => {
       Resources.CustomDashresourceDasheventDashbridgeLambdaFunction.Properties.Runtime
     ).to.equal('nodejs24.x');
   });
+
+  it('should set Architectures from provider.architecture', async () => {
+    serverless.service.provider.architecture = 'arm64';
+    await addCustomResourceToService(provider, 's3', iamRoleStatements);
+
+    const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
+    expect(
+      Resources.CustomDashresourceDashexistingDashs3LambdaFunction.Properties.Architectures
+    ).to.deep.equal(['arm64']);
+  });
+
+  it('should not set Architectures when provider.architecture is not defined', async () => {
+    await addCustomResourceToService(provider, 's3', iamRoleStatements);
+
+    const { Resources } = serverless.service.provider.compiledCloudFormationTemplate;
+    expect(
+      Resources.CustomDashresourceDashexistingDashs3LambdaFunction.Properties
+    ).to.not.have.property('Architectures');
+  });
 });
 
 describe('test/unit/lib/plugins/aws/customResources/index.test.js', () => {


### PR DESCRIPTION
## Summary

Fixes #116. The internal custom resource Lambda (used for S3 notifications, Cognito user pools, Event Bridge, and the API Gateway CloudWatch role) was always deployed as `x86_64` because `Architectures` was never set on the generated CloudFormation resource, regardless of `provider.architecture` in `serverless.yml`.

## Changes

- `lib/plugins/aws/custom-resources/index.js`: when `provider.architecture` is configured, set `Properties.Architectures` on the compiled custom resource `AWS::Lambda::Function`. Mirrors the pattern already used for user-defined functions in `lib/plugins/aws/package/compile/functions.js`.
- No new config surface — this extends where the existing, schema-validated `provider.architecture` value is applied.

## Tests

Two new cases in `test/unit/lib/plugins/aws/custom-resources/index.test.js`:
- `Architectures` is set to `['arm64']` when `provider.architecture` is `'arm64'`.
- `Architectures` is omitted when `provider.architecture` is unset (preserves current x86_64 default behavior).

All 14 tests in the custom-resources suite pass. Full unit suite (SDK v2 and v3), packaging tests (v2 and v3), isolated tests, prettier, and eslint all pass locally.