### PR TITLE
Fix plugin command resolution after schema reload

### DIFF
--- a/lib/classes/cli.js
+++ b/lib/classes/cli.js
@@ -2,7 +2,6 @@
 
 const { stdoutColors, stderrColors } = require('../utils/colors');
 const { log } = require('../utils/serverless-utils/log');
-const resolveCliInput = require('../cli/resolve-input');
 const renderHelp = require('../cli/render-help');
 
 const legacyPluginLog = log.get('plugin-legacy');
@@ -40,8 +39,8 @@ class CLI {
   }
 
   displayHelp() {
-    if (!resolveCliInput().isHelpRequest) return false;
-    renderHelp(this.serverless.pluginManager.externalPlugins);
+    if (!this.serverless.processedInput.isHelpRequest) return false;
+    renderHelp(this.serverless.pluginManager.externalPlugins, this.serverless.processedInput);
     return true;
   }
 

--- a/lib/classes/plugin-manager.js
+++ b/lib/classes/plugin-manager.js
@@ -208,6 +208,7 @@ class PluginManager {
         // Plugin not installed
         if (
           this.serverless.processedInput.isHelpRequest ||
+          this.cliOptions.help ||
           this.pluginIndependentCommands.has(this.cliCommands[0])
         ) {
           // User may intend to install plugins just listed in serverless config

--- a/lib/classes/plugin-manager.js
+++ b/lib/classes/plugin-manager.js
@@ -4,7 +4,6 @@ const path = require('path');
 const isObject = require('type/object/is');
 const ServerlessError = require('../serverless-error');
 const mergePlainObjects = require('../utils/merge-plain-objects');
-const resolveCliInput = require('../cli/resolve-input');
 const renderCommandHelp = require('../cli/render-help/command');
 const tokenizeException = require('../utils/tokenize-exception');
 const getRequire = require('../utils/get-require');
@@ -208,7 +207,7 @@ class PluginManager {
 
         // Plugin not installed
         if (
-          resolveCliInput().isHelpRequest ||
+          this.serverless.processedInput.isHelpRequest ||
           this.pluginIndependentCommands.has(this.cliCommands[0])
         ) {
           // User may intend to install plugins just listed in serverless config
@@ -544,7 +543,7 @@ class PluginManager {
   async invoke(commandsArray, allowEntryPoints) {
     const command = this.getCommand(commandsArray, allowEntryPoints);
     if (command.type === 'container') {
-      renderCommandHelp(commandsArray.join(' '));
+      renderCommandHelp(commandsArray.join(' '), this.serverless.processedInput);
       return;
     }
 
@@ -600,7 +599,7 @@ class PluginManager {
    */
   async run(commandsArray) {
     this.commandRunStartTime = Date.now();
-    if (resolveCliInput().commands[0] !== 'plugin') {
+    if (commandsArray[0] !== 'plugin') {
       // first initialize hooks
       for (const { hook } of this.hooks.initialize || []) await hook();
     }

--- a/lib/classes/service.js
+++ b/lib/classes/service.js
@@ -8,7 +8,6 @@ const isPlainObject = require('type/plain-object/is');
 const mergePlainObjects = require('../utils/merge-plain-objects');
 const { hasOwn } = require('../utils/safe-object');
 const { log } = require('../utils/serverless-utils/log');
-const resolveCliInput = require('../cli/resolve-input');
 // const currentVersion = require('../../package').version;
 // const isLocallyInstalled = require('../cli/is-locally-installed');
 
@@ -50,7 +49,7 @@ class Service {
     try {
       this.loadServiceFileParam();
     } catch (error) {
-      if (resolveCliInput().isHelpRequest) return;
+      if (this.serverless.processedInput.isHelpRequest) return;
       throw error;
     }
   }

--- a/lib/cli/ensure-supported-command.js
+++ b/lib/cli/ensure-supported-command.js
@@ -23,9 +23,9 @@ const getCommandSuggestion = (command, commandsSchema) => {
   return ` Did you mean "${suggestion}"?`;
 };
 
-module.exports = (configuration = null) => {
+module.exports = (configuration = null, resolvedInput = resolveInput()) => {
   const { command, options, commandSchema, commandsSchema, isContainerCommand, isHelpRequest } =
-    resolveInput();
+    resolvedInput;
 
   if (!commandSchema && !isContainerCommand) {
     throw new ServerlessError(

--- a/lib/cli/render-help/command.js
+++ b/lib/cli/render-help/command.js
@@ -6,8 +6,8 @@ const renderOptionsHelp = require('./options');
 
 const generateCommandUsage = require('./generate-command-usage');
 
-module.exports = (commandName) => {
-  const { commandsSchema } = resolveInput();
+module.exports = (commandName, resolvedInput = resolveInput()) => {
+  const { commandsSchema } = resolvedInput;
   const commandSchema = commandsSchema.get(commandName);
 
   if (commandSchema) {

--- a/lib/cli/render-help/general.js
+++ b/lib/cli/render-help/general.js
@@ -7,8 +7,8 @@ const resolveInput = require('../resolve-input');
 const generateCommandUsage = require('./generate-command-usage');
 const renderOptions = require('./options');
 
-module.exports = (loadedPlugins) => {
-  const { commandsSchema } = resolveInput();
+module.exports = (loadedPlugins, resolvedInput = resolveInput()) => {
+  const { commandsSchema } = resolvedInput;
 
   writeText(
     `Serverless Framework v${version}`,

--- a/lib/cli/render-help/index.js
+++ b/lib/cli/render-help/index.js
@@ -4,13 +4,13 @@ const resolveInput = require('../resolve-input');
 const renderGeneralHelp = require('./general');
 const renderCommandHelp = require('./command');
 
-module.exports = (loadedPlugins) => {
-  const { command } = resolveInput();
+module.exports = (loadedPlugins, resolvedInput = resolveInput()) => {
+  const { command } = resolvedInput;
   if (!command) {
-    renderGeneralHelp(loadedPlugins);
+    renderGeneralHelp(loadedPlugins, resolvedInput);
   } else if (command === 'help') {
-    renderGeneralHelp(loadedPlugins);
+    renderGeneralHelp(loadedPlugins, resolvedInput);
   } else {
-    renderCommandHelp(command);
+    renderCommandHelp(command, resolvedInput);
   }
 };

--- a/lib/cli/resolve-input.js
+++ b/lib/cli/resolve-input.js
@@ -7,6 +7,8 @@ const parseArgs = require('./parse-args');
 
 const isParamName = RegExp.prototype.test.bind(require('./param-reg-exp'));
 
+let cachedResult;
+
 const resolveArgsSchema = (commandOptionsSchema) => {
   const options = { boolean: new Set(), string: new Set(), alias: new Map(), multiple: new Set() };
   for (const [name, optionSchema] of Object.entries(commandOptionsSchema)) {
@@ -27,11 +29,12 @@ const resolveArgsSchema = (commandOptionsSchema) => {
   return options;
 };
 
-const resolveInput = (
-  commandsSchema = require('./commands-schema'),
-  argv = process.argv.slice(2)
-) => {
-  commandsSchema = ensureMap(commandsSchema);
+const resolveInput = function (commandsSchema, argv = process.argv.slice(2)) {
+  if (arguments.length === 0 && cachedResult !== undefined) return cachedResult;
+
+  commandsSchema = ensureMap(
+    commandsSchema === undefined ? require('./commands-schema') : commandsSchema
+  );
   const firstParamIndex = argv.findIndex(isParamName);
 
   const commands = argv.slice(0, firstParamIndex === -1 ? Infinity : firstParamIndex);
@@ -50,7 +53,6 @@ const resolveInput = (
     );
     if (result.isContainerCommand) {
       result.isHelpRequest = true;
-      return result;
     }
   }
 
@@ -58,9 +60,12 @@ const resolveInput = (
     result.isHelpRequest = true;
   }
 
+  cachedResult = result;
   return result;
 };
 
-resolveInput.clear = () => {};
+resolveInput.clear = () => {
+  cachedResult = undefined;
+};
 
 module.exports = resolveInput;

--- a/lib/configuration/resolve-provider-name.js
+++ b/lib/configuration/resolve-provider-name.js
@@ -5,7 +5,10 @@ const isObject = require('type/object/is');
 const ServerlessError = require('../serverless-error');
 const resolveCliInput = require('../cli/resolve-input');
 
-module.exports = (configuration) => {
+module.exports = (configuration, options = {}) => {
+  if (!options) options = {};
+  const isHelpRequest =
+    options.isHelpRequest == null ? resolveCliInput().isHelpRequest : options.isHelpRequest;
   try {
     return ensureString(
       isObject(configuration.provider) ? configuration.provider.name : configuration.provider,
@@ -16,7 +19,7 @@ module.exports = (configuration) => {
       }
     );
   } catch (error) {
-    if (resolveCliInput().isHelpRequest) return null;
+    if (isHelpRequest) return null;
     throw error;
   }
 };

--- a/lib/configuration/variables/eventually-report-resolution-errors.js
+++ b/lib/configuration/variables/eventually-report-resolution-errors.js
@@ -5,14 +5,17 @@ const { log } = require('../../utils/serverless-utils/log');
 const ServerlessError = require('../../serverless-error');
 const resolveCliInput = require('../../cli/resolve-input');
 
-module.exports = (configurationPath, configuration, variablesMeta) => {
+module.exports = (configurationPath, configuration, variablesMeta, options = {}) => {
+  if (!options) options = {};
+  const isHelpRequest =
+    options.isHelpRequest == null ? resolveCliInput().isHelpRequest : options.isHelpRequest;
   const resolutionErrors = new Set(
     Array.from(variablesMeta.values(), ({ error }) => error).filter(Boolean)
   );
 
   if (!resolutionErrors.size) return false;
 
-  if (resolveCliInput().isHelpRequest) {
+  if (isHelpRequest) {
     log.warning(
       'Resolution of service configuration failed when resolving variables: ' +
         `${Array.from(resolutionErrors, (error) => `\n  - ${error.message}`)}\n`

--- a/lib/plugins/config.js
+++ b/lib/plugins/config.js
@@ -47,7 +47,10 @@ class Config {
   }
 
   async updateConfig() {
-    renderCommandHelp(this.serverless.processedInput.commands.join(' '));
+    renderCommandHelp(
+      this.serverless.processedInput.commands.join(' '),
+      this.serverless.processedInput
+    );
   }
 }
 

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -37,7 +37,6 @@ const isStandaloneExecutable = require('./utils/is-standalone-executable');
 const { setByPath } = require('./utils/object-path');
 const logDeprecation = require('./utils/log-deprecation');
 const commmandsSchema = require('./cli/commands-schema');
-const resolveCliInput = require('./cli/resolve-input');
 const parseEntries = require('./configuration/variables/resolve-meta').parseEntries;
 
 // Old local fallback is triggered in older versions by Serverless constructor directly
@@ -102,7 +101,15 @@ class Serverless {
     // Ensure that original `options` are not mutated, can be removed after addressing:
     // https://github.com/serverless/serverless/issues/2582
     const cliOptions = { ...ensurePlainObject(config.options) };
-    this.processedInput = { commands, options: cliOptions };
+    this.processedInput = {
+      command: config.command || commands.join(' '),
+      commands,
+      options: cliOptions,
+      commandSchema: config.commandSchema,
+      commandsSchema: config.commandsSchema || commmandsSchema,
+      isContainerCommand: Boolean(config.isContainerCommand),
+      isHelpRequest: Boolean(config.isHelpRequest),
+    };
 
     this.providers = {};
 
@@ -172,7 +179,7 @@ class Serverless {
     // Some plugins acccess `options` through `this.variables`
     this.variables.options = this.pluginManager.cliOptions;
 
-    if (resolveCliInput().commands[0] !== 'plugin') {
+    if (this.processedInput.commands[0] !== 'plugin') {
       // merge arrays after variables have been populated
       // (https://github.com/serverless/serverless/issues/3511)
       this.service.mergeArrays();

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -104,11 +104,18 @@ process.once('uncaughtException', (error) => {
     const resolveInput = require('../lib/cli/resolve-input');
 
     let commands;
+    let cliInput;
+    const setCliInput = (resolvedInput) => {
+      cliInput = {
+        ...resolvedInput,
+        isContainerCommand: Boolean(resolvedInput.isContainerCommand),
+        isHelpRequest: Boolean(resolvedInput.isHelpRequest),
+      };
+      ({ command, commands, options, isHelpRequest, commandSchema } = cliInput);
+    };
     processLog.debug('resolve CLI input (no service schema)');
     // Parse args against schemas of commands which do not require to be run in service context
-    ({ command, commands, options, isHelpRequest, commandSchema } = resolveInput(
-      require('../lib/cli/commands-schema/no-service')
-    ));
+    setCliInput(resolveInput(require('../lib/cli/commands-schema/no-service')));
 
     // If version number request, show it and abort
     if (options.version) {
@@ -132,6 +139,7 @@ process.once('uncaughtException', (error) => {
     const { randomUUID } = require('node:crypto');
     const clear = require('ext/object/clear');
     const Serverless = require('../lib/serverless');
+    const { safeShallowAssign } = require('../lib/utils/safe-object');
     const resolveVariables = require('../lib/configuration/variables/resolve');
     const isPropertyResolved = require('../lib/configuration/variables/is-property-resolved');
     const eventuallyReportVariableResolutionErrors = require('../lib/configuration/variables/eventually-report-resolution-errors');
@@ -155,6 +163,17 @@ process.once('uncaughtException', (error) => {
         'INACCESSIBLE_CONFIGURATION_PROPERTY'
       );
     };
+    const eventuallyReportVariableResolutionErrorsForCliInput = (
+      serviceConfigurationPath,
+      serviceConfiguration,
+      serviceVariablesMeta
+    ) =>
+      eventuallyReportVariableResolutionErrors(
+        serviceConfigurationPath,
+        serviceConfiguration,
+        serviceVariablesMeta,
+        { isHelpRequest }
+      );
 
     if (!commandSchema || commandSchema.serviceDependencyMode) {
       // Command is potentially service specific, follow up with resolution of service config
@@ -163,17 +182,17 @@ process.once('uncaughtException', (error) => {
       // as they may influence configuration resolution
       processLog.debug('resolve CLI input (service schema)');
       resolveInput.clear();
-      ({ command, commands, options, isHelpRequest, commandSchema } = resolveInput(
-        require('../lib/cli/commands-schema/service')
-      ));
+      setCliInput(resolveInput(require('../lib/cli/commands-schema/service')));
 
       processLog.debug('resolve eventual service configuration');
       const resolveConfigurationPath = require('../lib/cli/resolve-configuration-path');
       const readConfiguration = require('../lib/configuration/read');
       const resolveProviderName = require('../lib/configuration/resolve-provider-name');
+      const resolveProviderNameForCliInput = (serviceConfiguration) =>
+        resolveProviderName(serviceConfiguration, { isHelpRequest });
 
       // Resolve eventual service configuration path
-      configurationPath = await resolveConfigurationPath();
+      configurationPath = await resolveConfigurationPath({ options: { ...options } });
       if (configurationPath) {
         processLog.debug('service configuration found at %s', configurationPath);
       } else processLog.debug('no service configuration found');
@@ -205,7 +224,7 @@ process.once('uncaughtException', (error) => {
           variablesMeta = resolveVariablesMeta(configuration);
 
           if (
-            eventuallyReportVariableResolutionErrors(
+            eventuallyReportVariableResolutionErrorsForCliInput(
               configurationPath,
               configuration,
               variablesMeta
@@ -220,7 +239,7 @@ process.once('uncaughtException', (error) => {
           if (!ensureResolvedProperty('deprecationNotificationMode')) return;
 
           if (isPropertyResolved(variablesMeta, 'provider\0name')) {
-            providerName = resolveProviderName(configuration);
+            providerName = resolveProviderNameForCliInput(configuration);
             if (providerName == null) {
               variablesMeta = null;
               return;
@@ -231,9 +250,7 @@ process.once('uncaughtException', (error) => {
             // parse args again also against schemas commands which require AWS service context
             processLog.debug('resolve CLI input (AWS service schema)');
             resolveInput.clear();
-            ({ command, commands, options, isHelpRequest, commandSchema } = resolveInput(
-              require('../lib/cli/commands-schema/aws-service')
-            ));
+            setCliInput(resolveInput(require('../lib/cli/commands-schema/aws-service')));
           }
 
           let envVarNamesNeededForDotenvResolution;
@@ -264,7 +281,7 @@ process.once('uncaughtException', (error) => {
             await resolveVariables(resolverConfiguration);
 
             if (
-              eventuallyReportVariableResolutionErrors(
+              eventuallyReportVariableResolutionErrorsForCliInput(
                 configurationPath,
                 configuration,
                 variablesMeta
@@ -276,7 +293,7 @@ process.once('uncaughtException', (error) => {
             }
 
             if (!providerName && isPropertyResolved(variablesMeta, 'provider\0name')) {
-              providerName = resolveProviderName(configuration);
+              providerName = resolveProviderNameForCliInput(configuration);
               if (providerName == null) {
                 variablesMeta = null;
                 return;
@@ -287,9 +304,7 @@ process.once('uncaughtException', (error) => {
                 // service
                 processLog.debug('resolve CLI input (AWS service schema)');
                 resolveInput.clear();
-                ({ command, commands, options, isHelpRequest, commandSchema } = resolveInput(
-                  require('../lib/cli/commands-schema/aws-service')
-                ));
+                setCliInput(resolveInput(require('../lib/cli/commands-schema/aws-service')));
 
                 if (commandSchema) {
                   processLog.debug('resolve variables in core properties #2');
@@ -299,7 +314,7 @@ process.once('uncaughtException', (error) => {
                   });
                   await resolveVariables(resolverConfiguration);
                   if (
-                    eventuallyReportVariableResolutionErrors(
+                    eventuallyReportVariableResolutionErrorsForCliInput(
                       configurationPath,
                       configuration,
                       variablesMeta
@@ -328,7 +343,7 @@ process.once('uncaughtException', (error) => {
                 propertyPathsToResolve: new Set(['provider\0stage', 'useDotenv']),
               });
               if (
-                eventuallyReportVariableResolutionErrors(
+                eventuallyReportVariableResolutionErrorsForCliInput(
                   configurationPath,
                   configuration,
                   variablesMeta
@@ -371,7 +386,7 @@ process.once('uncaughtException', (error) => {
               processLog.debug('resolve variables in "provider.name"');
               await resolveVariables(resolverConfiguration);
               if (
-                eventuallyReportVariableResolutionErrors(
+                eventuallyReportVariableResolutionErrorsForCliInput(
                   configurationPath,
                   configuration,
                   variablesMeta
@@ -387,7 +402,7 @@ process.once('uncaughtException', (error) => {
 
           if (!providerName) {
             if (!ensureResolvedProperty('provider\0name')) return;
-            providerName = resolveProviderName(configuration);
+            providerName = resolveProviderNameForCliInput(configuration);
             if (providerName == null) {
               variablesMeta = null;
               return;
@@ -395,9 +410,7 @@ process.once('uncaughtException', (error) => {
             if (!commandSchema && providerName === 'aws') {
               processLog.debug('resolve CLI input (AWS service schema)');
               resolveInput.clear();
-              ({ command, commands, options, isHelpRequest, commandSchema } = resolveInput(
-                require('../lib/cli/commands-schema/aws-service')
-              ));
+              setCliInput(resolveInput(require('../lib/cli/commands-schema/aws-service')));
               if (commandSchema) {
                 resolverConfiguration.options = filterSupportedOptions(options, {
                   commandSchema,
@@ -419,7 +432,7 @@ process.once('uncaughtException', (error) => {
 
           await resolveVariables(resolverConfiguration);
           if (
-            eventuallyReportVariableResolutionErrors(
+            eventuallyReportVariableResolutionErrorsForCliInput(
               configurationPath,
               configuration,
               variablesMeta
@@ -446,27 +459,23 @@ process.once('uncaughtException', (error) => {
 
         // Ensure to have full AWS commands schema loaded if we're in context of AWS provider
         // It's not the case if not AWS service specific command was resolved
-        if (configuration && resolveProviderName(configuration) === 'aws') {
+        if (configuration && resolveProviderNameForCliInput(configuration) === 'aws') {
           processLog.debug('resolve CLI input (AWS service schema)');
           resolveInput.clear();
-          ({ command, commands, options, isHelpRequest, commandSchema } = resolveInput(
-            require('../lib/cli/commands-schema/aws-service')
-          ));
+          setCliInput(resolveInput(require('../lib/cli/commands-schema/aws-service')));
         }
       } else {
         // In non-service context we recognize all AWS service commands
         processLog.debug('parsing of configuration file failed');
         processLog.debug('resolve CLI input (AWS service schema)');
         resolveInput.clear();
-        ({ command, commands, options, isHelpRequest, commandSchema } = resolveInput(
-          require('../lib/cli/commands-schema/aws-service')
-        ));
+        setCliInput(resolveInput(require('../lib/cli/commands-schema/aws-service')));
 
         // Validate result command and options
-        require('../lib/cli/ensure-supported-command')();
+        require('../lib/cli/ensure-supported-command')(null, cliInput);
       }
     } else {
-      require('../lib/cli/ensure-supported-command')();
+      require('../lib/cli/ensure-supported-command')(null, cliInput);
     }
 
     const configurationFilename = configuration && configurationPath.slice(serviceDir.length + 1);
@@ -479,7 +488,7 @@ process.once('uncaughtException', (error) => {
     if (!isHelpRequest) {
       if (isStandaloneCommand) {
         processLog.debug('run standalone command');
-        if (configuration) require('../lib/cli/ensure-supported-command')(configuration);
+        if (configuration) require('../lib/cli/ensure-supported-command')(configuration, cliInput);
         await require(`../commands/${commands.join('-')}`)({
           configuration,
           serviceDir,
@@ -496,8 +505,7 @@ process.once('uncaughtException', (error) => {
       configuration,
       serviceDir,
       configurationFilename,
-      commands,
-      options,
+      ...cliInput,
       variablesMeta,
     });
 
@@ -522,11 +530,7 @@ process.once('uncaughtException', (error) => {
               { providerName: providerName || 'aws', configuration }
             );
             resolveInput.clear();
-            ({ command, commands, options, isHelpRequest, commandSchema } =
-              resolveInput(commandsSchema));
-            serverless.processedInput.commands = serverless.pluginManager.cliCommands = commands;
-            serverless.processedInput.options = options;
-            Object.assign(clear(serverless.pluginManager.cliOptions), options);
+            setCliInput(resolveInput(commandsSchema));
             hasFinalCommandSchema = true;
           }
         }
@@ -534,14 +538,17 @@ process.once('uncaughtException', (error) => {
           // Invalid configuration, ensure to recognize all AWS commands
           processLog.debug('resolve CLI input (AWS service schema)');
           resolveInput.clear();
-          ({ command, commands, options, isHelpRequest, commandSchema } = resolveInput(
-            require('../lib/cli/commands-schema/aws-service')
-          ));
+          setCliInput(resolveInput(require('../lib/cli/commands-schema/aws-service')));
         }
         hasFinalCommandSchema = true;
 
+        Object.assign(serverless.processedInput, cliInput);
+        serverless.pluginManager.cliCommands = commands;
+        safeShallowAssign(clear(serverless.pluginManager.cliOptions), options);
+
         // Validate result command and options
-        if (hasFinalCommandSchema) require('../lib/cli/ensure-supported-command')(configuration);
+        if (hasFinalCommandSchema)
+          require('../lib/cli/ensure-supported-command')(configuration, cliInput);
         if (isHelpRequest) return;
         if (!(variablesMeta && variablesMeta.size)) return;
         if (!resolverConfiguration) {
@@ -595,7 +602,7 @@ process.once('uncaughtException', (error) => {
           await resolveVariables(resolverConfiguration);
           if (!variablesMeta.size) return;
           if (
-            eventuallyReportVariableResolutionErrors(
+            eventuallyReportVariableResolutionErrorsForCliInput(
               configurationPath,
               configuration,
               variablesMeta
@@ -644,7 +651,11 @@ process.once('uncaughtException', (error) => {
         await resolveVariables(resolverConfiguration);
         if (!variablesMeta.size) return;
         if (
-          eventuallyReportVariableResolutionErrors(configurationPath, configuration, variablesMeta)
+          eventuallyReportVariableResolutionErrorsForCliInput(
+            configurationPath,
+            configuration,
+            variablesMeta
+          )
         ) {
           return;
         }
@@ -671,7 +682,7 @@ process.once('uncaughtException', (error) => {
       if (isHelpRequest && serverless.pluginManager.externalPlugins) {
         // Show help
         processLog.debug('render help');
-        require('../lib/cli/render-help')(serverless.pluginManager.externalPlugins);
+        require('../lib/cli/render-help')(serverless.pluginManager.externalPlugins, cliInput);
       } else {
         processLog.debug('run Serverless instance');
         // Run command

--- a/test/fixtures/programmatic/plugin/plugin.js
+++ b/test/fixtures/programmatic/plugin/plugin.js
@@ -9,6 +9,21 @@ module.exports = class TestPlugin {
       customCommand: {
         usage: 'Description of custom command',
         configDependent: false,
+        lifecycleEvents: ['run'],
+        options: {
+          pluginOption: {
+            usage: 'Plugin option',
+            type: 'string',
+          },
+        },
+      },
+    };
+
+    this.hooks = {
+      'customCommand:run': () => {
+        this.utils.writeText(
+          `customCommand invoked${this.options.pluginOption ? ` ${this.options.pluginOption}` : ''}`
+        );
       },
     };
   }

--- a/test/unit/lib/cli/ensure-supported-command.test.js
+++ b/test/unit/lib/cli/ensure-supported-command.test.js
@@ -5,10 +5,19 @@ const overrideArgv = require('process-utils/override-argv');
 const ServerlessError = require('../../../../lib/serverless-error');
 const { triggeredDeprecations } = require('../../../../lib/utils/log-deprecation');
 const ensureSupportedCommand = require('../../../../lib/cli/ensure-supported-command');
+const resolveInput = require('../../../../lib/cli/resolve-input');
 
 describe('test/unit/lib/cli/ensure-supported-command.test.js', () => {
-  it('should do nothing on valid command', async () => {
+  beforeEach(() => {
     triggeredDeprecations.clear();
+    resolveInput.clear();
+  });
+
+  afterEach(() => {
+    resolveInput.clear();
+  });
+
+  it('should do nothing on valid command', async () => {
     overrideArgv(
       {
         args: ['serverless', 'help'],
@@ -18,7 +27,6 @@ describe('test/unit/lib/cli/ensure-supported-command.test.js', () => {
   });
 
   it('should do nothing on container command', async () => {
-    triggeredDeprecations.clear();
     overrideArgv(
       {
         args: ['serverless', 'plugin'],
@@ -28,7 +36,6 @@ describe('test/unit/lib/cli/ensure-supported-command.test.js', () => {
   });
 
   it('should reject invalid command', async () => {
-    triggeredDeprecations.clear();
     overrideArgv(
       {
         args: ['serverless', 'hablo'],
@@ -41,7 +48,6 @@ describe('test/unit/lib/cli/ensure-supported-command.test.js', () => {
   });
 
   it('should report invalid options', async () => {
-    triggeredDeprecations.clear();
     overrideArgv(
       {
         args: ['serverless', 'deploy', '--hadsfa'],
@@ -54,7 +60,6 @@ describe('test/unit/lib/cli/ensure-supported-command.test.js', () => {
   });
 
   it('should reject missing options', async () => {
-    triggeredDeprecations.clear();
     overrideArgv(
       {
         args: ['serverless', 'config', 'credentials'],
@@ -64,5 +69,48 @@ describe('test/unit/lib/cli/ensure-supported-command.test.js', () => {
           .to.throw(ServerlessError)
           .with.property('code', 'MISSING_REQUIRED_CLI_OPTION')
     );
+  });
+
+  it('should accept plugin command from explicit resolved input', () => {
+    const commandsSchema = new Map();
+    commandsSchema.commonOptions = {};
+    commandsSchema.set('customCommand', {
+      usage: 'Description of custom command',
+      serviceDependencyMode: 'required',
+      options: {},
+    });
+
+    const resolvedInput = {
+      command: 'customCommand',
+      commands: ['customCommand'],
+      options: {},
+      commandSchema: commandsSchema.get('customCommand'),
+      commandsSchema,
+    };
+
+    expect(() => ensureSupportedCommand({}, resolvedInput)).to.not.throw();
+  });
+
+  it('should validate plugin command options from explicit resolved input', () => {
+    const commandsSchema = new Map();
+    commandsSchema.commonOptions = {};
+    commandsSchema.set('customCommand', {
+      usage: 'Description of custom command',
+      options: {
+        pluginOption: { type: 'string' },
+      },
+    });
+
+    const resolvedInput = {
+      command: 'customCommand',
+      commands: ['customCommand'],
+      options: { unsupported: true },
+      commandSchema: commandsSchema.get('customCommand'),
+      commandsSchema,
+    };
+
+    expect(() => ensureSupportedCommand({}, resolvedInput))
+      .to.throw(ServerlessError)
+      .with.property('code', 'UNSUPPORTED_CLI_OPTIONS');
   });
 });

--- a/test/unit/lib/cli/render-help/index.test.js
+++ b/test/unit/lib/cli/render-help/index.test.js
@@ -3,10 +3,32 @@
 const { expect } = require('chai');
 const overrideArgv = require('process-utils/override-argv');
 const resolveInput = require('../../../../../lib/cli/resolve-input');
+const resolveFinalCommandsSchema = require('../../../../../lib/cli/commands-schema/resolve-final');
 const renderHelp = require('../../../../../lib/cli/render-help');
 const observeOutput = require('../../../../lib/observe-output');
 
 describe('test/unit/lib/cli/render-help/index.test.js', () => {
+  class TestPlugin {
+    constructor() {
+      this.commands = {
+        customCommand: {
+          usage: 'Description of custom command',
+          lifecycleEvents: ['run'],
+          options: {
+            pluginOption: {
+              usage: 'Plugin option',
+              type: 'string',
+            },
+          },
+        },
+      };
+    }
+  }
+
+  afterEach(() => {
+    resolveInput.clear();
+  });
+
   it('should show general help on main command', async () => {
     resolveInput.clear();
     const output = await overrideArgv(
@@ -52,5 +74,53 @@ describe('test/unit/lib/cli/render-help/index.test.js', () => {
     expect(output.observedOutput).to.have.string(
       output.commandsSchema.get('deploy function').usage
     );
+  });
+
+  it('should include plugin commands in general help from explicit resolved input', async () => {
+    const plugin = new TestPlugin();
+    const loadedPlugins = new Set([plugin]);
+    const commandsSchema = resolveFinalCommandsSchema(loadedPlugins, {
+      providerName: 'aws',
+      configuration: {},
+    });
+
+    const output = await observeOutput(() =>
+      renderHelp(loadedPlugins, {
+        command: '',
+        commands: [],
+        options: { help: true },
+        commandSchema: commandsSchema.get(''),
+        commandsSchema,
+        isHelpRequest: true,
+      })
+    );
+
+    expect(output).to.include('TestPlugin');
+    expect(output).to.include('customCommand');
+    expect(output).to.include('Description of custom command');
+  });
+
+  it('should render plugin command help from explicit resolved input', async () => {
+    const plugin = new TestPlugin();
+    const loadedPlugins = new Set([plugin]);
+    const commandsSchema = resolveFinalCommandsSchema(loadedPlugins, {
+      providerName: 'aws',
+      configuration: {},
+    });
+
+    const output = await observeOutput(() =>
+      renderHelp(loadedPlugins, {
+        command: 'customCommand',
+        commands: ['customCommand'],
+        options: { help: true },
+        commandSchema: commandsSchema.get('customCommand'),
+        commandsSchema,
+        isHelpRequest: true,
+      })
+    );
+
+    expect(output).to.include('customCommand');
+    expect(output).to.include('Description of custom command');
+    expect(output).to.include('pluginOption');
   });
 });

--- a/test/unit/lib/cli/resolve-input.test.js
+++ b/test/unit/lib/cli/resolve-input.test.js
@@ -4,8 +4,13 @@ const { expect } = require('chai');
 const overrideArgv = require('process-utils/override-argv');
 const resolveInput = require('../../../../lib/cli/resolve-input');
 const commandsSchema = require('../../../../lib/cli/commands-schema');
+const resolveFinalCommandsSchema = require('../../../../lib/cli/commands-schema/resolve-final');
 
 describe('test/unit/lib/cli/resolve-input.test.js', () => {
+  afterEach(() => {
+    resolveInput.clear();
+  });
+
   describe('when commands', () => {
     let data;
     before(() => {
@@ -222,6 +227,91 @@ describe('test/unit/lib/cli/resolve-input.test.js', () => {
         options: { env: ['foo=bar', 'bar=baz'] },
         commandsSchema,
       });
+    });
+  });
+
+  describe('cache', () => {
+    it('should return latest explicitly resolved input when later called without arguments', () => {
+      const plugin = {
+        commands: {
+          customCommand: {
+            usage: 'Description of custom command',
+            lifecycleEvents: ['run'],
+            options: {
+              pluginOption: { type: 'string', usage: 'Plugin option' },
+            },
+          },
+        },
+      };
+      const finalCommandsSchema = resolveFinalCommandsSchema(new Set([plugin]), {
+        providerName: 'aws',
+        configuration: {},
+      });
+
+      const resolved = resolveInput(finalCommandsSchema, [
+        'customCommand',
+        '--pluginOption',
+        'value',
+        '--help',
+      ]);
+
+      expect(resolved.command).to.equal('customCommand');
+      expect(resolved.commandSchema).to.equal(finalCommandsSchema.get('customCommand'));
+      expect(resolved.options).to.deep.equal({ pluginOption: 'value', help: true });
+      expect(resolved.isHelpRequest).to.equal(true);
+      expect(resolveInput()).to.equal(resolved);
+    });
+
+    it('should let final plugin schema overwrite an earlier non-plugin parse', () => {
+      const noServiceCommandsSchema = require('../../../../lib/cli/commands-schema/no-service');
+      const finalCommandsSchema = resolveFinalCommandsSchema(
+        new Set([
+          {
+            commands: {
+              customCommand: {
+                usage: 'Description of custom command',
+                lifecycleEvents: ['run'],
+                options: {},
+              },
+            },
+          },
+        ]),
+        { providerName: 'aws', configuration: {} }
+      );
+
+      const early = resolveInput(noServiceCommandsSchema, ['customCommand', '--help']);
+      expect(early.commandSchema).to.equal(undefined);
+
+      const final = resolveInput(finalCommandsSchema, ['customCommand', '--help']);
+      expect(final.commandSchema).to.equal(finalCommandsSchema.get('customCommand'));
+      expect(resolveInput()).to.equal(final);
+    });
+
+    it('should clear cached resolved input', () => {
+      const finalCommandsSchema = resolveFinalCommandsSchema(
+        new Set([
+          {
+            commands: {
+              customCommand: {
+                usage: 'Description of custom command',
+                lifecycleEvents: ['run'],
+                options: {},
+              },
+            },
+          },
+        ]),
+        { providerName: 'aws', configuration: {} }
+      );
+
+      const final = resolveInput(finalCommandsSchema, ['customCommand']);
+      expect(resolveInput()).to.equal(final);
+
+      resolveInput.clear();
+
+      const fallback = overrideArgv({ args: ['serverless', '--help'] }, () => resolveInput());
+
+      expect(fallback).to.not.equal(final);
+      expect(fallback.commandsSchema).to.equal(commandsSchema);
     });
   });
 });

--- a/test/unit/scripts/serverless.test.js
+++ b/test/unit/scripts/serverless.test.js
@@ -278,6 +278,74 @@ describe('test/unit/scripts/serverless.test.js', () => {
     expect(output).to.include('stage');
   });
 
+  it('should include plugin commands in service help output', async () => {
+    const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('plugin');
+
+    const output = stripAnsi(
+      String(
+        (
+          await spawn('node', [serverlessPath, '--help'], {
+            cwd: serviceDir,
+          })
+        ).stdoutBuffer
+      )
+    );
+
+    expect(output).to.include('TestPlugin');
+    expect(output).to.include('customCommand');
+    expect(output).to.include('Description of custom command');
+  });
+
+  it('should print plugin command help to stdout', async () => {
+    const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('plugin');
+
+    const output = stripAnsi(
+      String(
+        (
+          await spawn('node', [serverlessPath, 'customCommand', '--help'], {
+            cwd: serviceDir,
+          })
+        ).stdoutBuffer
+      )
+    );
+
+    expect(output).to.include('customCommand');
+    expect(output).to.include('Description of custom command');
+    expect(output).to.include('pluginOption');
+  });
+
+  it('should dispatch plugin command', async () => {
+    const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('plugin');
+
+    const output = stripAnsi(
+      String(
+        (
+          await spawn('node', [serverlessPath, 'customCommand'], {
+            cwd: serviceDir,
+          })
+        ).stdoutBuffer
+      )
+    );
+
+    expect(output).to.include('customCommand invoked');
+  });
+
+  it('should parse plugin command options from final plugin schema', async () => {
+    const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('plugin');
+
+    const output = stripAnsi(
+      String(
+        (
+          await spawn('node', [serverlessPath, 'customCommand', '--pluginOption', 'abc'], {
+            cwd: serviceDir,
+          })
+        ).stdoutBuffer
+      )
+    );
+
+    expect(output).to.include('customCommand invoked abc');
+  });
+
   it('should print not integrated command --help to stdout', async () => {
     const output = String(
       (await spawn('node', [serverlessPath, 'plugin', 'install', '--help'])).stdoutBuffer


### PR DESCRIPTION
Restore cached CLI input behavior and thread the final plugin-aware input through validation and help rendering so external plugin commands remain visible and dispatchable.

---

Closes #176.