### PR TITLE
Fix verbose deploy hang on failed stack statuses

### DIFF
--- a/lib/plugins/aws/lib/monitor-stack.js
+++ b/lib/plugins/aws/lib/monitor-stack.js
@@ -111,7 +111,12 @@ module.exports = {
                 (!this.options.verbose ||
                   (stackStatus &&
                     (stackStatus.endsWith('ROLLBACK_COMPLETE') ||
-                      ['DELETE_FAILED', 'DELETE_COMPLETE'].includes(stackStatus))))
+                      [
+                        'CREATE_FAILED',
+                        'UPDATE_FAILED',
+                        'DELETE_FAILED',
+                        'DELETE_COMPLETE',
+                      ].includes(stackStatus))))
               ) {
                 const decoratedErrorMessage = `${stackLatestError.ResourceStatus}: ${
                   stackLatestError.LogicalResourceId

--- a/lib/plugins/aws/lib/monitor-stack.js
+++ b/lib/plugins/aws/lib/monitor-stack.js
@@ -110,13 +110,9 @@ module.exports = {
                 stackLatestError &&
                 (!this.options.verbose ||
                   (stackStatus &&
-                    (stackStatus.endsWith('ROLLBACK_COMPLETE') ||
-                      [
-                        'CREATE_FAILED',
-                        'UPDATE_FAILED',
-                        'DELETE_FAILED',
-                        'DELETE_COMPLETE',
-                      ].includes(stackStatus))))
+                    (stackStatus.endsWith('FAILED') ||
+                      stackStatus.endsWith('ROLLBACK_COMPLETE') ||
+                      stackStatus === 'DELETE_COMPLETE')))
               ) {
                 const decoratedErrorMessage = `${stackLatestError.ResourceStatus}: ${
                   stackLatestError.LogicalResourceId

--- a/test/unit/lib/plugins/aws/lib/monitor-stack.test.js
+++ b/test/unit/lib/plugins/aws/lib/monitor-stack.test.js
@@ -518,7 +518,7 @@ describe('monitorStack', () => {
           })
         ).to.be.equal(true);
       } finally {
-        describeStackEventsStub.restore();
+        awsPlugin.provider.request.restore();
       }
     });
 
@@ -583,7 +583,7 @@ describe('monitorStack', () => {
           })
         ).to.be.equal(true);
       } finally {
-        describeStackEventsStub.restore();
+        awsPlugin.provider.request.restore();
       }
     });
 
@@ -661,7 +661,7 @@ describe('monitorStack', () => {
           })
         ).to.be.equal(true);
       } finally {
-        describeStackEventsStub.restore();
+        awsPlugin.provider.request.restore();
       }
     });
 
@@ -739,7 +739,7 @@ describe('monitorStack', () => {
           })
         ).to.be.equal(true);
       } finally {
-        describeStackEventsStub.restore();
+        awsPlugin.provider.request.restore();
       }
     });
 

--- a/test/unit/lib/plugins/aws/lib/monitor-stack.test.js
+++ b/test/unit/lib/plugins/aws/lib/monitor-stack.test.js
@@ -587,6 +587,162 @@ describe('monitorStack', () => {
       }
     });
 
