### PR TITLE
Fix issues with the AWS SDK v3 implementation

### DIFF
--- a/lib/aws/client-factory.js
+++ b/lib/aws/client-factory.js
@@ -15,6 +15,37 @@ const { SSMClient } = require('@aws-sdk/client-ssm');
 const { STSClient } = require('@aws-sdk/client-sts');
 const { Upload } = require('@aws-sdk/lib-storage');
 
+const objectIds = new WeakMap();
+let nextObjectId = 0;
+
+function getObjectId(value) {
+  if (!value || (typeof value !== 'object' && typeof value !== 'function')) return null;
+  if (!objectIds.has(value)) objectIds.set(value, ++nextObjectId);
+  return objectIds.get(value);
+}
+
+function getCredentialsCacheKey(credentials) {
+  if (!credentials) return 'none';
+  if (typeof credentials === 'function') return `provider:${getObjectId(credentials)}`;
+  if (credentials.accessKeyId) {
+    return `static:${credentials.accessKeyId}:${Boolean(credentials.sessionToken)}`;
+  }
+  return `object:${getObjectId(credentials)}`;
+}
+
+function createClientCacheKey(serviceName, config) {
+  return [
+    `service:${serviceName}`,
+    `region:${config.region || ''}`,
+    `accelerate:${Boolean(config.useAccelerateEndpoint)}`,
+    `endpoint:${config.endpoint || ''}`,
+    `maxAttempts:${config.maxAttempts || ''}`,
+    `retryMode:${config.retryMode || ''}`,
+    `credentials:${getCredentialsCacheKey(config.credentials)}`,
+    `requestHandler:${getObjectId(config.requestHandler) || 'none'}`,
+  ].join('|');
+}
+
 // Map service names to their client classes
 const CLIENT_MAP = {
   APIGateway: APIGatewayClient,
@@ -50,11 +81,10 @@ class AWSClientFactory {
       throw new Error(`Unknown AWS service: ${serviceName}`);
     }
 
-    // Create a cache key based on service and config
-    const configKey = JSON.stringify({ serviceName, ...this.baseConfig, ...overrideConfig });
+    const clientConfig = { ...this.baseConfig, ...overrideConfig };
+    const configKey = createClientCacheKey(serviceName, clientConfig);
 
     if (!this.clients.has(configKey)) {
-      const clientConfig = { ...this.baseConfig, ...overrideConfig };
       this.clients.set(configKey, new ClientClass(clientConfig));
     }
 
@@ -82,6 +112,11 @@ class AWSClientFactory {
 
     return client.send(command);
   }
+
+  clear() {
+    this.clients.clear();
+  }
 }
 
 module.exports = AWSClientFactory;
+module.exports.createClientCacheKey = createClientCacheKey;

