### PR TITLE
Harden plugin input and process argument handling

### DIFF
--- a/lib/commands/plugin-management.js
+++ b/lib/commands/plugin-management.js
@@ -3,6 +3,18 @@
 const path = require('path');
 const ServerlessError = require('../../lib/serverless-error');
 
+const maxNpmPackageNameLength = 214;
+const npmPackageNamePattern = /^(?:@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*$/;
+
+const validatePluginName = (name) => {
+  if (name.length > maxNpmPackageNameLength || !npmPackageNamePattern.test(name)) {
+    throw new ServerlessError(
+      `Invalid plugin name "${name}". Plugin names must be valid npm package names.`,
+      'INVALID_PLUGIN_NAME'
+    );
+  }
+};
+
 module.exports = {
   validate({ serviceDir }) {
     if (!serviceDir) {
@@ -24,6 +36,12 @@ module.exports = {
   },
 
   getPluginInfo(name_) {
+    if (typeof name_ !== 'string') {
+      throw new ServerlessError(
+        `Invalid plugin name "${name_}". Plugin names must be valid npm package names.`,
+        'INVALID_PLUGIN_NAME'
+      );
+    }
     let name;
     let version;
     if (name_.startsWith('@')) {
@@ -32,6 +50,7 @@ module.exports = {
     } else {
       [name, version] = name_.split('@', 2);
     }
+    validatePluginName(name);
     return { name, version };
   },
 };

--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -705,54 +705,38 @@ class AwsInvokeLocal {
     try {
       await fsp.stat(executablePath);
     } catch {
-      return new Promise((resolve, reject) => {
-        const javaBridgeProgress = progress.get('javaBridge');
-        javaBridgeProgress.notice('Building Java bridge', { isMainEvent: true });
-        const mvn = spawn('mvn', ['package', '-f', path.join(javaBridgePath, 'pom.xml')], {
-          shell: true,
-        });
+      const javaBridgeProgress = progress.get('javaBridge');
+      javaBridgeProgress.notice('Building Java bridge', { isMainEvent: true });
+      const mvn = spawnExt('mvn', ['package', '-f', path.join(javaBridgePath, 'pom.xml')], {
+        shouldCloseStdin: true,
+      });
 
+      if (mvn.stderr) {
         mvn.stderr.on('data', (buf) => {
           log.info(`mvn(stderr) - ${buf.toString()}`);
         });
-        const chunk = [];
-        mvn.stdout.on('data', (buf) => chunk.push(buf));
+      }
 
-        let isRejected = false;
-        mvn.on('error', (error) => {
-          if (!isRejected) {
-            isRejected = true;
-            reject(error);
-          }
-        });
+      try {
+        await mvn;
+      } catch (error) {
+        if (error.stdoutBuffer) {
+          error.stdoutBuffer
+            .toString()
+            .split(/\n/)
+            .forEach((line) => {
+              log.info(`mvn(stdout) - ${line}`);
+            });
+        }
+        throw new ServerlessError(
+          `Failed to build the Java bridge. exit code=${error.code} signal=${error.signal}`,
+          'JAVA_BRIDGE_BUILD_FAILED'
+        );
+      } finally {
+        javaBridgeProgress.remove();
+      }
 
-        mvn.on('exit', (code, signal) => {
-          javaBridgeProgress.remove();
-          if (code === 0) {
-            resolve(this.callJavaBridge(artifactPath, className, handlerName, input));
-          } else if (!isRejected) {
-            chunk
-              .map((elem) => elem.toString())
-              .join('')
-              .split(/\n/)
-              .forEach((line) => {
-                log.info(`mvn(stdout) - ${line}`);
-              });
-            isRejected = true;
-            reject(
-              new ServerlessError(
-                `Failed to build the Java bridge. exit code=${code} signal=${signal}`,
-                'JAVA_BRIDGE_BUILD_FAILED'
-              )
-            );
-          }
-        });
-
-        process.nextTick(() => {
-          if (isRejected) return; // Runtime not available
-          mvn.stdin.end();
-        });
-      });
+      return await this.callJavaBridge(artifactPath, className, handlerName, input);
     }
     return await this.callJavaBridge(artifactPath, className, handlerName, input);
   }

--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -720,10 +720,11 @@ class AwsInvokeLocal {
       try {
         await mvn;
       } catch (error) {
-        if (error.stdoutBuffer) {
+        if (error.stdoutBuffer && error.stdoutBuffer.length > 0) {
           error.stdoutBuffer
             .toString()
             .split(/\n/)
+            .filter(Boolean)
             .forEach((line) => {
               log.info(`mvn(stdout) - ${line}`);
             });

--- a/lib/plugins/package/lib/zip-service.js
+++ b/lib/plugins/package/lib/zip-service.js
@@ -6,23 +6,26 @@ const path = require('path');
 const crypto = require('crypto');
 const fs = require('fs');
 const fsp = fs.promises;
-const childProcess = require('child_process');
 const glob = require('../../../utils/glob');
 const memoizee = require('memoizee');
 const ServerlessError = require('../../../serverless-error');
 const { log } = require('../../../utils/serverless-utils/log');
+const spawnExt = require('../../../utils/spawn');
 
-const execCommand = (command, options) =>
-  new Promise((resolve, reject) => {
-    childProcess.exec(command, options, (error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-
-      resolve();
-    });
-  });
+const npmList = (cwd, envName) =>
+  spawnExt(
+    'npm',
+    ['ls', `--${envName}=true`, '--parseable=true', '--long=false', '--silent', '--all'],
+    {
+      cwd,
+      // We are overriding `NODE_ENV` because when it is set to "production"
+      // it causes invalid output of `npm ls` with `--dev=true`
+      env: {
+        ...process.env,
+        NODE_ENV: null,
+      },
+    }
+  );
 const readFile = (...args) => fsp.readFile(...args);
 
 const excludeNodeDevDependenciesMemoized = memoizee(excludeNodeDevDependencies, {
@@ -212,18 +215,8 @@ async function excludeNodeDevDependencies(serviceDir) {
         ['dev', 'prod'].map(async (env) => {
           const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile;
           try {
-            await execCommand(
-              `npm ls --${env}=true --parseable=true --long=false --silent --all >> ${depFile}`,
-              {
-                cwd: dirWithPackageJson,
-                // We are overriding `NODE_ENV` because when it is set to "production"
-                // it causes invalid output of `npm ls` with `--dev=true`
-                env: {
-                  ...process.env,
-                  NODE_ENV: null,
-                },
-              }
-            );
+            const { stdoutBuffer } = await npmList(dirWithPackageJson, env);
+            await fsp.appendFile(depFile, stdoutBuffer || '');
           } catch {
             // Invalid package.json or npm ls failures should not crash packaging.
           }

--- a/lib/plugins/package/lib/zip-service.js
+++ b/lib/plugins/package/lib/zip-service.js
@@ -12,20 +12,27 @@ const ServerlessError = require('../../../serverless-error');
 const { log } = require('../../../utils/serverless-utils/log');
 const spawnExt = require('../../../utils/spawn');
 
-const npmList = (cwd, envName) =>
-  spawnExt(
-    'npm',
-    ['ls', `--${envName}=true`, '--parseable=true', '--long=false', '--silent', '--all'],
-    {
-      cwd,
-      // We are overriding `NODE_ENV` because when it is set to "production"
-      // it causes invalid output of `npm ls` with `--dev=true`
-      env: {
-        ...process.env,
-        NODE_ENV: null,
-      },
-    }
-  );
+const npmList = async (cwd, envName, outputFilePath) => {
+  const outputFile = await fsp.open(outputFilePath, 'a');
+  try {
+    await spawnExt(
+      'npm',
+      ['ls', `--${envName}=true`, '--parseable=true', '--long=false', '--silent', '--all'],
+      {
+        cwd,
+        // We are overriding `NODE_ENV` because when it is set to "production"
+        // it causes invalid output of `npm ls` with `--dev=true`
+        env: {
+          ...process.env,
+          NODE_ENV: null,
+        },
+        stdio: ['ignore', outputFile.fd, 'ignore'],
+      }
+    );
+  } finally {
+    await outputFile.close();
+  }
+};
 const readFile = (...args) => fsp.readFile(...args);
 
 const excludeNodeDevDependenciesMemoized = memoizee(excludeNodeDevDependencies, {
@@ -215,8 +222,7 @@ async function excludeNodeDevDependencies(serviceDir) {
         ['dev', 'prod'].map(async (env) => {
           const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile;
           try {
-            const { stdoutBuffer } = await npmList(dirWithPackageJson, env);
-            await fsp.appendFile(depFile, stdoutBuffer || '');
+            await npmList(dirWithPackageJson, env, depFile);
           } catch {
             // Invalid package.json or npm ls failures should not crash packaging.
           }

--- a/lib/utils/download-template-from-repo.js
+++ b/lib/utils/download-template-from-repo.js
@@ -302,7 +302,7 @@ async function downloadTemplateFromRepo(inputUrl, requestedServiceName, download
     fse.ensureDirSync(path.dirname(targetDirectoryPath));
 
     if (isPlainGitURL(inputUrl)) {
-      return spawn('git', ['clone', inputUrl, downloadServicePath]).then(() => {
+      return spawn('git', ['clone', '--', inputUrl, downloadServicePath]).then(() => {
         if (shouldRenameService) renameService(effectiveServiceName, targetDirectoryPath);
         return sourceName;
       });

--- a/test/unit/commands/plugin-install.test.js
+++ b/test/unit/commands/plugin-install.test.js
@@ -118,6 +118,33 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
     });
   });
 
+  describe('with invalid plugin name', () => {
+    it('rejects before installing or updating the configuration file', async () => {
+      const fixture = await fixturesEngine.setup('function');
+      const configuration = fixture.serviceConfig;
+      const serviceDir = fixture.servicePath;
+      const configurationFilePath = await resolveConfigurationPath({
+        cwd: serviceDir,
+      });
+      const configurationFilename = configurationFilePath.slice(serviceDir.length + 1);
+      const originalConfigurationText = await fse.readFile(configurationFilePath, 'utf8');
+
+      await expect(
+        installPlugin({
+          configuration,
+          serviceDir,
+          configurationFilename,
+          options: {
+            name: '--prefix=/tmp/x',
+          },
+        })
+      ).to.be.rejected.and.have.property('code', 'INVALID_PLUGIN_NAME');
+
+      expect(spawnFake).to.not.have.been.called;
+      expect(await fse.readFile(configurationFilePath, 'utf8')).to.equal(originalConfigurationText);
+    });
+  });
+
   describe('with intrinsic-tagged yaml', () => {
     it('preserves shorthand intrinsic tags when adding a plugin to array-form yaml', async () => {
       const fixture = await fixturesEngine.setup('function');

--- a/test/unit/commands/plugin-install.test.js
+++ b/test/unit/commands/plugin-install.test.js
@@ -138,7 +138,7 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
             name: '--prefix=/tmp/x',
           },
         })
-      ).to.be.rejected.and.have.property('code', 'INVALID_PLUGIN_NAME');
+      ).to.be.eventually.rejected.and.have.property('code', 'INVALID_PLUGIN_NAME');
 
       expect(spawnFake).to.not.have.been.called;
       expect(await fse.readFile(configurationFilePath, 'utf8')).to.equal(originalConfigurationText);

--- a/test/unit/commands/plugin-uninstall.test.js
+++ b/test/unit/commands/plugin-uninstall.test.js
@@ -84,6 +84,40 @@ describe('test/unit/commands/plugin-uninstall.test.js', async () => {
     expect(serverlessFileObj.plugins).to.be.undefined;
   });
 
+  describe('with invalid plugin name', () => {
+    it('rejects before uninstalling or updating the configuration file', async () => {
+      const fixture = await fixturesEngine.setup('function', {
+        configExt: {
+          plugins: [pluginName],
+        },
+      });
+
+      const configuration = fixture.serviceConfig;
+      const fixtureServiceDir = fixture.servicePath;
+      const fixtureConfigurationPath = await resolveConfigurationPath({
+        cwd: fixtureServiceDir,
+      });
+      const configurationFilename = fixtureConfigurationPath.slice(fixtureServiceDir.length + 1);
+      const originalConfigurationText = await fse.readFile(fixtureConfigurationPath, 'utf8');
+
+      await expect(
+        uninstallPlugin({
+          configuration,
+          serviceDir: fixtureServiceDir,
+          configurationFilename,
+          options: {
+            name: '--prefix=/tmp/x',
+          },
+        })
+      ).to.be.rejected.and.have.property('code', 'INVALID_PLUGIN_NAME');
+
+      expect(spawnFake).to.not.have.been.called;
+      expect(await fse.readFile(fixtureConfigurationPath, 'utf8')).to.equal(
+        originalConfigurationText
+      );
+    });
+  });
+
   describe('with intrinsic-tagged yaml', () => {
     it('preserves shorthand intrinsic tags when removing a plugin from array-form yaml', async () => {
       const fixture = await fixturesEngine.setup('function');

--- a/test/unit/commands/plugin-uninstall.test.js
+++ b/test/unit/commands/plugin-uninstall.test.js
@@ -109,7 +109,7 @@ describe('test/unit/commands/plugin-uninstall.test.js', async () => {
             name: '--prefix=/tmp/x',
           },
         })
-      ).to.be.rejected.and.have.property('code', 'INVALID_PLUGIN_NAME');
+      ).to.be.eventually.rejected.and.have.property('code', 'INVALID_PLUGIN_NAME');
 
       expect(spawnFake).to.not.have.been.called;
       expect(await fse.readFile(fixtureConfigurationPath, 'utf8')).to.equal(

--- a/test/unit/lib/commands/plugin-management.test.js
+++ b/test/unit/lib/commands/plugin-management.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const { expect } = require('chai');
+const { getPluginInfo } = require('../../../../lib/commands/plugin-management');
+
+describe('test/unit/lib/commands/plugin-management.test.js', () => {
+  describe('#getPluginInfo()', () => {
+    const maxLengthName = 'a'.repeat(214);
+    const overLengthName = 'a'.repeat(215);
+    const scopedMaxLengthName = `@${'a'.repeat(100)}/${'b'.repeat(112)}`;
+    const scopedOverLengthName = `@${'a'.repeat(100)}/${'b'.repeat(113)}`;
+
+    for (const [input, expected] of [
+      ['serverless-webpack', { name: 'serverless-webpack', version: undefined }],
+      ['serverless-plugin-foo', { name: 'serverless-plugin-foo', version: undefined }],
+      ['@scope/serverless-plugin', { name: '@scope/serverless-plugin', version: undefined }],
+      ['serverless-plugin@latest', { name: 'serverless-plugin', version: 'latest' }],
+      ['serverless-plugin@1.2.3', { name: 'serverless-plugin', version: '1.2.3' }],
+      ['serverless-plugin@^1.0.0 || 2', { name: 'serverless-plugin', version: '^1.0.0 || 2' }],
+      ['@scope/serverless-plugin@1.2.3', { name: '@scope/serverless-plugin', version: '1.2.3' }],
+      [maxLengthName, { name: maxLengthName, version: undefined }],
+      [`${maxLengthName}@latest`, { name: maxLengthName, version: 'latest' }],
+      [scopedMaxLengthName, { name: scopedMaxLengthName, version: undefined }],
+      [`${scopedMaxLengthName}@1.2.3`, { name: scopedMaxLengthName, version: '1.2.3' }],
+    ]) {
+      it(`parses valid plugin spec "${input}"`, () => {
+        expect(getPluginInfo(input)).to.deep.equal(expected);
+      });
+    }
+
+    for (const input of [
+      '',
+      '@',
+      '@scope',
+      '@scope/',
+      '--prefix=/tmp/x',
+      '-plugin',
+      '.plugin',
+      '_plugin',
+      'serverless plugin',
+      'serverless;id',
+      'serverless|id',
+      'serverless`id`',
+      'serverless$(id)',
+      'serverless\nplugin',
+      '/tmp/plugin',
+      '../plugin',
+      overLengthName,
+      `${overLengthName}@latest`,
+      scopedOverLengthName,
+      `${scopedOverLengthName}@1.2.3`,
+    ]) {
+      it(`rejects invalid plugin spec ${JSON.stringify(input)}`, () => {
+        expect(() => getPluginInfo(input))
+          .to.throw()
+          .with.property('code', 'INVALID_PLUGIN_NAME');
+      });
+    }
+  });
+});

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -994,7 +994,7 @@ describe('AwsInvokeLocal', () => {
             tmpServicePath,
             {}
           )
-        ).to.be.rejected.and.have.property('code', 'JAVA_BRIDGE_BUILD_FAILED');
+        ).to.be.eventually.rejected.and.have.property('code', 'JAVA_BRIDGE_BUILD_FAILED');
 
         expect(callJavaBridgeStub).to.not.have.been.called;
         expect(spawnExtStub.calledOnce).to.be.equal(true);

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -940,6 +940,9 @@ describe('AwsInvokeLocal', () => {
 
     describe('when attempting to build the Java bridge', () => {
       it("if it's not present yet", async () => {
+        fse.removeSync(bridgePath);
+        spawnExtStub.resetHistory();
+
         await awsInvokeLocal.invokeLocalJava(
           'java',
           'com.serverless.Handler',
@@ -965,6 +968,41 @@ describe('AwsInvokeLocal', () => {
             })
           )
         ).to.be.equal(true);
+        expect(spawnExtStub.calledOnce).to.be.equal(true);
+        expect(spawnExtStub.firstCall.args).to.deep.equal([
+          'mvn',
+          ['package', '-f', path.join(path.dirname(bridgePath), 'pom.xml')],
+          { shouldCloseStdin: true },
+        ]);
+      });
+
+      it('rejects if the Java bridge build fails', async () => {
+        fse.removeSync(bridgePath);
+        spawnExtStub.rejects(
+          Object.assign(new Error('mvn failed'), {
+            code: 1,
+            signal: null,
+            stdoutBuffer: Buffer.from('build failed'),
+          })
+        );
+
+        await expect(
+          awsInvokeLocal.invokeLocalJava(
+            'java',
+            'com.serverless.Handler',
+            'handleRequest',
+            tmpServicePath,
+            {}
+          )
+        ).to.be.rejected.and.have.property('code', 'JAVA_BRIDGE_BUILD_FAILED');
+
+        expect(callJavaBridgeStub).to.not.have.been.called;
+        expect(spawnExtStub.calledOnce).to.be.equal(true);
+        expect(spawnExtStub.firstCall.args).to.deep.equal([
+          'mvn',
+          ['package', '-f', path.join(path.dirname(bridgePath), 'pom.xml')],
+          { shouldCloseStdin: true },
+        ]);
       });
     });
   });

--- a/test/unit/lib/plugins/package/lib/zip-service.test.js
+++ b/test/unit/lib/plugins/package/lib/zip-service.test.js
@@ -29,6 +29,9 @@ const expectNpmListCall = (stub, index, envName) => {
     '--all',
   ]);
   expect(call.args[2].cwd).to.match(/.+/);
+  expect(call.args[2].stdio[0]).to.equal('ignore');
+  expect(call.args[2].stdio[1]).to.be.a('number');
+  expect(call.args[2].stdio[2]).to.equal('ignore');
   expect(call.args[2]).to.not.have.property('shell');
 };
 
@@ -145,21 +148,28 @@ describe('zipService', () => {
 
     describe('when dealing with Node.js runtimes', () => {
       let globSyncStub;
-      let appendFileAsyncStub;
+      let closeFileStub;
+      let openFileAsyncStub;
       let readFileAsyncStub;
+      let nextFileDescriptor;
       let serviceDir;
 
       beforeEach(() => {
         serviceDir = packagePlugin.serverless.serviceDir;
+        nextFileDescriptor = 100;
         globSyncStub = sinon.stub(glob, 'sync');
         readFileAsyncStub = sinon.stub(fs.promises, 'readFile');
-        appendFileAsyncStub = sinon.stub(fs.promises, 'appendFile').resolves();
+        closeFileStub = sinon.stub().resolves();
+        openFileAsyncStub = sinon.stub(fs.promises, 'open').callsFake(async () => ({
+          fd: nextFileDescriptor++,
+          close: closeFileStub,
+        }));
       });
 
       afterEach(() => {
         glob.sync.restore();
         fs.promises.readFile.restore();
-        fs.promises.appendFile.restore();
+        fs.promises.open.restore();
       });
 
       it('does not add async helpers to core modules when loaded', () => {
@@ -221,7 +231,8 @@ describe('zipService', () => {
             });
             expectNpmListCall(spawnExtStub, 0, 'dev');
             expectNpmListCall(spawnExtStub, 1, 'prod');
-            expect(appendFileAsyncStub).to.have.been.calledTwice;
+            expect(openFileAsyncStub).to.have.been.calledTwice;
+            expect(closeFileStub).to.have.been.calledTwice;
             expect(updatedParams.exclude).to.deep.equal(['user-defined-exclude-me']);
             expect(updatedParams.include).to.deep.equal(['user-defined-include-me']);
             expect(updatedParams.zipFileName).to.equal(params.zipFileName);
@@ -229,21 +240,32 @@ describe('zipService', () => {
         );
       });
 
-      it('should append npm ls stdout without shell redirection', async () => {
+      it('should stream npm ls stdout to dependency files without shell redirection', async () => {
         const filePaths = ['package.json', 'node_modules'];
 
         globSyncStub.returns(filePaths);
-        resolveSpawnCall(spawnExtStub.onCall(0), 'dev-dependencies');
-        resolveSpawnCall(spawnExtStub.onCall(1), 'prod-dependencies');
+        resolveSpawnCall(spawnExtStub.onCall(0));
+        resolveSpawnCall(spawnExtStub.onCall(1));
         readFileAsyncStub.resolves('');
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(() => {
           expectNpmListCall(spawnExtStub, 0, 'dev');
           expectNpmListCall(spawnExtStub, 1, 'prod');
-          expect(appendFileAsyncStub).to.have.been.calledTwice;
+          expect(openFileAsyncStub).to.have.been.calledTwice;
+          expect(openFileAsyncStub.getCalls().map((call) => call.args[1])).to.deep.equal([
+            'a',
+            'a',
+          ]);
+          const openedFiles = openFileAsyncStub
+            .getCalls()
+            .map((call) => path.basename(call.args[0]));
           expect(
-            appendFileAsyncStub.getCalls().map((call) => call.args[1].toString())
-          ).to.have.members(['dev-dependencies', 'prod-dependencies']);
+            openedFiles.some((fileName) => /^node-dependencies-.+-dev$/.test(fileName))
+          ).to.equal(true);
+          expect(
+            openedFiles.some((fileName) => /^node-dependencies-.+-prod$/.test(fileName))
+          ).to.equal(true);
+          expect(closeFileStub).to.have.been.calledTwice;
         });
       });
 
@@ -274,6 +296,7 @@ describe('zipService', () => {
           (updatedParams) => {
             expect(globSyncStub).to.been.calledOnce;
             expect(spawnExtStub).to.have.been.calledTwice;
+            expect(closeFileStub).to.have.been.calledTwice;
             expect(readFileAsyncStub).to.have.been.calledTwice;
             expect(updatedParams.exclude).to.deep.equal(['user-defined-exclude-me']);
             expect(updatedParams.include).to.deep.equal(['user-defined-include-me']);

--- a/test/unit/lib/plugins/package/lib/zip-service.test.js
+++ b/test/unit/lib/plugins/package/lib/zip-service.test.js
@@ -5,19 +5,35 @@ const path = require('path');
 const JsZip = require('jszip');
 const glob = require('../../../../../../lib/utils/glob');
 const fs = require('fs');
-const childProcess = require('child_process');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const isObject = require('type/object/is');
-const Package = require('../../../../../../lib/plugins/package/package');
 const Serverless = require('../../../../../../lib/serverless');
 const { getTmpDirPath } = require('../../../../../utils/fs');
 
 // Configure chai
 const { expect } = require('chai');
 
-const resolveExecCall = (stub) => stub.callsArgWith(2, null, '', '');
-const rejectExecCall = (stub) => stub.callsArgWith(2, new Error('npm ls failed'));
+const resolveSpawnCall = (stub, output = '') =>
+  stub.resolves({ stdoutBuffer: Buffer.from(output) });
+const rejectSpawnCall = (stub) => stub.rejects(new Error('npm ls failed'));
+const expectNpmListCall = (stub, index, envName) => {
+  const call = stub.getCall(index);
+  expect(call.args[0]).to.equal('npm');
+  expect(call.args[1]).to.deep.equal([
+    'ls',
+    `--${envName}=true`,
+    '--parseable=true',
+    '--long=false',
+    '--silent',
+    '--all',
+  ]);
+  expect(call.args[2].cwd).to.match(/.+/);
+  expect(call.args[2]).to.not.have.property('shell');
+};
+
+let Package;
+let spawnExtStub;
 
 describe('zipService', () => {
   let tmpDirPath;
@@ -27,6 +43,13 @@ describe('zipService', () => {
 
   beforeEach(() => {
     tmpDirPath = getTmpDirPath();
+    spawnExtStub = sinon.stub().resolves({ stdoutBuffer: Buffer.alloc(0) });
+    const zipService = proxyquire('../../../../../../lib/plugins/package/lib/zip-service', {
+      '../../../utils/spawn': spawnExtStub,
+    });
+    Package = proxyquire('../../../../../../lib/plugins/package/package', {
+      './lib/zip-service': zipService,
+    });
     serverless = new Serverless({ commands: [], options: {} });
     serverless.service.service = 'first-service';
     serverless.serviceDir = tmpDirPath;
@@ -122,33 +145,33 @@ describe('zipService', () => {
 
     describe('when dealing with Node.js runtimes', () => {
       let globSyncStub;
-      let execAsyncStub;
+      let appendFileAsyncStub;
       let readFileAsyncStub;
       let serviceDir;
 
       beforeEach(() => {
         serviceDir = packagePlugin.serverless.serviceDir;
         globSyncStub = sinon.stub(glob, 'sync');
-        execAsyncStub = sinon.stub(childProcess, 'exec');
         readFileAsyncStub = sinon.stub(fs.promises, 'readFile');
+        appendFileAsyncStub = sinon.stub(fs.promises, 'appendFile').resolves();
       });
 
       afterEach(() => {
         glob.sync.restore();
-        childProcess.exec.restore();
         fs.promises.readFile.restore();
+        fs.promises.appendFile.restore();
       });
 
       it('does not add async helpers to core modules when loaded', () => {
-        const fakeChildProcess = { exec: () => {} };
         const fakeFs = { promises: { readFile: () => {} } };
+        const fakeSpawn = () => {};
 
         proxyquire.noCallThru().load('../../../../../../lib/plugins/package/lib/zip-service', {
-          child_process: fakeChildProcess,
-          fs: fakeFs,
+          'fs': fakeFs,
+          '../../../utils/spawn': fakeSpawn,
         });
 
-        expect(fakeChildProcess).to.not.have.property('execAsync');
+        expect(fakeSpawn).to.not.have.property('spawnAsync');
         expect(fakeFs).to.not.have.property('readFileAsync');
       });
 
@@ -160,7 +183,7 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           (updatedParams) => {
             expect(globSyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub).to.not.have.been.called;
+            expect(spawnExtStub).to.not.have.been.called;
             expect(readFileAsyncStub).to.not.have.been.called;
             expect(globSyncStub).to.have.been.calledWithExactly(['**/package.json'], {
               cwd: packagePlugin.serverless.serviceDir,
@@ -180,14 +203,14 @@ describe('zipService', () => {
         const filePaths = ['package.json', 'node_modules'];
 
         globSyncStub.returns(filePaths);
-        resolveExecCall(execAsyncStub);
+        resolveSpawnCall(spawnExtStub);
         const depPaths = '';
         readFileAsyncStub.resolves(depPaths);
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           (updatedParams) => {
             expect(globSyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub).to.have.been.calledTwice;
+            expect(spawnExtStub).to.have.been.calledTwice;
             expect(readFileAsyncStub).to.have.been.calledTwice;
             expect(globSyncStub).to.have.been.calledWithExactly(['**/package.json'], {
               cwd: packagePlugin.serverless.serviceDir,
@@ -196,19 +219,32 @@ describe('zipService', () => {
               follow: true,
               nosort: true,
             });
-            expect(execAsyncStub.args[0][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[0][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[1][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
+            expectNpmListCall(spawnExtStub, 0, 'dev');
+            expectNpmListCall(spawnExtStub, 1, 'prod');
+            expect(appendFileAsyncStub).to.have.been.calledTwice;
             expect(updatedParams.exclude).to.deep.equal(['user-defined-exclude-me']);
             expect(updatedParams.include).to.deep.equal(['user-defined-include-me']);
             expect(updatedParams.zipFileName).to.equal(params.zipFileName);
           }
         );
+      });
+
+      it('should append npm ls stdout without shell redirection', async () => {
+        const filePaths = ['package.json', 'node_modules'];
+
+        globSyncStub.returns(filePaths);
+        resolveSpawnCall(spawnExtStub.onCall(0), 'dev-dependencies');
+        resolveSpawnCall(spawnExtStub.onCall(1), 'prod-dependencies');
+        readFileAsyncStub.resolves('');
+
+        return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(() => {
+          expectNpmListCall(spawnExtStub, 0, 'dev');
+          expectNpmListCall(spawnExtStub, 1, 'prod');
+          expect(appendFileAsyncStub).to.have.been.calledTwice;
+          expect(
+            appendFileAsyncStub.getCalls().map((call) => call.args[1].toString())
+          ).to.have.members(['dev-dependencies', 'prod-dependencies']);
+        });
       });
 
       it('should return excludes and includes if an error is thrown in the global scope', () => {
@@ -217,7 +253,7 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           (updatedParams) => {
             expect(globSyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub).to.not.have.been.called;
+            expect(spawnExtStub).to.not.have.been.called;
             expect(readFileAsyncStub).to.not.have.been.called;
             expect(updatedParams.exclude).to.deep.equal(['user-defined-exclude-me']);
             expect(updatedParams.include).to.deep.equal(['user-defined-include-me']);
@@ -226,18 +262,18 @@ describe('zipService', () => {
         );
       });
 
-      it('should return excludes and includes if a exec Promise is rejected', async () => {
+      it('should return excludes and includes if an npm ls spawn is rejected', async () => {
         const filePaths = ['package.json', 'node_modules'];
 
         globSyncStub.returns(filePaths);
-        resolveExecCall(execAsyncStub.onCall(0));
-        rejectExecCall(execAsyncStub.onCall(1));
+        resolveSpawnCall(spawnExtStub.onCall(0));
+        rejectSpawnCall(spawnExtStub.onCall(1));
         readFileAsyncStub.resolves();
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           (updatedParams) => {
             expect(globSyncStub).to.been.calledOnce;
-            expect(execAsyncStub).to.have.been.calledTwice;
+            expect(spawnExtStub).to.have.been.calledTwice;
             expect(readFileAsyncStub).to.have.been.calledTwice;
             expect(updatedParams.exclude).to.deep.equal(['user-defined-exclude-me']);
             expect(updatedParams.include).to.deep.equal(['user-defined-include-me']);
@@ -250,7 +286,7 @@ describe('zipService', () => {
         const filePaths = ['package.json', 'node_modules'];
 
         globSyncStub.returns(filePaths);
-        resolveExecCall(execAsyncStub);
+        resolveSpawnCall(spawnExtStub);
 
         readFileAsyncStub.onCall(0).resolves();
         readFileAsyncStub.onCall(1).rejects();
@@ -258,7 +294,7 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           (updatedParams) => {
             expect(globSyncStub).to.been.calledOnce;
-            expect(execAsyncStub).to.have.been.calledTwice;
+            expect(spawnExtStub).to.have.been.calledTwice;
             expect(readFileAsyncStub).to.have.been.calledTwice;
             expect(updatedParams.exclude).to.deep.equal(['user-defined-exclude-me']);
             expect(updatedParams.include).to.deep.equal(['user-defined-include-me']);
@@ -282,12 +318,12 @@ describe('zipService', () => {
         ];
 
         globSyncStub.returns(filePaths);
-        resolveExecCall(execAsyncStub.onCall(0));
-        resolveExecCall(execAsyncStub.onCall(1));
-        rejectExecCall(execAsyncStub.onCall(2));
-        rejectExecCall(execAsyncStub.onCall(3));
-        resolveExecCall(execAsyncStub.onCall(4));
-        resolveExecCall(execAsyncStub.onCall(5));
+        resolveSpawnCall(spawnExtStub.onCall(0));
+        resolveSpawnCall(spawnExtStub.onCall(1));
+        rejectSpawnCall(spawnExtStub.onCall(2));
+        rejectSpawnCall(spawnExtStub.onCall(3));
+        resolveSpawnCall(spawnExtStub.onCall(4));
+        resolveSpawnCall(spawnExtStub.onCall(5));
         const depPaths = [
           path.join(serviceDir, 'node_modules', 'module-1'),
           path.join(serviceDir, 'node_modules', 'module-2'),
@@ -304,7 +340,7 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           (updatedParams) => {
             expect(globSyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub.callCount).to.equal(6);
+            expect(spawnExtStub.callCount).to.equal(6);
             expect(readFileAsyncStub).to.have.callCount(6);
             expect(readFileAsyncStub).to.have.been.calledWith(
               path.join(serviceDir, 'node_modules', 'module-1', 'package.json')
@@ -325,30 +361,9 @@ describe('zipService', () => {
               follow: true,
               nosort: true,
             });
-            expect(execAsyncStub.args[0][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[0][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[1][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[2][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[2][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[3][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[3][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[4][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[4][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[5][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[5][1].cwd).to.match(/.+/);
+            ['dev', 'prod', 'dev', 'prod', 'dev', 'prod'].forEach((envName, index) => {
+              expectNpmListCall(spawnExtStub, index, envName);
+            });
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
               path.join('node_modules', 'module-1', '**'),
@@ -366,7 +381,7 @@ describe('zipService', () => {
         const filePaths = ['package.json', 'node_modules'];
 
         globSyncStub.returns(filePaths);
-        resolveExecCall(execAsyncStub);
+        resolveSpawnCall(spawnExtStub);
         const depPaths = [
           path.join(serviceDir, 'node_modules', 'module-1'),
           path.join(serviceDir, 'node_modules', 'module-2'),
@@ -379,7 +394,7 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           (updatedParams) => {
             expect(globSyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub).to.have.been.calledTwice;
+            expect(spawnExtStub).to.have.been.calledTwice;
             expect(readFileAsyncStub).to.have.callCount(4);
             expect(readFileAsyncStub).to.have.been.calledWith(
               path.join(serviceDir, 'node_modules', 'module-1', 'package.json')
@@ -394,14 +409,8 @@ describe('zipService', () => {
               follow: true,
               nosort: true,
             });
-            expect(execAsyncStub.args[0][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[0][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[1][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
+            expectNpmListCall(spawnExtStub, 0, 'dev');
+            expectNpmListCall(spawnExtStub, 1, 'prod');
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
               path.join('node_modules', 'module-1', '**'),
@@ -427,7 +436,7 @@ describe('zipService', () => {
         ];
 
         globSyncStub.returns(filePaths);
-        resolveExecCall(execAsyncStub);
+        resolveSpawnCall(spawnExtStub);
         const depPaths = [
           path.join(serviceDir, 'node_modules', 'module-1'),
           path.join(serviceDir, 'node_modules', 'module-2'),
@@ -448,7 +457,7 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           (updatedParams) => {
             expect(globSyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub.callCount).to.equal(6);
+            expect(spawnExtStub.callCount).to.equal(6);
             expect(readFileAsyncStub).to.have.callCount(8);
             expect(globSyncStub).to.have.been.calledWithExactly(['**/package.json'], {
               cwd: packagePlugin.serverless.serviceDir,
@@ -457,30 +466,9 @@ describe('zipService', () => {
               follow: true,
               nosort: true,
             });
-            expect(execAsyncStub.args[0][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[0][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[1][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[2][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[2][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[3][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[3][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[4][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[4][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[5][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[5][1].cwd).to.match(/.+/);
+            ['dev', 'prod', 'dev', 'prod', 'dev', 'prod'].forEach((envName, index) => {
+              expectNpmListCall(spawnExtStub, index, envName);
+            });
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
               path.join('node_modules', 'module-1', '**'),
@@ -500,7 +488,7 @@ describe('zipService', () => {
         const filePaths = ['package.json', 'node_modules'];
 
         globSyncStub.returns(filePaths);
-        resolveExecCall(execAsyncStub);
+        resolveSpawnCall(spawnExtStub);
 
         const devDepPaths = [
           path.join(serviceDir, 'node_modules', 'module-1'),
@@ -515,7 +503,7 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           (updatedParams) => {
             expect(globSyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub).to.have.been.calledTwice;
+            expect(spawnExtStub).to.have.been.calledTwice;
             expect(readFileAsyncStub).to.have.been.calledThrice;
             expect(readFileAsyncStub).to.have.been.calledWith(
               path.join(serviceDir, 'node_modules', 'module-1', 'package.json')
@@ -527,14 +515,8 @@ describe('zipService', () => {
               follow: true,
               nosort: true,
             });
-            expect(execAsyncStub.args[0][0]).to.match(
-              /npm ls --dev=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[0][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[1][0]).to.match(
-              /npm ls --prod=true --parseable=true --long=false --silent --all >> .+/
-            );
-            expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
+            expectNpmListCall(spawnExtStub, 0, 'dev');
+            expectNpmListCall(spawnExtStub, 1, 'prod');
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
               path.join('node_modules', 'module-1', '**'),
@@ -558,7 +540,7 @@ describe('zipService', () => {
         const filePaths = ['node_modules/', 'package.json'].concat(devPaths).concat(prodPaths);
 
         globSyncStub.returns(filePaths);
-        resolveExecCall(execAsyncStub);
+        resolveSpawnCall(spawnExtStub);
 
         const mapper = (depPath) => path.join(`${serviceDir}`, depPath);
 
@@ -580,7 +562,7 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           (updatedParams) => {
             expect(globSyncStub).to.been.calledOnce;
-            expect(execAsyncStub).to.have.been.calledTwice;
+            expect(spawnExtStub).to.have.been.calledTwice;
 
             expect(readFileAsyncStub).to.have.callCount(5);
             expect(readFileAsyncStub).to.have.been.calledWith(
@@ -620,7 +602,7 @@ describe('zipService', () => {
         ];
 
         globSyncStub.returns(filePaths);
-        resolveExecCall(execAsyncStub);
+        resolveSpawnCall(spawnExtStub);
         const deps = [
           'node_modules/module-1',
           'node_modules/module-2',
@@ -654,7 +636,7 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           (updatedParams) => {
             expect(globSyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub.callCount).to.equal(6);
+            expect(spawnExtStub.callCount).to.equal(6);
             expect(readFileAsyncStub).to.have.callCount(8);
             for (const depPath of deps) {
               expect(readFileAsyncStub).to.have.been.calledWith(

--- a/test/unit/lib/utils/download-template-from-repo.test.js
+++ b/test/unit/lib/utils/download-template-from-repo.test.js
@@ -130,7 +130,8 @@ describe('downloadTemplateFromRepo', () => {
         expect(downloadStub.calledOnce).to.equal(false);
         expect(spawnStub.args[0][0]).to.equal('git');
         expect(spawnStub.args[0][1][0]).to.equal('clone');
-        expect(spawnStub.args[0][1][1]).to.equal(url);
+        expect(spawnStub.args[0][1][1]).to.equal('--');
+        expect(spawnStub.args[0][1][2]).to.equal(url);
       });
     });
 
@@ -151,7 +152,8 @@ describe('downloadTemplateFromRepo', () => {
         expect(downloadStub.calledOnce).to.equal(false);
         expect(spawnStub.args[0][0]).to.equal('git');
         expect(spawnStub.args[0][1][0]).to.equal('clone');
-        expect(spawnStub.args[0][1][1]).to.equal(url);
+        expect(spawnStub.args[0][1][1]).to.equal('--');
+        expect(spawnStub.args[0][1][2]).to.equal(url);
         const yml = readFileSync(path.join(newServicePath, 'serverless.yml'));
         expect(yml.service).to.equal(name);
         expect(serviceName).to.equal('sample-service');
@@ -166,7 +168,8 @@ describe('downloadTemplateFromRepo', () => {
         expect(downloadStub.calledOnce).to.equal(false);
         expect(spawnStub.args[0][0]).to.equal('git');
         expect(spawnStub.args[0][1][0]).to.equal('clone');
-        expect(spawnStub.args[0][1][1]).to.equal(url);
+        expect(spawnStub.args[0][1][1]).to.equal('--');
+        expect(spawnStub.args[0][1][2]).to.equal(url);
       });
     });
 
@@ -187,7 +190,8 @@ describe('downloadTemplateFromRepo', () => {
         expect(downloadStub.calledOnce).to.equal(false);
         expect(spawnStub.args[0][0]).to.equal('git');
         expect(spawnStub.args[0][1][0]).to.equal('clone');
-        expect(spawnStub.args[0][1][1]).to.equal(url);
+        expect(spawnStub.args[0][1][1]).to.equal('--');
+        expect(spawnStub.args[0][1][2]).to.equal(url);
         const yml = readFileSync(path.join(newServicePath, 'serverless.yml'));
         expect(yml.service).to.equal(name);
         expect(serviceName).to.equal('sample-service');


### PR DESCRIPTION
- Validate plugin package names before plugin install/uninstall, including npm's 214-character package name limit.
- Replace Maven bridge and package dependency shell usage with argv-based spawning.
- Add `--` to plain `git clone` template downloads to harden argument handling.