+    it('should exit on failure with --verbose when stack status is ROLLBACK_FAILED', async () => {
+      awsPlugin.options.verbose = true;
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
+      const cfDataMock = {
+        StackId: 'new-service-dev',
+      };
+      const createStartEvent = {
+        StackEvents: [
+          {
+            EventId: '1a2b3c4d',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'CREATE_IN_PROGRESS',
+          },
+        ],
+      };
+      const resourceFailedEvent = {
+        StackEvents: [
+          {
+            EventId: '1e2f3g4h',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'mochaLambda',
+            ResourceType: 'AWS::Lambda::Function',
+            Timestamp: new Date(),
+            ResourceStatus: 'CREATE_FAILED',
+            ResourceStatusReason: 'Resource creation cancelled',
+          },
+        ],
+      };
+      const rollbackInProgressEvent = {
+        StackEvents: [
+          {
+            EventId: '1i2j3k4l',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'ROLLBACK_IN_PROGRESS',
+          },
+        ],
+      };
+      const rollbackFailedEvent = {
+        StackEvents: [
+          {
+            EventId: '1m2n3o4p',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'ROLLBACK_FAILED',
+          },
+        ],
+      };
+
+      describeStackEventsStub.onCall(0).resolves(createStartEvent);
+      describeStackEventsStub.onCall(1).resolves(resourceFailedEvent);
+      describeStackEventsStub.onCall(2).resolves(rollbackInProgressEvent);
+      describeStackEventsStub.onCall(3).resolves(rollbackFailedEvent);
+
+      try {
+        await expect(
+          awsPlugin.monitorStack('create', cfDataMock, { frequency: 10 })
+        ).to.eventually.be.rejectedWith(
+          'An error occurred: mochaLambda - Resource creation cancelled.'
+        );
+        expect(describeStackEventsStub.callCount).to.be.equal(4);
+        expect(
+          describeStackEventsStub.calledWithExactly('CloudFormation', 'describeStackEvents', {
+            StackName: cfDataMock.StackId,
+          })
+        ).to.be.equal(true);
+      } finally {
+        describeStackEventsStub.restore();
+      }
+    });
+
+    it('should exit on failure with --verbose when stack status is UPDATE_ROLLBACK_FAILED', async () => {
+      awsPlugin.options.verbose = true;
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
+      const cfDataMock = {
+        StackId: 'new-service-dev',
+      };
+      const updateStartEvent = {
+        StackEvents: [
+          {
+            EventId: '1a2b3c4d',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'UPDATE_IN_PROGRESS',
+          },
+        ],
+      };
+      const resourceFailedEvent = {
+        StackEvents: [
+          {
+            EventId: '1e2f3g4h',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'mochaApiGw',
+            ResourceType: 'AWS::ApiGateway::Deployment',
+            Timestamp: new Date(),
+            ResourceStatus: 'CREATE_FAILED',
+            ResourceStatusReason: 'Invalid stage identifier specified',
+          },
+        ],
+      };
+      const updateRollbackInProgressEvent = {
+        StackEvents: [
+          {
+            EventId: '1i2j3k4l',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'UPDATE_ROLLBACK_IN_PROGRESS',
+          },
+        ],
+      };
+      const updateRollbackFailedEvent = {
+        StackEvents: [
+          {
+            EventId: '1m2n3o4p',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'UPDATE_ROLLBACK_FAILED',
+          },
+        ],
+      };
+
+      describeStackEventsStub.onCall(0).resolves(updateStartEvent);
+      describeStackEventsStub.onCall(1).resolves(resourceFailedEvent);
+      describeStackEventsStub.onCall(2).resolves(updateRollbackInProgressEvent);
+      describeStackEventsStub.onCall(3).resolves(updateRollbackFailedEvent);
+
+      try {
+        await expect(
+          awsPlugin.monitorStack('update', cfDataMock, { frequency: 10 })
+        ).to.eventually.be.rejectedWith(
+          'An error occurred: mochaApiGw - Invalid stage identifier specified.'
+        );
+        expect(describeStackEventsStub.callCount).to.be.equal(4);
+        expect(
+          describeStackEventsStub.calledWithExactly('CloudFormation', 'describeStackEvents', {
+            StackName: cfDataMock.StackId,
+          })
+        ).to.be.equal(true);
+      } finally {
+        describeStackEventsStub.restore();
+      }
+    });
+
     it('should keep monitoring when 1st ResourceType is not "AWS::CloudFormation::Stack"', async () => {
       const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
       const cfDataMock = {

--- a/test/unit/lib/plugins/aws/lib/monitor-stack.test.js
+++ b/test/unit/lib/plugins/aws/lib/monitor-stack.test.js
@@ -457,6 +457,136 @@ describe('monitorStack', () => {
       });
     });
 
+    it('should exit on failure with --verbose when stack status is CREATE_FAILED', async () => {
+      awsPlugin.options.verbose = true;
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
+      const cfDataMock = {
+        StackId: 'new-service-dev',
+      };
+      const createStartEvent = {
+        StackEvents: [
+          {
+            EventId: '1a2b3c4d',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'CREATE_IN_PROGRESS',
+          },
+        ],
+      };
+      const resourceFailedEvent = {
+        StackEvents: [
+          {
+            EventId: '1e2f3g4h',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'mochaLambda',
+            ResourceType: 'AWS::Lambda::Function',
+            Timestamp: new Date(),
+            ResourceStatus: 'CREATE_FAILED',
+            ResourceStatusReason: 'Resource creation cancelled',
+          },
+        ],
+      };
+      const stackCreateFailedEvent = {
+        StackEvents: [
+          {
+            EventId: '1i2j3k4l',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'CREATE_FAILED',
+          },
+        ],
+      };
+
+      describeStackEventsStub.onCall(0).resolves(createStartEvent);
+      describeStackEventsStub.onCall(1).resolves(resourceFailedEvent);
+      describeStackEventsStub.onCall(2).resolves(stackCreateFailedEvent);
+
+      try {
+        await expect(
+          awsPlugin.monitorStack('create', cfDataMock, { frequency: 10 })
+        ).to.eventually.be.rejectedWith(
+          'An error occurred: mochaLambda - Resource creation cancelled.'
+        );
+        expect(describeStackEventsStub.callCount).to.be.equal(3);
+        expect(
+          describeStackEventsStub.calledWithExactly('CloudFormation', 'describeStackEvents', {
+            StackName: cfDataMock.StackId,
+          })
+        ).to.be.equal(true);
+      } finally {
+        describeStackEventsStub.restore();
+      }
+    });
+
+    it('should exit on failure with --verbose when stack status is UPDATE_FAILED', async () => {
+      awsPlugin.options.verbose = true;
+      const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
+      const cfDataMock = {
+        StackId: 'new-service-dev',
+      };
+      const updateStartEvent = {
+        StackEvents: [
+          {
+            EventId: '1a2b3c4d',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'UPDATE_IN_PROGRESS',
+          },
+        ],
+      };
+      const resourceFailedEvent = {
+        StackEvents: [
+          {
+            EventId: '1e2f3g4h',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'mochaApiGw',
+            ResourceType: 'AWS::ApiGateway::Deployment',
+            Timestamp: new Date(),
+            ResourceStatus: 'CREATE_FAILED',
+            ResourceStatusReason: 'Invalid stage identifier specified',
+          },
+        ],
+      };
+      const stackUpdateFailedEvent = {
+        StackEvents: [
+          {
+            EventId: '1i2j3k4l',
+            StackName: 'new-service-dev',
+            LogicalResourceId: 'new-service-dev',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            Timestamp: new Date(),
+            ResourceStatus: 'UPDATE_FAILED',
+          },
+        ],
+      };
+
+      describeStackEventsStub.onCall(0).resolves(updateStartEvent);
+      describeStackEventsStub.onCall(1).resolves(resourceFailedEvent);
+      describeStackEventsStub.onCall(2).resolves(stackUpdateFailedEvent);
+
+      try {
+        await expect(
+          awsPlugin.monitorStack('update', cfDataMock, { frequency: 10 })
+        ).to.eventually.be.rejectedWith(
+          'An error occurred: mochaApiGw - Invalid stage identifier specified.'
+        );
+        expect(describeStackEventsStub.callCount).to.be.equal(3);
+        expect(
+          describeStackEventsStub.calledWithExactly('CloudFormation', 'describeStackEvents', {
+            StackName: cfDataMock.StackId,
+          })
+        ).to.be.equal(true);
+      } finally {
+        describeStackEventsStub.restore();
+      }
+    });
+
     it('should keep monitoring when 1st ResourceType is not "AWS::CloudFormation::Stack"', async () => {
       const describeStackEventsStub = sinon.stub(awsPlugin.provider, 'request');
       const cfDataMock = {


### PR DESCRIPTION
## Summary
- Treat CREATE_FAILED and UPDATE_FAILED as terminal statuses while monitoring stack failures in verbose mode.
- Add regression coverage for verbose create and update failures that stop at failed stack statuses.

Resolves #150