--- a/lib/aws/commands.js
+++ b/lib/aws/commands.js
@@ -45,6 +45,7 @@ const { GetMetricStatisticsCommand } = require('@aws-sdk/client-cloudwatch');
 // CloudWatch Logs Commands
 const {
   DescribeLogStreamsCommand,
+  DeleteLogGroupCommand,
   FilterLogEventsCommand,
   DeleteSubscriptionFilterCommand,
   DescribeSubscriptionFiltersCommand,
@@ -65,6 +66,7 @@ const {
   GetAuthorizationTokenCommand,
   CreateRepositoryCommand,
   DescribeImagesCommand,
+  PutLifecyclePolicyCommand,
 } = require('@aws-sdk/client-ecr');
 
 // EventBridge Commands
@@ -189,6 +191,7 @@ const COMMAND_MAP = {
 
   CloudWatchLogs: {
     describeLogStreams: DescribeLogStreamsCommand,
+    deleteLogGroup: DeleteLogGroupCommand,
     filterLogEvents: FilterLogEventsCommand,
     deleteSubscriptionFilter: DeleteSubscriptionFilterCommand,
     describeSubscriptionFilters: DescribeSubscriptionFiltersCommand,
@@ -207,6 +210,7 @@ const COMMAND_MAP = {
     getAuthorizationToken: GetAuthorizationTokenCommand,
     createRepository: CreateRepositoryCommand,
     describeImages: DescribeImagesCommand,
+    putLifecyclePolicy: PutLifecyclePolicyCommand,
   },
 
   EventBridge: {
@@ -292,13 +296,17 @@ function getCommand(serviceName, methodName) {
   const serviceCommands = COMMAND_MAP[serviceName];
 
   if (!serviceCommands) {
-    throw new Error(`Unknown AWS service: ${serviceName}`);
+    throw Object.assign(new Error(`Unknown AWS service: ${serviceName}`), {
+      code: 'AWS_SDK_V3_UNKNOWN_SERVICE',
+    });
   }
 
   const CommandClass = serviceCommands[methodName];
 
   if (!CommandClass) {
-    throw new Error(`Unknown method '${methodName}' for service '${serviceName}'`);
+    throw Object.assign(new Error(`Unknown method '${methodName}' for service '${serviceName}'`), {
+      code: 'AWS_SDK_V3_UNKNOWN_METHOD',
+    });
   }
 
   return CommandClass;
@@ -325,5 +333,7 @@ function createCommand(serviceName, methodName, params = {}) {
 }
 
 module.exports = {
+  COMMAND_MAP,
+  getCommand,
   createCommand,
 };

--- a/lib/aws/config.js
+++ b/lib/aws/config.js
@@ -4,6 +4,7 @@ const HttpsProxyAgent = require('https-proxy-agent');
 const url = require('url');
 const https = require('https');
 const fs = require('fs');
+const { NodeHttpHandler } = require('@smithy/node-http-handler');
 
 /**
  * Build AWS SDK v3 client configuration from environment and options
@@ -18,7 +19,7 @@ function buildClientConfig(options = {}) {
   const config = {
     region:
       options.region || process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'us-east-1',
-    maxAttempts: options.maxAttempts || getMaxRetries(),
+    maxAttempts: options.maxAttempts === undefined ? getMaxRetries() : options.maxAttempts,
     retryMode: options.retryMode || 'standard',
   };
 
@@ -30,7 +31,7 @@ function buildClientConfig(options = {}) {
   // Configure HTTP options (proxy, timeout, certificates)
   const httpOptions = buildHttpOptions();
   if (httpOptions) {
-    config.requestHandler = httpOptions;
+    config.requestHandler = new NodeHttpHandler(httpOptions);
   }
 
   return config;
@@ -51,7 +52,6 @@ function getMaxRetries() {
  */
 function buildHttpOptions() {
   const httpOptions = {};
-  let needsCustomAgent = false;
 
   // Configure timeout
   const timeout = process.env.AWS_CLIENT_TIMEOUT || process.env.aws_client_timeout;
@@ -61,29 +61,25 @@ function buildHttpOptions() {
 
   // Configure proxy
   const proxy = getProxyUrl();
-  if (proxy) {
-    httpOptions.httpsAgent = new HttpsProxyAgent(buildProxyOptions(proxy));
-    needsCustomAgent = true;
-  }
+  const proxyOptions = proxy ? buildProxyOptions(proxy) : null;
 
   // Configure custom CA certificates
   const caCerts = getCACertificates();
+  const agentOptions = {};
   if (caCerts.length > 0) {
-    const agentOptions = {
+    Object.assign(agentOptions, {
       rejectUnauthorized: true,
       ca: caCerts,
-    };
-
-    if (proxy) {
-      // Merge with existing proxy agent options
-      Object.assign(httpOptions.httpsAgent.options, agentOptions);
-    } else {
-      httpOptions.httpsAgent = new https.Agent(agentOptions);
-      needsCustomAgent = true;
-    }
+    });
   }
 
-  return needsCustomAgent || httpOptions.requestTimeout ? httpOptions : null;
+  if (proxyOptions) {
+    httpOptions.httpsAgent = new HttpsProxyAgent({ ...proxyOptions, ...agentOptions });
+  } else if (caCerts.length > 0) {
+    httpOptions.httpsAgent = new https.Agent(agentOptions);
+  }
+
+  return httpOptions.httpsAgent || httpOptions.requestTimeout ? httpOptions : null;
 }
 
 /**
@@ -156,5 +152,7 @@ function shouldUseS3Acceleration(method, params) {
 
 module.exports = {
   buildClientConfig,
+  buildHttpOptions,
+  getMaxRetries,
   shouldUseS3Acceleration,
 };

--- a/lib/aws/credentials.js
+++ b/lib/aws/credentials.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const v2CredentialProviders = new WeakMap();
+
+function resolveV2Credentials(credentials) {
+  if (!credentials) return Promise.resolve();
+
+  if (typeof credentials.getPromise === 'function') {
+    return credentials.getPromise();
+  }
+
+  if (typeof credentials.get === 'function') {
+    return new Promise((resolve, reject) => {
+      credentials.get((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+  }
+
+  const shouldRefresh =
+    typeof credentials.needsRefresh !== 'function' || credentials.needsRefresh();
+
+  if (shouldRefresh && typeof credentials.refreshPromise === 'function') {
+    return credentials.refreshPromise();
+  }
+
+  if (shouldRefresh && typeof credentials.refresh === 'function') {
+    return new Promise((resolve, reject) => {
+      credentials.refresh((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+  }
+
+  return Promise.resolve();
+}
+
+function createCredentialsProviderError(message) {
+  return Object.assign(new Error(message), { name: 'CredentialsProviderError' });
+}
+
+function normalizeCredentialIdentity(credentials) {
+  if (!credentials || !credentials.accessKeyId || !credentials.secretAccessKey) {
+    throw createCredentialsProviderError('Could not load credentials from Serverless AWS provider');
+  }
+
+  const result = {
+    accessKeyId: credentials.accessKeyId,
+    secretAccessKey: credentials.secretAccessKey,
+  };
+
+  if (credentials.sessionToken) result.sessionToken = credentials.sessionToken;
+  if (credentials.expireTime) result.expiration = credentials.expireTime;
+
+  return result;
+}
+
+function v2CredentialsToV3Provider(credentials) {
+  if (!credentials) return undefined;
+
+  if (v2CredentialProviders.has(credentials)) return v2CredentialProviders.get(credentials);
+
+  const provider = async () => {
+    await resolveV2Credentials(credentials);
+    return normalizeCredentialIdentity(credentials);
+  };
+
+  v2CredentialProviders.set(credentials, provider);
+  return provider;
+}
+
+function staticCredentialsToV3Provider(credentials) {
+  if (!credentials || !credentials.accessKeyId || !credentials.secretAccessKey) return undefined;
+
+  return {
+    accessKeyId: credentials.accessKeyId,
+    secretAccessKey: credentials.secretAccessKey,
+    sessionToken: credentials.sessionToken,
+  };
+}
+
+function toV3CredentialsProvider(params = {}) {
+  if (params.credentials) return v2CredentialsToV3Provider(params.credentials);
+  return staticCredentialsToV3Provider(params);
+}
+
+module.exports = {
+  toV3CredentialsProvider,
+  v2CredentialsToV3Provider,
+};

--- a/lib/aws/error-utils.js
+++ b/lib/aws/error-utils.js
@@ -1,131 +1,68 @@
 'use strict';
 
-/**
- * Error code mappings from v2 to v3
- * v2 errors used 'code' property, v3 uses 'name' property
- */
-const ERROR_CODE_MAPPINGS = {
-  // CloudFormation errors
-  ValidationError: 'ValidationException',
-  AlreadyExistsException: 'AlreadyExistsException',
-  LimitExceededException: 'LimitExceededException',
-  InsufficientCapabilitiesException: 'InsufficientCapabilitiesException',
+const ServerlessError = require('../serverless-error');
+const colors = require('../utils/colors');
+const credentialsHelpUrl = require('./credentials-help-url');
 
-  // S3 errors
-  NoSuchBucket: 'NoSuchBucket',
-  NoSuchKey: 'NoSuchKey',
-  BucketAlreadyExists: 'BucketAlreadyExists',
-  BucketAlreadyOwnedByYou: 'BucketAlreadyOwnedByYou',
+const normalizerPattern = /(?<!^)([A-Z])/g;
 
-  // Lambda errors
-  ResourceNotFoundException: 'ResourceNotFoundException',
-  ResourceConflictException: 'ResourceConflictException',
-  InvalidParameterValueException: 'InvalidParameterValueException',
-  TooManyRequestsException: 'TooManyRequestsException',
-
-  // IAM errors
-  NoSuchEntity: 'NoSuchEntityException',
-  EntityAlreadyExists: 'EntityAlreadyExistsException',
-  MalformedPolicyDocument: 'MalformedPolicyDocumentException',
-
-  // General AWS errors
-  AccessDenied: 'AccessDeniedException',
-  UnauthorizedOperation: 'UnauthorizedException',
-  Throttling: 'ThrottlingException',
-  RequestExpired: 'RequestExpiredException',
-  CredentialsError: 'CredentialsError',
-  ExpiredTokenException: 'ExpiredTokenException',
+const normalizeErrorCodePostfix = (name) => {
+  return String(name).replace(normalizerPattern, '_$1').toUpperCase();
 };
 
-/**
- * Transform AWS SDK v3 error to be compatible with v2 error handling
- * @param {Error} error - AWS SDK v3 error
- * @returns {Error} Transformed error with v2-compatible properties
- */
-function transformV3Error(error) {
-  if (!error || typeof error !== 'object') {
-    return error;
-  }
+function isCredentialsError(error) {
+  if (!error) return false;
 
-  // If it's already a v2-style error, return as-is
-  if (error.code && !error.name) {
-    return error;
-  }
+  const code = error.code || error.name;
+  const message = error.message || '';
 
-  // Check for credentials errors and transform them to match v2 behavior
-  if (
-    error.name === 'CredentialsProviderError' ||
-    (error.message && error.message.includes('Could not load credentials'))
-  ) {
-    const ServerlessError = require('../serverless-error');
-    const colors = require('../utils/colors');
-    const credentialsHelpUrl = require('./credentials-help-url');
-
-    const errorMessage = [
-      'AWS provider credentials not found.',
-      ' Learn how to set up AWS provider credentials',
-      ` in our docs here: <${colors.green(credentialsHelpUrl)}>`,
-      '.',
-    ].join('');
-
-    throw Object.assign(new ServerlessError(errorMessage, 'AWS_CREDENTIALS_NOT_FOUND'), {
-      providerError: Object.assign({}, error, { retryable: false }),
-    });
-  }
-
-  // Create a new error object with v2-compatible properties
-  const transformedError = new Error(error.message || 'Unknown AWS error');
-
-  // Copy all original properties
-  Object.assign(transformedError, error);
-
-  // Map v3 'name' to v2 'code' for backward compatibility
-  if (error.name && !error.code) {
-    transformedError.code = error.name;
-  }
-
-  // Map some common v3 properties to v2 equivalents
-  if (error.$metadata) {
-    transformedError.statusCode = error.$metadata.httpStatusCode;
-    transformedError.retryable = isRetryableError(error);
-    transformedError.requestId = error.$metadata.requestId;
-    transformedError.cfId = error.$metadata.cfId;
-  }
-
-  // Add providerError for compatibility with existing error handling
-  transformedError.providerError = {
-    ...error,
-    code: transformedError.code,
-    statusCode: transformedError.statusCode,
-    retryable: transformedError.retryable,
-  };
-
-  return transformedError;
+  return (
+    code === 'CredentialsProviderError' ||
+    code === 'CredentialsError' ||
+    message.startsWith('Missing credentials in config') ||
+    message.includes('Could not load credentials') ||
+    message.includes('Resolved credential object is not valid')
+  );
 }
 
-/**
- * Determine if an error is retryable
- * @param {Error} error - AWS SDK error
- * @returns {boolean} Whether the error is retryable
- */
+function createCredentialsNotFoundError(error) {
+  let bottomError = error || {};
+  while (
+    bottomError.originalError &&
+    bottomError.message &&
+    !bottomError.message.startsWith('EC2 Metadata')
+  ) {
+    bottomError = bottomError.originalError;
+  }
+
+  const message = bottomError.message || (error && error.message) || '';
+  const errorMessage =
+    message && !message.startsWith('EC2 Metadata')
+      ? message
+      : [
+          'AWS provider credentials not found.',
+          ' Learn how to set up AWS provider credentials',
+          ` in our docs here: <${colors.green(credentialsHelpUrl)}>`,
+          '.',
+        ].join('');
+
+  return Object.assign(new ServerlessError(errorMessage, 'AWS_CREDENTIALS_NOT_FOUND'), {
+    providerError: Object.assign({}, error, { retryable: false }),
+  });
+}
+
 function isRetryableError(error) {
   if (!error) return false;
 
-  // Check metadata for retry info
-  if (error.$metadata) {
-    const statusCode = error.$metadata.httpStatusCode;
+  const statusCode = error.statusCode || (error.$metadata && error.$metadata.httpStatusCode);
 
-    // 5xx errors are generally retryable
-    if (statusCode >= 500) return true;
+  if (statusCode >= 500) return true;
+  if (statusCode === 429) return true;
+  if (statusCode === 403) return false;
 
-    // 429 (Too Many Requests) is retryable
-    if (statusCode === 429) return true;
+  if (error.$retryable) return true;
+  if (error.retryable != null) return Boolean(error.retryable);
 
-    // 403 (Forbidden) is generally not retryable
-    if (statusCode === 403) return false;
-  }
-
-  // Check error names/codes for specific retryable errors
   const errorCode = error.name || error.code;
   const retryableErrors = [
     'ThrottlingException',
@@ -141,7 +78,74 @@ function isRetryableError(error) {
   return retryableErrors.includes(errorCode);
 }
 
+function toV2ProviderError(error) {
+  if (!error || typeof error !== 'object') return error;
+
+  const metadata = error.$metadata || {};
+  const providerError = Object.assign({}, error);
+
+  providerError.code = error.code || error.name || error.Code || 'Error';
+  providerError.statusCode = error.statusCode || metadata.httpStatusCode;
+  providerError.retryable = isRetryableError(providerError);
+
+  if (metadata.requestId && !providerError.requestId) providerError.requestId = metadata.requestId;
+  if (metadata.extendedRequestId && !providerError.extendedRequestId) {
+    providerError.extendedRequestId = metadata.extendedRequestId;
+  }
+  if (metadata.cfId && !providerError.cfId) providerError.cfId = metadata.cfId;
+
+  return providerError;
+}
+
+function createAwsServerlessError({ error, serviceName, methodName }) {
+  if (isCredentialsError(error)) return createCredentialsNotFoundError(error);
+
+  const providerError = toV2ProviderError(error);
+  const message = error && error.message != null ? error.message : String(providerError.code);
+  const providerErrorCodeExtension = (() => {
+    if (!providerError.code) return 'ERROR';
+    if (typeof providerError.code === 'number') return `HTTP_${providerError.code}_ERROR`;
+    return normalizeErrorCodePostfix(providerError.code);
+  })();
+
+  return Object.assign(
+    new ServerlessError(
+      message,
+      `AWS_${normalizeErrorCodePostfix(serviceName)}_${normalizeErrorCodePostfix(
+        methodName
+      )}_${providerErrorCodeExtension}`
+    ),
+    {
+      providerError,
+      providerErrorCodeExtension,
+    }
+  );
+}
+
+function transformV3Error(error) {
+  if (!error || typeof error !== 'object') return error;
+  if (isCredentialsError(error)) throw createCredentialsNotFoundError(error);
+
+  const providerError = toV2ProviderError(error);
+  const transformedError = new Error(error.message || 'Unknown AWS error');
+  Object.assign(transformedError, error, {
+    code: providerError.code,
+    statusCode: providerError.statusCode,
+    retryable: providerError.retryable,
+    requestId: providerError.requestId,
+    cfId: providerError.cfId,
+    providerError,
+  });
+
+  return transformedError;
+}
+
 module.exports = {
-  ERROR_CODE_MAPPINGS,
+  createAwsServerlessError,
+  createCredentialsNotFoundError,
+  isCredentialsError,
+  isRetryableError,
+  normalizeErrorCodePostfix,
+  toV2ProviderError,
   transformV3Error,
 };

--- a/lib/aws/request.js
+++ b/lib/aws/request.js
@@ -3,7 +3,6 @@
 const memoize = require('memoizee');
 const promiseLimit = require('ext/promise/limit').bind(Promise);
 const sdk = require('./sdk-v2');
-const ServerlessError = require('../../lib/serverless-error');
 const { log } = require('../utils/serverless-utils/log');
 const HttpsProxyAgent = require('https-proxy-agent');
 const url = require('url');
@@ -13,8 +12,12 @@ const deepSortObjectByKey = require('../utils/deep-sort-object-by-key');
 const ensureString = require('type/string/ensure');
 const isObject = require('type/object/is');
 const wait = require('../utils/sleep');
-const colors = require('../utils/colors');
-const credentialsHelpUrl = require('./credentials-help-url');
+const AWSClientFactory = require('./client-factory');
+const { createCommand } = require('./commands');
+const { buildClientConfig } = require('./config');
+const { toV3CredentialsProvider } = require('./credentials');
+const { createAwsServerlessError } = require('./error-utils');
+const { normalizeV3Response } = require('./response-normalizer');
 
 // Activate AWS SDK logging
 const awsLog = log.get('aws');
@@ -82,6 +85,7 @@ const MAX_RETRIES = (() => {
 })();
 
 const accelerationCompatibleS3Methods = new Set(['upload', 'putObject']);
+let v3ClientFactory;
 
 const shouldS3Accelerate = (method, params) => {
   if (
@@ -114,12 +118,51 @@ const getServiceInstance = memoize(
   }
 );
 
-const normalizerPattern = /(?<!^)([A-Z])/g;
-const normalizeErrorCodePostfix = (name) => {
-  return name.replace(normalizerPattern, '_$1').toUpperCase();
-};
-
 let requestCounter = 0;
+
+function getV3ClientFactory() {
+  if (!v3ClientFactory) v3ClientFactory = new AWSClientFactory();
+  return v3ClientFactory;
+}
+
+function buildV3ClientConfig(service, method) {
+  const serviceParams = service.params || {};
+  const clientConfig = buildClientConfig({
+    region: serviceParams.region,
+    credentials: toV3CredentialsProvider(serviceParams),
+    maxAttempts: 1,
+  });
+
+  if (service.name === 'S3' && shouldS3Accelerate(method, serviceParams)) {
+    clientConfig.useAccelerateEndpoint = true;
+  }
+
+  return clientConfig;
+}
+
+async function sendV2Request(service, method, args) {
+  const awsService = getServiceInstance(service, method);
+  const req = awsService[method](...args);
+  return req.promise();
+}
+
+async function sendV3Request(service, method, args) {
+  const command = createCommand(service.name, method, args[0]);
+  const clientConfig = buildV3ClientConfig(service, method);
+  const result = await getV3ClientFactory().send(service.name, command, clientConfig);
+  return normalizeV3Response(service.name, method, result);
+}
+
+function shouldUseV3() {
+  return process.env.SLS_AWS_SDK_V3 === '1';
+}
+
+function isV3MappingError(error) {
+  return (
+    error &&
+    (error.code === 'AWS_SDK_V3_UNKNOWN_SERVICE' || error.code === 'AWS_SDK_V3_UNKNOWN_METHOD')
+  );
+}
 
 /** Execute request to AWS service
  * @param {Object|string} [service] - Description of the service to call
@@ -176,60 +219,23 @@ async function awsRequest(service, method, ...args) {
   const request = await requestQueue(() =>
     persistentRequest(async () => {
       const requestId = ++requestCounter;
-      const awsService = getServiceInstance(service, method);
       awsLog.debug('[%d] %O %s %O', requestId, service, method, args);
-      const req = awsService[method](...args);
+      const sendRequest = shouldUseV3() ? sendV3Request : sendV2Request;
       try {
-        const result = await req.promise();
+        const result = await sendRequest(service, method, args);
         awsLog.debug('[%d] %O', requestId, result);
         return result;
       } catch (err) {
         awsLog.debug('[%d] %O', requestId, err);
-        let message = err.message != null ? err.message : String(err.code);
-        if (message.startsWith('Missing credentials in config')) {
-          // Credentials error
-          // If failed at last resort (EC2 Metadata check) expose a meaningful error
-          // with link to AWS documentation
-          // Otherwise, it's likely that user relied on some AWS creds, which appeared not correct
-          // therefore expose an AWS message directly
-          let bottomError = err;
-          while (bottomError.originalError && !bottomError.message.startsWith('EC2 Metadata')) {
-            bottomError = bottomError.originalError;
-          }
-
-          const errorMessage = bottomError.message.startsWith('EC2 Metadata')
-            ? [
-                'AWS provider credentials not found.',
-                ' Learn how to set up AWS provider credentials',
-                ` in our docs here: <${colors.green(credentialsHelpUrl)}>`,
-                '.',
-              ].join('')
-            : bottomError.message;
-          // We do not want to trigger the retry mechanism for credential errors
-          throw Object.assign(new ServerlessError(errorMessage, 'AWS_CREDENTIALS_NOT_FOUND'), {
-            providerError: Object.assign({}, err, { retryable: false }),
-          });
-        }
-        const providerErrorCodeExtension = (() => {
-          if (!err.code) return 'ERROR';
-          if (typeof err.code === 'number') return `HTTP_${err.code}_ERROR`;
-          return normalizeErrorCodePostfix(err.code);
-        })();
+        if (isV3MappingError(err)) throw err;
         if (err.stack) {
           log.debug(`${err.stack}\n${'-'.repeat(100)}`);
         }
-        throw Object.assign(
-          new ServerlessError(
-            message,
-            `AWS_${normalizeErrorCodePostfix(service.name)}_${normalizeErrorCodePostfix(
-              method
-            )}_${providerErrorCodeExtension}`
-          ),
-          {
-            providerError: err,
-            providerErrorCodeExtension,
-          }
-        );
+        throw createAwsServerlessError({
+          error: err,
+          serviceName: service.name,
+          methodName: method,
+        });
       }
     })
   );

--- a/lib/aws/response-normalizer.js
+++ b/lib/aws/response-normalizer.js
@@ -1,0 +1,50 @@
+'use strict';
+
+async function collectSdkStreamBody(body) {
+  if (!body) return body;
+  if (Buffer.isBuffer(body)) return body;
+  if (typeof body === 'string') return Buffer.from(body);
+  if (body instanceof Uint8Array) return Buffer.from(body);
+
+  if (typeof body.transformToByteArray === 'function') {
+    return Buffer.from(await body.transformToByteArray());
+  }
+
+  if (typeof body.transformToString === 'function') {
+    return Buffer.from(await body.transformToString());
+  }
+
+  if (typeof body[Symbol.asyncIterator] === 'function') {
+    const chunks = [];
+    for await (const chunk of body) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks);
+  }
+
+  return body;
+}
+
+async function normalizeV3Response(serviceName, methodName, response) {
+  if (!response || typeof response !== 'object') return response;
+
+  const normalized = { ...response };
+  delete normalized.$metadata;
+
+  if (serviceName === 'S3' && methodName === 'getObject' && normalized.Body) {
+    normalized.Body = await collectSdkStreamBody(normalized.Body);
+  }
+
+  if (serviceName === 'Lambda' && methodName === 'invoke' && normalized.Payload) {
+    if (normalized.Payload instanceof Uint8Array && !Buffer.isBuffer(normalized.Payload)) {
+      normalized.Payload = Buffer.from(normalized.Payload);
+    }
+  }
+
+  return normalized;
+}
+
+module.exports = {
+  collectSdkStreamBody,
+  normalizeV3Response,
+};

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -20,12 +20,6 @@ const { getByPath } = require('../../utils/object-path');
 const { hasOwn } = require('../../utils/safe-object');
 const { progress, log } = require('../../utils/serverless-utils/log');
 
-// AWS SDK v3 infrastructure
-const AWSClientFactory = require('../../aws/client-factory');
-const { createCommand } = require('../../aws/commands');
-const { buildClientConfig, shouldUseS3Acceleration } = require('../../aws/config');
-const { transformV3Error } = require('../../aws/error-utils');
-
 const isLambdaArn = RegExp.prototype.test.bind(/^arn:[^:]+:lambda:/);
 const isEcrUri = RegExp.prototype.test.bind(
   /^\d+\.dkr\.ecr\.[a-z0-9-]+..amazonaws.com\/([^@]+)|([^@:]+@sha256:[a-f0-9]{64})$/
@@ -230,9 +224,8 @@ class AwsProvider {
     //         offering a reliable alternative
     this.sdk = AWS;
 
-    // AWS SDK v3 infrastructure
+    // AWS SDK v3 direct-client infrastructure. provider.request routes through lib/aws/request.
     this.clientFactory = null; // Will be initialized when needed
-    this._v3Enabled = process.env.SLS_AWS_SDK_V3 === '1'; // Feature flag for gradual rollout
 
     this.serverless.setProvider(constants.providerName, this);
     this.hooks = {
@@ -1751,7 +1744,7 @@ class AwsProvider {
   }
 
   /**
-   * Primary AWS request interface - auto-routes to v2/v3 based on SLS_AWS_SDK_V3 flag
+   * Primary AWS request interface. lib/aws/request owns v2/v3 backend selection.
    * @param {string} service - Service name
    * @param {string} method - Method name
    * @param {Object} params - Parameters
@@ -1759,10 +1752,6 @@ class AwsProvider {
    * @returns {Promise} AWS API response
    */
   async request(service, method, params, options) {
-    // Use v3 if feature flag is enabled, otherwise fallback to v2
-    if (this._v3Enabled) {
-      return this._requestV3(service, method, params, options);
-    }
     return this._requestV2(service, method, params, options);
   }
 
@@ -1794,92 +1783,26 @@ class AwsProvider {
   }
 
   /**
-   * Direct AWS SDK v3 interface (private)
-   * @param {string} service - AWS service name (e.g., 'CloudFormation', 'S3')
-   * @param {string} method - Method name from v2 SDK (e.g., 'createStack', 'listObjects')
-   * @param {Object} params - Parameters for the AWS API call
-   * @param {Object} options - Additional options
-   * @returns {Promise} AWS API response
-   * @private
-   */
-  async _requestV3(service, method, params = {}, options = {}) {
-    try {
-      if (!this.clientFactory) {
-        this.clientFactory = new AWSClientFactory(this._getV3BaseConfig());
-      }
-
-      const clientConfig = this._buildV3ClientConfig(service, method, options);
-
-      const command = createCommand(service, method, params);
-
-      return await this.clientFactory.send(service, command, clientConfig);
-    } catch (error) {
-      // Transform v3 error to be compatible with existing error handling
-      throw transformV3Error(error);
-    }
-  }
-
-  /**
    * Get AWS SDK v3 client for direct use
    * @param {string} service - AWS service name
    * @param {Object} options - Client configuration options
    * @returns {Object} AWS SDK v3 client instance
    */
   getV3Client(service, options = {}) {
+    const AWSClientFactory = require('../../aws/client-factory');
+    const { buildClientConfig } = require('../../aws/config');
+    const { toV3CredentialsProvider } = require('../../aws/credentials');
+
     if (!this.clientFactory) {
-      this.clientFactory = new AWSClientFactory(this._getV3BaseConfig());
+      this.clientFactory = new AWSClientFactory();
     }
 
-    const clientConfig = this._buildV3ClientConfig(service, null, options);
-    return this.clientFactory.getClient(service, clientConfig);
-  }
-
-  /**
-   * Build base configuration for AWS SDK v3 clients
-   * @private
-   */
-  _getV3BaseConfig() {
-    // Convert v2 credentials format to v3 format
-    const { credentials: v2Creds } = this.getCredentials();
-    const credentials =
-      v2Creds && v2Creds.accessKeyId
-        ? {
-            accessKeyId: v2Creds.accessKeyId,
-            secretAccessKey: v2Creds.secretAccessKey,
-            sessionToken: v2Creds.sessionToken,
-          }
-        : undefined;
-
-    return buildClientConfig({
+    const clientConfig = buildClientConfig({
       region: this.getRegion(),
-      credentials,
+      credentials: toV3CredentialsProvider(this.getCredentials()),
+      ...options,
     });
-  }
-
-  /**
-   * Build client-specific configuration for AWS SDK v3
-   * @private
-   */
-  _buildV3ClientConfig(service, method, options) {
-    const baseConfig = this._getV3BaseConfig();
-    const requestOptions = isObject(options) ? options : {};
-
-    // Override region if specified
-    if (requestOptions.region) {
-      baseConfig.region = requestOptions.region;
-    }
-
-    // Handle S3-specific configuration
-    if (service === 'S3' && method) {
-      const useAcceleration = shouldUseS3Acceleration(method, {
-        isS3TransferAccelerationEnabled: this.isS3TransferAccelerationEnabled(),
-      });
-      if (useAcceleration) {
-        baseConfig.useAccelerateEndpoint = true;
-      }
-    }
-
-    return baseConfig;
+    return this.clientFactory.getClient(service, clientConfig);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@aws-sdk/credential-providers": "^3.975.0",
     "@aws-sdk/lib-dynamodb": "^3.975.0",
     "@aws-sdk/lib-storage": "^3.975.0",
+    "@smithy/node-http-handler": "^4.6.1",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "aws-sdk": "^2.1693.0",

--- a/test/unit/lib/aws/client-factory.test.js
+++ b/test/unit/lib/aws/client-factory.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const chai = require('chai');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+
+const { expect } = chai;
+
+describe('test/unit/lib/aws/client-factory.test.js', () => {
+  let instances;
+  let sendStub;
+  let uploadDoneStub;
+  let uploadOptions;
+  let AWSClientFactory;
+
+  beforeEach(() => {
+    instances = [];
+    sendStub = sinon.stub().resolves({ ok: true });
+    uploadDoneStub = sinon.stub().resolves({ uploaded: true });
+    uploadOptions = null;
+
+    class FakeS3Client {
+      constructor(config) {
+        this.config = config;
+        this.send = sendStub;
+        instances.push(this);
+      }
+    }
+
+    function FakeUpload(options) {
+      uploadOptions = options;
+      this.done = uploadDoneStub;
+    }
+
+    AWSClientFactory = proxyquire('../../../../lib/aws/client-factory', {
+      '@aws-sdk/client-s3': { S3Client: FakeS3Client },
+      '@aws-sdk/lib-storage': { Upload: FakeUpload },
+    });
+  });
+
+  it('reuses clients for the same service and config', () => {
+    const factory = new AWSClientFactory();
+
+    const firstClient = factory.getClient('S3', { region: 'us-east-1' });
+    const secondClient = factory.getClient('S3', { region: 'us-east-1' });
+
+    expect(firstClient).to.equal(secondClient);
+    expect(instances).to.have.length(1);
+  });
+
+  it('creates separate clients for different regions', () => {
+    const factory = new AWSClientFactory();
+
+    const firstClient = factory.getClient('S3', { region: 'us-east-1' });
+    const secondClient = factory.getClient('S3', { region: 'eu-west-1' });
+
+    expect(firstClient).to.not.equal(secondClient);
+    expect(instances).to.have.length(2);
+  });
+
+  it('does not include credential secrets in cache keys', () => {
+    const cacheKey = AWSClientFactory.createClientCacheKey('S3', {
+      region: 'us-east-1',
+      credentials: {
+        accessKeyId: 'AKIAEXAMPLE',
+        secretAccessKey: 'secret-value',
+        sessionToken: 'session-token',
+      },
+    });
+
+    expect(cacheKey).to.include('AKIAEXAMPLE');
+    expect(cacheKey).to.not.include('secret-value');
+    expect(cacheKey).to.not.include('session-token');
+  });
+
+  it('sends normal commands with client.send', async () => {
+    const factory = new AWSClientFactory();
+    const command = { command: true };
+
+    const result = await factory.send('S3', command, { region: 'us-east-1' });
+
+    expect(result).to.deep.equal({ ok: true });
+    expect(sendStub).to.have.been.calledOnceWithExactly(command);
+  });
+
+  it('sends S3 upload markers with lib-storage Upload', async () => {
+    const factory = new AWSClientFactory();
+    const command = { _isUploadRequest: true, params: { Bucket: 'bucket', Key: 'key' } };
+
+    const result = await factory.send('S3', command, { region: 'us-east-1' });
+
+    expect(result).to.deep.equal({ uploaded: true });
+    expect(uploadOptions).to.deep.equal({ client: instances[0], params: command.params });
+    expect(uploadDoneStub).to.have.been.calledOnce;
+    expect(sendStub).to.not.have.been.called;
+  });
+});

--- a/test/unit/lib/aws/commands.test.js
+++ b/test/unit/lib/aws/commands.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const chai = require('chai');
+
+const { expect } = chai;
+
+describe('test/unit/lib/aws/commands.test.js', () => {
+  const { COMMAND_MAP, createCommand } = require('../../../../lib/aws/commands');
+
+  const providerRequestPairs = [
+    ['APIGateway', 'createStage'],
+    ['APIGateway', 'getApiKey'],
+    ['APIGateway', 'getDeployments'],
+    ['APIGateway', 'getRestApis'],
+    ['APIGateway', 'getStage'],
+    ['APIGateway', 'getUsagePlans'],
+    ['APIGateway', 'tagResource'],
+    ['APIGateway', 'untagResource'],
+    ['APIGateway', 'updateStage'],
+    ['APIGateway', 'updateUsagePlan'],
+    ['ApiGatewayV2', 'getApi'],
+    ['CloudFormation', 'createChangeSet'],
+    ['CloudFormation', 'createStack'],
+    ['CloudFormation', 'deleteChangeSet'],
+    ['CloudFormation', 'deleteStack'],
+    ['CloudFormation', 'describeChangeSet'],
+    ['CloudFormation', 'describeStackEvents'],
+    ['CloudFormation', 'describeStackResource'],
+    ['CloudFormation', 'describeStackResources'],
+    ['CloudFormation', 'describeStacks'],
+    ['CloudFormation', 'executeChangeSet'],
+    ['CloudFormation', 'getTemplate'],
+    ['CloudFormation', 'listExports'],
+    ['CloudFormation', 'listStackResources'],
+    ['CloudFormation', 'setStackPolicy'],
+    ['CloudFormation', 'updateStack'],
+    ['CloudFormation', 'validateTemplate'],
+    ['CloudWatch', 'getMetricStatistics'],
+    ['CloudWatchLogs', 'deleteLogGroup'],
+    ['CloudWatchLogs', 'deleteSubscriptionFilter'],
+    ['CloudWatchLogs', 'describeLogStreams'],
+    ['CloudWatchLogs', 'describeSubscriptionFilters'],
+    ['CloudWatchLogs', 'filterLogEvents'],
+    ['ECR', 'createRepository'],
+    ['ECR', 'deleteRepository'],
+    ['ECR', 'describeImages'],
+    ['ECR', 'describeRepositories'],
+    ['ECR', 'getAuthorizationToken'],
+    ['ECR', 'putLifecyclePolicy'],
+    ['IAM', 'getRole'],
+    ['Lambda', 'getFunction'],
+    ['Lambda', 'getLayerVersion'],
+    ['Lambda', 'invoke'],
+    ['Lambda', 'listVersionsByFunction'],
+    ['Lambda', 'updateFunctionCode'],
+    ['Lambda', 'updateFunctionConfiguration'],
+    ['S3', 'deleteObjects'],
+    ['S3', 'getObject'],
+    ['S3', 'headBucket'],
+    ['S3', 'headObject'],
+    ['S3', 'listObjectVersions'],
+    ['S3', 'listObjectsV2'],
+    ['SSM', 'getParameter'],
+    ['STS', 'getCallerIdentity'],
+  ];
+
+  for (const [service, method] of providerRequestPairs) {
+    it(`maps ${service}.${method} to a v3 command`, () => {
+      const params = { marker: `${service}.${method}` };
+      const command = createCommand(service, method, params);
+
+      expect(command.input).to.deep.equal(params);
+      expect(COMMAND_MAP[service][method]).to.be.a('function');
+    });
+  }
+
+  it('special-cases S3.upload', () => {
+    const params = { Bucket: 'bucket', Key: 'key' };
+
+    expect(createCommand('S3', 'upload', params)).to.deep.equal({
+      _isUploadRequest: true,
+      params,
+    });
+  });
+
+  it('fails loudly for unknown services', () => {
+    expect(() => createCommand('Route53', 'listHostedZones', {}))
+      .to.throw('Unknown AWS service: Route53')
+      .and.have.property('code', 'AWS_SDK_V3_UNKNOWN_SERVICE');
+  });
+
+  it('fails loudly for unknown methods', () => {
+    expect(() => createCommand('S3', 'unknownMethod', {}))
+      .to.throw("Unknown method 'unknownMethod' for service 'S3'")
+      .and.have.property('code', 'AWS_SDK_V3_UNKNOWN_METHOD');
+  });
+});

--- a/test/unit/lib/aws/config.test.js
+++ b/test/unit/lib/aws/config.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const chai = require('chai');
+const proxyquire = require('proxyquire');
+const overrideEnv = require('process-utils/override-env');
+
+const { expect } = chai;
+
+describe('test/unit/lib/aws/config.test.js', () => {
+  function loadConfig() {
+    function FakeNodeHttpHandler(options) {
+      this.options = options;
+    }
+
+    function FakeHttpsProxyAgent(options) {
+      this.options = options;
+    }
+
+    class FakeHttpsAgent {
+      constructor(options) {
+        this.options = options;
+      }
+    }
+
+    return proxyquire('../../../../lib/aws/config', {
+      '@smithy/node-http-handler': { NodeHttpHandler: FakeNodeHttpHandler },
+      'https-proxy-agent': FakeHttpsProxyAgent,
+      'https': { Agent: FakeHttpsAgent },
+    });
+  }
+
+  it('preserves explicit maxAttempts values including zero', async () => {
+    await overrideEnv(async () => {
+      const { buildClientConfig } = loadConfig();
+
+      expect(buildClientConfig({ maxAttempts: 0 }).maxAttempts).to.equal(0);
+      expect(buildClientConfig({ maxAttempts: 1 }).maxAttempts).to.equal(1);
+    });
+  });
+
+  it('uses NodeHttpHandler for timeout config', async () => {
+    await overrideEnv(async () => {
+      process.env.AWS_CLIENT_TIMEOUT = '1234';
+      const { buildClientConfig } = loadConfig();
+
+      const config = buildClientConfig();
+
+      expect(config.requestHandler.options).to.deep.equal({ requestTimeout: 1234 });
+    });
+  });
+
+  it('passes proxy and CA options when constructing the proxy agent', async () => {
+    await overrideEnv(async () => {
+      process.env.HTTPS_PROXY = 'https://proxy.example.com:1234';
+      process.env.HTTPS_CA = 'certificate';
+      const { buildClientConfig } = loadConfig();
+
+      const config = buildClientConfig();
+
+      expect(config.requestHandler.options.httpsAgent.options).to.include({
+        protocol: 'https:',
+        host: 'proxy.example.com:1234',
+        rejectUnauthorized: true,
+      });
+      expect(config.requestHandler.options.httpsAgent.options.ca).to.deep.equal(['certificate']);
+    });
+  });
+
+  it('detects S3 acceleration only for compatible methods', () => {
+    const { shouldUseS3Acceleration } = loadConfig();
+
+    expect(shouldUseS3Acceleration('upload', { isS3TransferAccelerationEnabled: true })).to.equal(
+      true
+    );
+    expect(
+      shouldUseS3Acceleration('putObject', { isS3TransferAccelerationEnabled: true })
+    ).to.equal(true);
+    expect(
+      shouldUseS3Acceleration('getObject', { isS3TransferAccelerationEnabled: true })
+    ).to.equal(false);
+  });
+});

--- a/test/unit/lib/aws/error-utils.test.js
+++ b/test/unit/lib/aws/error-utils.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const chai = require('chai');
+
+const { expect } = chai;
+
+describe('test/unit/lib/aws/error-utils.test.js', () => {
+  const {
+    createAwsServerlessError,
+    isRetryableError,
+    transformV3Error,
+  } = require('../../../../lib/aws/error-utils');
+
+  it('wraps v3 errors with v2-style Serverless error codes', () => {
+    const error = Object.assign(new Error('missing object'), {
+      name: 'NoSuchKey',
+      $metadata: { httpStatusCode: 404, requestId: 'request-id' },
+    });
+
+    const wrappedError = createAwsServerlessError({
+      error,
+      serviceName: 'S3',
+      methodName: 'getObject',
+    });
+
+    expect(wrappedError.code).to.equal('AWS_S3_GET_OBJECT_NO_SUCH_KEY');
+    expect(wrappedError.providerError).to.include({
+      code: 'NoSuchKey',
+      statusCode: 404,
+      requestId: 'request-id',
+    });
+  });
+
+  it('normalizes retryable v3 status codes', () => {
+    expect(isRetryableError({ $metadata: { httpStatusCode: 500 } })).to.equal(true);
+    expect(isRetryableError({ $metadata: { httpStatusCode: 429 } })).to.equal(true);
+    expect(isRetryableError({ $metadata: { httpStatusCode: 403 } })).to.equal(false);
+  });
+
+  it('transforms credential provider errors to credentials not found errors', () => {
+    expect(() =>
+      transformV3Error(
+        Object.assign(new Error('Could not load credentials from any providers'), {
+          name: 'CredentialsProviderError',
+        })
+      )
+    )
+      .to.throw()
+      .and.have.property('code', 'AWS_CREDENTIALS_NOT_FOUND');
+  });
+});

--- a/test/unit/lib/aws/request.test.js
+++ b/test/unit/lib/aws/request.test.js
@@ -494,4 +494,74 @@ describe('#request', () => {
       });
     });
   });
+
+  describe('AWS SDK v3 backend', () => {
+    it('sends mapped commands through the v3 client factory', async () => {
+      await overrideEnv(async () => {
+        process.env.SLS_AWS_SDK_V3 = '1';
+
+        const command = { command: true };
+        const sendStub = sinon.stub().resolves({ ok: true, $metadata: { requestId: 'id' } });
+        const createCommandStub = sinon.stub().returns(command);
+        const buildClientConfigStub = sinon.stub().returns({ region: 'us-east-1', maxAttempts: 1 });
+        const normalizeV3ResponseStub = sinon.stub().resolves({ ok: true });
+
+        class FakeAWSClientFactory {
+          send(...args) {
+            return sendStub(...args);
+          }
+        }
+
+        const awsRequest = proxyquire('../../../../lib/aws/request', {
+          './sdk-v2': { config: { httpOptions: {} } },
+          './client-factory': FakeAWSClientFactory,
+          './commands': { createCommand: createCommandStub },
+          './config': { buildClientConfig: buildClientConfigStub },
+          './credentials': { toV3CredentialsProvider: sinon.stub().returns('credentials') },
+          './response-normalizer': { normalizeV3Response: normalizeV3ResponseStub },
+        });
+
+        const result = await awsRequest(
+          { name: 'S3', params: { region: 'us-east-1' } },
+          'getObject',
+          { Bucket: 'bucket', Key: 'key' }
+        );
+
+        expect(result).to.deep.equal({ ok: true });
+        expect(createCommandStub).to.have.been.calledOnceWithExactly('S3', 'getObject', {
+          Bucket: 'bucket',
+          Key: 'key',
+        });
+        expect(buildClientConfigStub).to.have.been.calledOnce;
+        expect(buildClientConfigStub.firstCall.args[0]).to.include({
+          region: 'us-east-1',
+          credentials: 'credentials',
+          maxAttempts: 1,
+        });
+        expect(sendStub).to.have.been.calledOnceWithExactly('S3', command, {
+          region: 'us-east-1',
+          maxAttempts: 1,
+        });
+        expect(normalizeV3ResponseStub).to.have.been.calledOnce;
+      });
+    });
+
+    it('fails loudly for unmapped v3 commands', async () => {
+      await overrideEnv(async () => {
+        process.env.SLS_AWS_SDK_V3 = '1';
+        const mappingError = Object.assign(new Error('Unknown method'), {
+          code: 'AWS_SDK_V3_UNKNOWN_METHOD',
+        });
+
+        const awsRequest = proxyquire('../../../../lib/aws/request', {
+          './sdk-v2': { config: { httpOptions: {} } },
+          './commands': { createCommand: sinon.stub().throws(mappingError) },
+        });
+
+        await expect(awsRequest({ name: 'S3' }, 'unknownMethod', {})).to.be.rejectedWith(
+          'Unknown method'
+        );
+      });
+    });
+  });
 });

--- a/test/unit/lib/aws/request.test.js
+++ b/test/unit/lib/aws/request.test.js
@@ -19,6 +19,17 @@ const createDeferred = () => {
 };
 
 describe('#request', () => {
+  let restoreSdkModeEnv;
+
+  beforeEach(() => {
+    ({ restoreEnv: restoreSdkModeEnv } = overrideEnv({ asCopy: true }));
+    process.env.SLS_AWS_SDK_V3 = '0';
+  });
+
+  afterEach(() => {
+    restoreSdkModeEnv();
+  });
+
   describe('Credentials support', () => {
     // awsRequest supports credentials from two sources:
     // - an AWS credentials object passed as part of params in the call

--- a/test/unit/lib/aws/response-normalizer.test.js
+++ b/test/unit/lib/aws/response-normalizer.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const { Readable } = require('stream');
+const chai = require('chai');
+
+const { expect } = chai;
+
+describe('test/unit/lib/aws/response-normalizer.test.js', () => {
+  const { normalizeV3Response } = require('../../../../lib/aws/response-normalizer');
+
+  it('converts S3 getObject readable bodies to buffers', async () => {
+    const response = await normalizeV3Response('S3', 'getObject', {
+      Body: Readable.from(['hello']),
+      $metadata: { requestId: 'request-id' },
+    });
+
+    expect(Buffer.isBuffer(response.Body)).to.equal(true);
+    expect(String(response.Body)).to.equal('hello');
+    expect(response).to.not.have.property('$metadata');
+  });
+
+  it('converts S3 getObject transformToByteArray bodies to buffers', async () => {
+    const response = await normalizeV3Response('S3', 'getObject', {
+      Body: { transformToByteArray: async () => Uint8Array.from(Buffer.from('hello')) },
+    });
+
+    expect(Buffer.isBuffer(response.Body)).to.equal(true);
+    expect(String(response.Body)).to.equal('hello');
+  });
+
+  it('converts Lambda invoke Uint8Array payloads to buffers', async () => {
+    const response = await normalizeV3Response('Lambda', 'invoke', {
+      Payload: Uint8Array.from(Buffer.from('{"ok":true}')),
+      StatusCode: 200,
+      $metadata: { requestId: 'request-id' },
+    });
+
+    expect(Buffer.isBuffer(response.Payload)).to.equal(true);
+    expect(String(response.Payload)).to.equal('{"ok":true}');
+    expect(response).to.deep.equal({ Payload: response.Payload, StatusCode: 200 });
+  });
+});


### PR DESCRIPTION
This hardens the opt-in AWS SDK v3 path by routing `provider.request()` through the shared AWS request layer instead of the provider-local v3 adapter.

- Add missing v3 command mappings for `ECR.putLifecyclePolicy` and `CloudWatchLogs.deleteLogGroup`
- Preserve shared request-layer behavior for v3, including caching, queueing, retries, logging, and normalized AWS errors
- Add v3 response normalization for S3 `getObject` bodies and Lambda invoke payloads
- Fix v3 HTTP configuration to use `NodeHttpHandler`
- Add v3 credential-provider bridging instead of static credential snapshots
- Improve v3 client cache keys to avoid serializing secret values
- Keep `provider.sdk` as AWS SDK v2 for plugin compatibility
- Add focused unit coverage for command mapping, v3 request routing, config, client factory behavior, error normalization, and response normalization