### PR TITLE
Fix S3 pagination, batching, and key parsing for large deployments

### DIFF
--- a/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.js
+++ b/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.js
@@ -69,7 +69,7 @@ module.exports = {
     try {
       const response = await listObjectsV2(this.provider, {
         Bucket: this.bucketName,
-        Prefix: `${prefix}/${service}/${stage}`,
+        Prefix: `${prefix}/${service}/${stage}/`,
       });
 
       const stacks = findAndGroupDeployments(response, prefix, service, stage);

--- a/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.js
+++ b/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.js
@@ -5,6 +5,58 @@ const getS3ObjectsFromStacks = require('../../utils/get-s3-objects-from-stacks')
 const ServerlessError = require('../../../../serverless-error');
 const { log } = require('../../../../utils/serverless-utils/log');
 
+const maxDeleteObjectsCount = 1000;
+
+const getErrorCode = (error) =>
+  error && (error.code || error.Code || (error.providerError && error.providerError.code));
+
+const getErrorStatusCode = (error) =>
+  error && ((error.providerError && error.providerError.statusCode) || error.statusCode);
+
+const isS3ListObjectsAccessDeniedError = (error) =>
+  getErrorCode(error) === 'AWS_S3_LIST_OBJECTS_V2_ACCESS_DENIED' ||
+  getErrorCode(error) === 'AccessDenied' ||
+  getErrorStatusCode(error) === 403;
+
+const createS3ListObjectsAccessDeniedError = () =>
+  new ServerlessError(
+    'Could not list objects in the deployment bucket. Make sure you have sufficient permissions to access it.',
+    'AWS_S3_LIST_OBJECTS_V2_ACCESS_DENIED'
+  );
+
+const createDeleteObjectsError = (bucketName, firstError) => {
+  const firstErrorCode = firstError.Code || firstError.code;
+
+  if (firstErrorCode === 'AccessDenied') {
+    return new ServerlessError(
+      `Could not remove deployment artifacts from the S3 deployment bucket (${bucketName}). Make sure that you have permissions that allow S3 objects deletion. First encountered S3 error code: ${firstErrorCode}`,
+      'CANNOT_DELETE_S3_OBJECTS_ACCESS_DENIED'
+    );
+  }
+
+  return new ServerlessError(
+    `Could not remove deployment artifacts from the S3 deployment bucket (${bucketName}). First encountered S3 error code: ${firstErrorCode}`,
+    'CANNOT_DELETE_S3_OBJECTS_GENERIC'
+  );
+};
+
+async function listObjectsV2(provider, params) {
+  const Contents = [];
+  let ContinuationToken;
+
+  do {
+    const response = await provider.request('S3', 'listObjectsV2', {
+      ...params,
+      ...(ContinuationToken ? { ContinuationToken } : {}),
+    });
+
+    Contents.push(...(response?.Contents || []));
+    ContinuationToken = response && response.NextContinuationToken;
+  } while (ContinuationToken);
+
+  return { Contents };
+}
+
 module.exports = {
   async getObjectsToRemove() {
     const stacksToKeepCount =
@@ -14,33 +66,36 @@ module.exports = {
     const stage = this.provider.getStage();
     const prefix = this.provider.getDeploymentPrefix();
 
-    let response;
     try {
-      response = await this.provider.request('S3', 'listObjectsV2', {
+      const response = await listObjectsV2(this.provider, {
         Bucket: this.bucketName,
         Prefix: `${prefix}/${service}/${stage}`,
       });
+
+      const stacks = findAndGroupDeployments(response, prefix, service, stage);
+      const stacksToRemove = stacks.slice(0, -stacksToKeepCount || Infinity);
+
+      return getS3ObjectsFromStacks(stacksToRemove, prefix, service, stage);
     } catch (err) {
-      if (err.code === 'AWS_S3_LIST_OBJECTS_V2_ACCESS_DENIED') {
-        throw new ServerlessError(
-          'Could not list objects in the deployment bucket. Make sure you have sufficient permissions to access it.',
-          err.code
-        );
-      }
+      if (isS3ListObjectsAccessDeniedError(err)) throw createS3ListObjectsAccessDeniedError();
       throw err;
     }
-    const stacks = findAndGroupDeployments(response, prefix, service, stage);
-    const stacksToRemove = stacks.slice(0, -stacksToKeepCount || Infinity);
-
-    return getS3ObjectsFromStacks(stacksToRemove, prefix, service, stage);
   },
 
   async removeObjects(objectsToRemove) {
     if (!objectsToRemove || !objectsToRemove.length) return;
-    await this.provider.request('S3', 'deleteObjects', {
-      Bucket: this.bucketName,
-      Delete: { Objects: objectsToRemove },
-    });
+
+    for (let index = 0; index < objectsToRemove.length; index += maxDeleteObjectsCount) {
+      const batch = objectsToRemove.slice(index, index + maxDeleteObjectsCount);
+      const result = await this.provider.request('S3', 'deleteObjects', {
+        Bucket: this.bucketName,
+        Delete: { Objects: batch },
+      });
+
+      if (result && result.Errors && result.Errors.length) {
+        throw createDeleteObjectsError(this.bucketName, result.Errors[0]);
+      }
+    }
   },
 
   async cleanupS3Bucket() {
@@ -55,31 +110,26 @@ module.exports = {
   },
 
   async cleanupArtifactsForEmptyChangeSet() {
-    let response;
     try {
-      response = await this.provider.request('S3', 'listObjectsV2', {
+      const response = await listObjectsV2(this.provider, {
         Bucket: this.bucketName,
         Prefix: this.serverless.service.package.artifactDirectoryName,
       });
+
+      const service = this.serverless.service.service;
+      const stage = this.provider.getStage();
+      const deploymentPrefix = this.provider.getDeploymentPrefix();
+
+      const objectsToRemove = getS3ObjectsFromStacks(
+        findAndGroupDeployments(response, deploymentPrefix, service, stage),
+        deploymentPrefix,
+        service,
+        stage
+      );
+      await this.removeObjects(objectsToRemove);
     } catch (err) {
-      if (err.code === 'AWS_S3_LIST_OBJECTS_V2_ACCESS_DENIED') {
-        throw new ServerlessError(
-          'Could not list objects in the deployment bucket. Make sure you have sufficient permissions to access it.',
-          err.code
-        );
-      }
+      if (isS3ListObjectsAccessDeniedError(err)) throw createS3ListObjectsAccessDeniedError();
       throw err;
     }
-    const service = this.serverless.service.service;
-    const stage = this.provider.getStage();
-    const deploymentPrefix = this.provider.getDeploymentPrefix();
-
-    const objectsToRemove = getS3ObjectsFromStacks(
-      findAndGroupDeployments(response, deploymentPrefix, service, stage),
-      deploymentPrefix,
-      service,
-      stage
-    );
-    await this.removeObjects(objectsToRemove);
   },
 };

--- a/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.js
+++ b/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.js
@@ -110,26 +110,27 @@ module.exports = {
   },
 
   async cleanupArtifactsForEmptyChangeSet() {
+    let response;
     try {
-      const response = await listObjectsV2(this.provider, {
+      response = await listObjectsV2(this.provider, {
         Bucket: this.bucketName,
         Prefix: this.serverless.service.package.artifactDirectoryName,
       });
-
-      const service = this.serverless.service.service;
-      const stage = this.provider.getStage();
-      const deploymentPrefix = this.provider.getDeploymentPrefix();
-
-      const objectsToRemove = getS3ObjectsFromStacks(
-        findAndGroupDeployments(response, deploymentPrefix, service, stage),
-        deploymentPrefix,
-        service,
-        stage
-      );
-      await this.removeObjects(objectsToRemove);
     } catch (err) {
       if (isS3ListObjectsAccessDeniedError(err)) throw createS3ListObjectsAccessDeniedError();
       throw err;
     }
+
+    const service = this.serverless.service.service;
+    const stage = this.provider.getStage();
+    const deploymentPrefix = this.provider.getDeploymentPrefix();
+
+    const objectsToRemove = getS3ObjectsFromStacks(
+      findAndGroupDeployments(response, deploymentPrefix, service, stage),
+      deploymentPrefix,
+      service,
+      stage
+    );
+    await this.removeObjects(objectsToRemove);
   },
 };

--- a/lib/plugins/aws/remove/lib/bucket.js
+++ b/lib/plugins/aws/remove/lib/bucket.js
@@ -3,6 +3,25 @@
 const { log } = require('../../../../utils/serverless-utils/log');
 const ServerlessError = require('../../../../serverless-error');
 
+const maxDeleteObjectsCount = 1000;
+
+const getErrorCode = (error) =>
+  error && (error.code || error.Code || (error.providerError && error.providerError.code));
+
+const getErrorStatusCode = (error) =>
+  error && ((error.providerError && error.providerError.statusCode) || error.statusCode);
+
+const isS3ListObjectsAccessDeniedError = (error) =>
+  getErrorCode(error) === 'AWS_S3_LIST_OBJECTS_V2_ACCESS_DENIED' ||
+  getErrorCode(error) === 'AccessDenied' ||
+  getErrorStatusCode(error) === 403;
+
+const createS3ListObjectsAccessDeniedError = () =>
+  new ServerlessError(
+    'Could not list objects in the deployment bucket. Make sure you have sufficient permissions to access it.',
+    'AWS_S3_LIST_OBJECTS_V2_ACCESS_DENIED'
+  );
+
 module.exports = {
   async setServerlessDeploymentBucketName() {
     try {
@@ -25,28 +44,27 @@ module.exports = {
 
     const serviceStage = `${this.serverless.service.service}/${this.provider.getStage()}`;
 
-    let result;
     try {
-      result = await this.provider.request('S3', 'listObjectsV2', {
-        Bucket: this.bucketName,
-        Prefix: `${this.provider.getDeploymentPrefix()}/${serviceStage}`,
-      });
-    } catch (err) {
-      if (err.code === 'AWS_S3_LIST_OBJECTS_V2_ACCESS_DENIED') {
-        throw new ServerlessError(
-          'Could not list objects in the deployment bucket. Make sure you have sufficient permissions to access it.',
-          err.code
-        );
-      }
-      throw err;
-    }
+      let ContinuationToken;
 
-    if (result) {
-      result.Contents.forEach((object) => {
-        this.objectsInBucket.push({
-          Key: object.Key,
+      do {
+        const result = await this.provider.request('S3', 'listObjectsV2', {
+          Bucket: this.bucketName,
+          Prefix: `${this.provider.getDeploymentPrefix()}/${serviceStage}`,
+          ...(ContinuationToken ? { ContinuationToken } : {}),
         });
-      });
+
+        for (const object of result?.Contents || []) {
+          this.objectsInBucket.push({
+            Key: object.Key,
+          });
+        }
+
+        ContinuationToken = result && result.NextContinuationToken;
+      } while (ContinuationToken);
+    } catch (err) {
+      if (isS3ListObjectsAccessDeniedError(err)) throw createS3ListObjectsAccessDeniedError();
+      throw err;
     }
   },
 
@@ -55,29 +73,38 @@ module.exports = {
 
     const serviceStage = `${this.serverless.service.service}/${this.provider.getStage()}`;
 
-    const result = await this.provider.request('S3', 'listObjectVersions', {
-      Bucket: this.bucketName,
-      Prefix: `${this.provider.getDeploymentPrefix()}/${serviceStage}`,
-    });
+    try {
+      let KeyMarker;
+      let VersionIdMarker;
 
-    if (result) {
-      if (result.Versions) {
-        result.Versions.forEach((object) => {
+      do {
+        const result = await this.provider.request('S3', 'listObjectVersions', {
+          Bucket: this.bucketName,
+          Prefix: `${this.provider.getDeploymentPrefix()}/${serviceStage}`,
+          ...(KeyMarker ? { KeyMarker } : {}),
+          ...(VersionIdMarker ? { VersionIdMarker } : {}),
+        });
+
+        for (const object of result?.Versions || []) {
           this.objectsInBucket.push({
             Key: object.Key,
             VersionId: object.VersionId,
           });
-        });
-      }
+        }
 
-      if (result.DeleteMarkers) {
-        result.DeleteMarkers.forEach((object) => {
+        for (const object of result?.DeleteMarkers || []) {
           this.objectsInBucket.push({
             Key: object.Key,
             VersionId: object.VersionId,
           });
-        });
-      }
+        }
+
+        KeyMarker = result && result.NextKeyMarker;
+        VersionIdMarker = result && result.NextVersionIdMarker;
+      } while (KeyMarker || VersionIdMarker);
+    } catch (err) {
+      if (isS3ListObjectsAccessDeniedError(err)) throw createS3ListObjectsAccessDeniedError();
+      throw err;
     }
   },
 
@@ -90,26 +117,29 @@ module.exports = {
 
   async deleteObjects() {
     if (this.objectsInBucket.length) {
-      const data = await this.provider.request('S3', 'deleteObjects', {
-        Bucket: this.bucketName,
-        Delete: {
-          Objects: this.objectsInBucket,
-        },
-      });
-      if (data && data.Errors && data.Errors.length) {
-        const firstErrorCode = data.Errors[0].Code;
+      for (let index = 0; index < this.objectsInBucket.length; index += maxDeleteObjectsCount) {
+        const batch = this.objectsInBucket.slice(index, index + maxDeleteObjectsCount);
+        const data = await this.provider.request('S3', 'deleteObjects', {
+          Bucket: this.bucketName,
+          Delete: {
+            Objects: batch,
+          },
+        });
+        if (data && data.Errors && data.Errors.length) {
+          const firstErrorCode = data.Errors[0].Code;
 
-        if (firstErrorCode === 'AccessDenied') {
+          if (firstErrorCode === 'AccessDenied') {
+            throw new ServerlessError(
+              `Could not empty the S3 deployment bucket (${this.bucketName}). Make sure that you have permissions that allow S3 objects deletion. First encountered S3 error code: ${firstErrorCode}`,
+              'CANNOT_DELETE_S3_OBJECTS_ACCESS_DENIED'
+            );
+          }
+
           throw new ServerlessError(
-            `Could not empty the S3 deployment bucket (${this.bucketName}). Make sure that you have permissions that allow S3 objects deletion. First encountered S3 error code: ${firstErrorCode}`,
-            'CANNOT_DELETE_S3_OBJECTS_ACCESS_DENIED'
+            `Could not empty the S3 deployment bucket (${this.bucketName}). First encountered S3 error code: ${firstErrorCode}`,
+            'CANNOT_DELETE_S3_OBJECTS_GENERIC'
           );
         }
-
-        throw new ServerlessError(
-          `Could not empty the S3 deployment bucket (${this.bucketName}). First encountered S3 error code: ${firstErrorCode}`,
-          'CANNOT_DELETE_S3_OBJECTS_GENERIC'
-        );
       }
     }
   },

--- a/lib/plugins/aws/remove/lib/bucket.js
+++ b/lib/plugins/aws/remove/lib/bucket.js
@@ -42,7 +42,9 @@ module.exports = {
   async listObjectsV2() {
     this.objectsInBucket = [];
 
-    const serviceStage = `${this.serverless.service.service}/${this.provider.getStage()}`;
+    const prefix = `${this.provider.getDeploymentPrefix()}/${
+      this.serverless.service.service
+    }/${this.provider.getStage()}/`;
 
     try {
       let ContinuationToken;
@@ -50,7 +52,7 @@ module.exports = {
       do {
         const result = await this.provider.request('S3', 'listObjectsV2', {
           Bucket: this.bucketName,
-          Prefix: `${this.provider.getDeploymentPrefix()}/${serviceStage}`,
+          Prefix: prefix,
           ...(ContinuationToken ? { ContinuationToken } : {}),
         });
 
@@ -71,7 +73,9 @@ module.exports = {
   async listObjectVersions() {
     this.objectsInBucket = [];
 
-    const serviceStage = `${this.serverless.service.service}/${this.provider.getStage()}`;
+    const prefix = `${this.provider.getDeploymentPrefix()}/${
+      this.serverless.service.service
+    }/${this.provider.getStage()}/`;
 
     try {
       let KeyMarker;
@@ -80,7 +84,7 @@ module.exports = {
       do {
         const result = await this.provider.request('S3', 'listObjectVersions', {
           Bucket: this.bucketName,
-          Prefix: `${this.provider.getDeploymentPrefix()}/${serviceStage}`,
+          Prefix: prefix,
           ...(KeyMarker ? { KeyMarker } : {}),
           ...(VersionIdMarker ? { VersionIdMarker } : {}),
         });

--- a/lib/plugins/aws/remove/lib/bucket.js
+++ b/lib/plugins/aws/remove/lib/bucket.js
@@ -40,76 +40,76 @@ module.exports = {
   },
 
   async listObjectsV2() {
-    this.objectsInBucket = [];
-
     const prefix = `${this.provider.getDeploymentPrefix()}/${
       this.serverless.service.service
     }/${this.provider.getStage()}/`;
 
-    try {
-      let ContinuationToken;
+    let ContinuationToken;
 
-      do {
-        const result = await this.provider.request('S3', 'listObjectsV2', {
+    do {
+      let result;
+
+      try {
+        result = await this.provider.request('S3', 'listObjectsV2', {
           Bucket: this.bucketName,
           Prefix: prefix,
           ...(ContinuationToken ? { ContinuationToken } : {}),
         });
+      } catch (err) {
+        if (isS3ListObjectsAccessDeniedError(err)) throw createS3ListObjectsAccessDeniedError();
+        throw err;
+      }
 
-        for (const object of result?.Contents || []) {
-          this.objectsInBucket.push({
-            Key: object.Key,
-          });
-        }
+      const pageObjects = (result?.Contents || []).map((object) => ({
+        Key: object.Key,
+      }));
 
-        ContinuationToken = result && result.NextContinuationToken;
-      } while (ContinuationToken);
-    } catch (err) {
-      if (isS3ListObjectsAccessDeniedError(err)) throw createS3ListObjectsAccessDeniedError();
-      throw err;
-    }
+      const nextContinuationToken = result && result.NextContinuationToken;
+      await this.deleteObjectBatches(pageObjects);
+      ContinuationToken = nextContinuationToken;
+    } while (ContinuationToken);
   },
 
   async listObjectVersions() {
-    this.objectsInBucket = [];
-
     const prefix = `${this.provider.getDeploymentPrefix()}/${
       this.serverless.service.service
     }/${this.provider.getStage()}/`;
 
-    try {
-      let KeyMarker;
-      let VersionIdMarker;
+    let KeyMarker;
+    let VersionIdMarker;
 
-      do {
-        const result = await this.provider.request('S3', 'listObjectVersions', {
+    do {
+      let result;
+
+      try {
+        result = await this.provider.request('S3', 'listObjectVersions', {
           Bucket: this.bucketName,
           Prefix: prefix,
           ...(KeyMarker ? { KeyMarker } : {}),
           ...(VersionIdMarker ? { VersionIdMarker } : {}),
         });
+      } catch (err) {
+        if (isS3ListObjectsAccessDeniedError(err)) throw createS3ListObjectsAccessDeniedError();
+        throw err;
+      }
 
-        for (const object of result?.Versions || []) {
-          this.objectsInBucket.push({
-            Key: object.Key,
-            VersionId: object.VersionId,
-          });
-        }
+      const pageObjects = [
+        ...(result?.Versions || []).map((object) => ({
+          Key: object.Key,
+          VersionId: object.VersionId,
+        })),
+        ...(result?.DeleteMarkers || []).map((object) => ({
+          Key: object.Key,
+          VersionId: object.VersionId,
+        })),
+      ];
 
-        for (const object of result?.DeleteMarkers || []) {
-          this.objectsInBucket.push({
-            Key: object.Key,
-            VersionId: object.VersionId,
-          });
-        }
-
-        KeyMarker = result && result.NextKeyMarker;
-        VersionIdMarker = result && result.NextVersionIdMarker;
-      } while (KeyMarker || VersionIdMarker);
-    } catch (err) {
-      if (isS3ListObjectsAccessDeniedError(err)) throw createS3ListObjectsAccessDeniedError();
-      throw err;
-    }
+      const nextKeyMarker = result && result.NextKeyMarker;
+      const nextVersionIdMarker = result && result.NextVersionIdMarker;
+      await this.deleteObjectBatches(pageObjects);
+      KeyMarker = nextKeyMarker;
+      VersionIdMarker = nextVersionIdMarker;
+    } while (KeyMarker || VersionIdMarker);
   },
 
   async listObjects() {
@@ -119,31 +119,31 @@ module.exports = {
       : this.listObjectsV2();
   },
 
-  async deleteObjects() {
-    if (this.objectsInBucket.length) {
-      for (let index = 0; index < this.objectsInBucket.length; index += maxDeleteObjectsCount) {
-        const batch = this.objectsInBucket.slice(index, index + maxDeleteObjectsCount);
-        const data = await this.provider.request('S3', 'deleteObjects', {
-          Bucket: this.bucketName,
-          Delete: {
-            Objects: batch,
-          },
-        });
-        if (data && data.Errors && data.Errors.length) {
-          const firstErrorCode = data.Errors[0].Code;
+  async deleteObjectBatches(objects) {
+    if (!objects.length) return;
 
-          if (firstErrorCode === 'AccessDenied') {
-            throw new ServerlessError(
-              `Could not empty the S3 deployment bucket (${this.bucketName}). Make sure that you have permissions that allow S3 objects deletion. First encountered S3 error code: ${firstErrorCode}`,
-              'CANNOT_DELETE_S3_OBJECTS_ACCESS_DENIED'
-            );
-          }
+    for (let index = 0; index < objects.length; index += maxDeleteObjectsCount) {
+      const batch = objects.slice(index, index + maxDeleteObjectsCount);
+      const data = await this.provider.request('S3', 'deleteObjects', {
+        Bucket: this.bucketName,
+        Delete: {
+          Objects: batch,
+        },
+      });
+      if (data && data.Errors && data.Errors.length) {
+        const firstErrorCode = data.Errors[0].Code;
 
+        if (firstErrorCode === 'AccessDenied') {
           throw new ServerlessError(
-            `Could not empty the S3 deployment bucket (${this.bucketName}). First encountered S3 error code: ${firstErrorCode}`,
-            'CANNOT_DELETE_S3_OBJECTS_GENERIC'
+            `Could not empty the S3 deployment bucket (${this.bucketName}). Make sure that you have permissions that allow S3 objects deletion. First encountered S3 error code: ${firstErrorCode}`,
+            'CANNOT_DELETE_S3_OBJECTS_ACCESS_DENIED'
           );
         }
+
+        throw new ServerlessError(
+          `Could not empty the S3 deployment bucket (${this.bucketName}). First encountered S3 error code: ${firstErrorCode}`,
+          'CANNOT_DELETE_S3_OBJECTS_GENERIC'
+        );
       }
     }
   },
@@ -152,7 +152,6 @@ module.exports = {
     await this.setServerlessDeploymentBucketName();
     if (this.bucketName && (await this.checkIfBucketExists(this.bucketName))) {
       await this.listObjects();
-      await this.deleteObjects();
     } else {
       log.info('S3 bucket not found. Skipping S3 bucket objects removal');
     }

--- a/lib/plugins/aws/rollback.js
+++ b/lib/plugins/aws/rollback.js
@@ -110,7 +110,7 @@ class AwsRollback {
     const serviceName = this.serverless.service.service;
     const stage = this.provider.getStage();
     const deploymentPrefix = this.provider.getDeploymentPrefix();
-    const prefix = `${deploymentPrefix}/${serviceName}/${stage}`;
+    const prefix = `${deploymentPrefix}/${serviceName}/${stage}/`;
 
     const response = { Contents: [] };
     try {
@@ -161,7 +161,7 @@ class AwsRollback {
       throw new ServerlessError(`${msg} ${hint}`, 'ROLLBACK_DEPLOYMENT_NOT_FOUND');
     }
 
-    service.package.artifactDirectoryName = `${prefix}/${dateString}`;
+    service.package.artifactDirectoryName = `${prefix}${dateString}`;
     const stateString = await (async () => {
       try {
         return (

--- a/lib/plugins/aws/rollback.js
+++ b/lib/plugins/aws/rollback.js
@@ -18,6 +18,26 @@ const slsConsoleLog = log.get('console');
 
 const mainProgress = progress.get('main');
 
+const getErrorCode = (error) =>
+  error && (error.code || error.Code || (error.providerError && error.providerError.code));
+
+const getErrorStatusCode = (error) =>
+  error && ((error.providerError && error.providerError.statusCode) || error.statusCode);
+
+const isS3ListObjectsAccessDeniedError = (error) =>
+  getErrorCode(error) === 'AWS_S3_LIST_OBJECTS_V2_ACCESS_DENIED' ||
+  getErrorCode(error) === 'AccessDenied' ||
+  getErrorStatusCode(error) === 403;
+
+const isS3GetObjectNoSuchKeyError = (error) =>
+  getErrorCode(error) === 'AWS_S3_GET_OBJECT_NO_SUCH_KEY' || getErrorCode(error) === 'NoSuchKey';
+
+const createS3ListObjectsAccessDeniedError = () =>
+  new ServerlessError(
+    'Could not list objects in the deployment bucket. Make sure you have sufficient permissions to access it.',
+    'AWS_S3_LIST_OBJECTS_V2_ACCESS_DENIED'
+  );
+
 class AwsRollback {
   constructor(serverless, options) {
     this.serverless = serverless;
@@ -92,19 +112,22 @@ class AwsRollback {
     const deploymentPrefix = this.provider.getDeploymentPrefix();
     const prefix = `${deploymentPrefix}/${serviceName}/${stage}`;
 
-    let response;
+    const response = { Contents: [] };
     try {
-      response = await this.provider.request('S3', 'listObjectsV2', {
-        Bucket: this.bucketName,
-        Prefix: prefix,
-      });
+      let ContinuationToken;
+
+      do {
+        const page = await this.provider.request('S3', 'listObjectsV2', {
+          Bucket: this.bucketName,
+          Prefix: prefix,
+          ...(ContinuationToken ? { ContinuationToken } : {}),
+        });
+
+        response.Contents.push(...(page?.Contents || []));
+        ContinuationToken = page && page.NextContinuationToken;
+      } while (ContinuationToken);
     } catch (err) {
-      if (err.code === 'AWS_S3_LIST_OBJECTS_V2_ACCESS_DENIED') {
-        throw new ServerlessError(
-          'Could not list objects in the deployment bucket. Make sure you have sufficient permissions to access it.',
-          err.code
-        );
-      }
+      if (isS3ListObjectsAccessDeniedError(err)) throw createS3ListObjectsAccessDeniedError();
       throw err;
     }
 
@@ -150,7 +173,7 @@ class AwsRollback {
           })
         ).Body;
       } catch (error) {
-        if (error.code === 'AWS_S3_GET_OBJECT_NO_SUCH_KEY') return null;
+        if (isS3GetObjectNoSuchKeyError(error)) return null;
         throw error;
       }
     })();

--- a/lib/plugins/aws/utils/find-and-group-deployments.js
+++ b/lib/plugins/aws/utils/find-and-group-deployments.js
@@ -1,21 +1,17 @@
 'use strict';
 
+const parseDeploymentObjectKey = require('./parse-deployment-object-key');
+
 module.exports = (s3Response, prefix, service, stage) => {
-  if (s3Response.Contents.length) {
-    const regex = new RegExp(`${prefix}/${service}/${stage}/(.+-.+-.+-.+)/(.+)`);
-    const s3Objects = s3Response.Contents.filter((s3Object) => s3Object.Key.match(regex));
-    const names = s3Objects.map((s3Object) => {
-      const match = s3Object.Key.match(regex);
-      return {
-        directory: match[1],
-        file: match[2],
-      };
-    });
-    const grouped = names.reduce((result, entry) => {
-      (result[entry.directory] ||= []).push(entry);
-      return result;
-    }, {});
-    return Object.values(grouped);
+  const grouped = new Map();
+
+  for (const s3Object of s3Response.Contents || []) {
+    const entry = parseDeploymentObjectKey(s3Object.Key, prefix, service, stage);
+    if (!entry) continue;
+
+    if (!grouped.has(entry.directory)) grouped.set(entry.directory, []);
+    grouped.get(entry.directory).push(entry);
   }
-  return [];
+
+  return Array.from(grouped.values());
 };

--- a/lib/plugins/aws/utils/parse-deployment-object-key.js
+++ b/lib/plugins/aws/utils/parse-deployment-object-key.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const isDeploymentDirToken = RegExp.prototype.test.bind(
+  /^[\d]+-\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+);
+
+module.exports = (key, prefix, service, stage) => {
+  if (!key) return null;
+
+  const base = `${prefix}/${service}/${stage}/`;
+  if (!key.startsWith(base)) return null;
+
+  const rest = key.slice(base.length);
+  const slashIndex = rest.indexOf('/');
+  if (slashIndex <= 0) return null;
+
+  const directory = rest.slice(0, slashIndex);
+  const file = rest.slice(slashIndex + 1);
+  if (!isDeploymentDirToken(directory) || !file) return null;
+
+  return { directory, file };
+};

--- a/test/unit/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.test.js
@@ -43,7 +43,7 @@ describe('cleanupS3Bucket', () => {
         expect(listObjectsStub).to.have.been.calledOnce;
         expect(listObjectsStub).to.have.been.calledWithExactly('S3', 'listObjectsV2', {
           Bucket: awsDeploy.bucketName,
-          Prefix: `${s3Key}`,
+          Prefix: `${s3Key}/`,
         });
         awsDeploy.provider.request.restore();
       });
@@ -97,7 +97,7 @@ describe('cleanupS3Bucket', () => {
         expect(listObjectsStub.calledOnce).to.be.equal(true);
         expect(listObjectsStub).to.have.been.calledWithExactly('S3', 'listObjectsV2', {
           Bucket: awsDeploy.bucketName,
-          Prefix: `${s3Key}`,
+          Prefix: `${s3Key}/`,
         });
         awsDeploy.provider.request.restore();
       });
@@ -132,7 +132,7 @@ describe('cleanupS3Bucket', () => {
           'listObjectsV2',
           {
             Bucket: awsDeploy.bucketName,
-            Prefix: `${s3Key}`,
+            Prefix: `${s3Key}/`,
           },
         ]);
         expect(listObjectsStub.secondCall.args).to.deep.equal([
@@ -140,7 +140,7 @@ describe('cleanupS3Bucket', () => {
           'listObjectsV2',
           {
             Bucket: awsDeploy.bucketName,
-            Prefix: `${s3Key}`,
+            Prefix: `${s3Key}/`,
             ContinuationToken: 'next-page',
           },
         ]);
@@ -169,7 +169,7 @@ describe('cleanupS3Bucket', () => {
         expect(listObjectsStub.calledOnce).to.be.equal(true);
         expect(listObjectsStub).to.have.been.calledWithExactly('S3', 'listObjectsV2', {
           Bucket: awsDeploy.bucketName,
-          Prefix: `${s3Key}`,
+          Prefix: `${s3Key}/`,
         });
         awsDeploy.provider.request.restore();
       });
@@ -196,7 +196,7 @@ describe('cleanupS3Bucket', () => {
         expect(listObjectsStub).to.have.been.calledOnce;
         expect(listObjectsStub).to.have.been.calledWithExactly('S3', 'listObjectsV2', {
           Bucket: awsDeploy.bucketName,
-          Prefix: `${s3Key}`,
+          Prefix: `${s3Key}/`,
         });
         awsDeploy.provider.request.restore();
       });
@@ -246,7 +246,7 @@ describe('cleanupS3Bucket', () => {
           expect(listObjectsStub.calledOnce).to.be.equal(true);
           expect(listObjectsStub).to.have.been.calledWithExactly('S3', 'listObjectsV2', {
             Bucket: awsDeploy.bucketName,
-            Prefix: `${s3Key}`,
+            Prefix: `${s3Key}/`,
           });
           awsDeploy.provider.request.restore();
         });
@@ -276,7 +276,7 @@ describe('cleanupS3Bucket', () => {
           expect(listObjectsStub.calledOnce).to.be.equal(true);
           expect(listObjectsStub).to.have.been.calledWithExactly('S3', 'listObjectsV2', {
             Bucket: awsDeploy.bucketName,
-            Prefix: `${s3Key}`,
+            Prefix: `${s3Key}/`,
           });
           awsDeploy.provider.request.restore();
         });

--- a/test/unit/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.test.js
@@ -103,6 +103,53 @@ describe('cleanupS3Bucket', () => {
       });
     });
 
+    it('should list all paginated deployment objects before selecting objects to remove', async () => {
+      serverless.service.provider.deploymentBucketObject = {
+        maxPreviousDeploymentArtifacts: 1,
+      };
+      const oldKey = `${s3Key}/141264711231-2016-08-18T15:43:00/artifact.zip`;
+      const newKey = `${s3Key}/151224711231-2016-08-18T15:42:00/artifact.zip`;
+      const listObjectsStub = sinon.stub(awsDeploy.provider, 'request');
+      listObjectsStub
+        .withArgs('S3', 'listObjectsV2')
+        .onFirstCall()
+        .resolves({
+          Contents: [{ Key: oldKey }],
+          NextContinuationToken: 'next-page',
+        })
+        .onSecondCall()
+        .resolves({
+          Contents: [{ Key: newKey }],
+        });
+
+      try {
+        const objectsToRemove = await awsDeploy.getObjectsToRemove();
+
+        expect(objectsToRemove).to.deep.equal([{ Key: oldKey }]);
+        expect(listObjectsStub).to.have.been.calledTwice;
+        expect(listObjectsStub.firstCall.args).to.deep.equal([
+          'S3',
+          'listObjectsV2',
+          {
+            Bucket: awsDeploy.bucketName,
+            Prefix: `${s3Key}`,
+          },
+        ]);
+        expect(listObjectsStub.secondCall.args).to.deep.equal([
+          'S3',
+          'listObjectsV2',
+          {
+            Bucket: awsDeploy.bucketName,
+            Prefix: `${s3Key}`,
+            ContinuationToken: 'next-page',
+          },
+        ]);
+      } finally {
+        awsDeploy.provider.request.restore();
+        delete serverless.service.provider.deploymentBucketObject;
+      }
+    });
+
     it('should return an empty array if there are less than 4 directories available', async () => {
       const serviceObjects = {
         Contents: [
@@ -244,6 +291,10 @@ describe('cleanupS3Bucket', () => {
       deleteObjectsStub = sinon.stub(awsDeploy.provider, 'request').resolves();
     });
 
+    afterEach(() => {
+      if (awsDeploy.provider.request.restore) awsDeploy.provider.request.restore();
+    });
+
     it('should resolve if no service objects are found in the S3 bucket', async () =>
       awsDeploy.removeObjects().then(() => {
         expect(deleteObjectsStub.calledOnce).to.be.equal(false);
@@ -268,6 +319,95 @@ describe('cleanupS3Bucket', () => {
         });
         awsDeploy.provider.request.restore();
       });
+    });
+
+    it('should remove service files in batches of 1000 objects', async () => {
+      const objectsToRemove = Array.from({ length: 1001 }, (ignored, index) => ({
+        Key: `${s3Key}/artifact-${index}.zip`,
+      }));
+
+      await awsDeploy.removeObjects(objectsToRemove);
+
+      expect(deleteObjectsStub).to.have.been.calledTwice;
+      expect(deleteObjectsStub.firstCall.args).to.deep.equal([
+        'S3',
+        'deleteObjects',
+        {
+          Bucket: awsDeploy.bucketName,
+          Delete: {
+            Objects: objectsToRemove.slice(0, 1000),
+          },
+        },
+      ]);
+      expect(deleteObjectsStub.secondCall.args).to.deep.equal([
+        'S3',
+        'deleteObjects',
+        {
+          Bucket: awsDeploy.bucketName,
+          Delete: {
+            Objects: objectsToRemove.slice(1000),
+          },
+        },
+      ]);
+    });
+
+    it('should fail when a delete objects batch returns a generic partial failure', async () => {
+      deleteObjectsStub.resolves({
+        Errors: [{ Code: 'InternalError' }],
+      });
+
+      await expect(
+        awsDeploy.removeObjects([{ Key: `${s3Key}/artifact.zip` }])
+      ).to.be.eventually.rejected.and.have.property('code', 'CANNOT_DELETE_S3_OBJECTS_GENERIC');
+    });
+
+    it('should fail when a delete objects batch returns an access denied partial failure', async () => {
+      deleteObjectsStub.resolves({
+        Errors: [{ Code: 'AccessDenied' }],
+      });
+
+      await expect(
+        awsDeploy.removeObjects([{ Key: `${s3Key}/artifact.zip` }])
+      ).to.be.eventually.rejected.and.have.property(
+        'code',
+        'CANNOT_DELETE_S3_OBJECTS_ACCESS_DENIED'
+      );
+    });
+  });
+
+  describe('#cleanupArtifactsForEmptyChangeSet()', () => {
+    it('should remove artifacts from all listed pages', async () => {
+      const deploymentDirectory = '151224711231-2016-08-18T15:42:00';
+      const firstKey = `${s3Key}/${deploymentDirectory}/artifact.zip`;
+      const secondKey = `${s3Key}/${deploymentDirectory}/compiled-cloudformation-template.json`;
+      const requestStub = sinon.stub(awsDeploy.provider, 'request');
+      awsDeploy.serverless.service.package.artifactDirectoryName = `${s3Key}/${deploymentDirectory}`;
+      requestStub
+        .withArgs('S3', 'listObjectsV2')
+        .onFirstCall()
+        .resolves({
+          Contents: [{ Key: firstKey }],
+          NextContinuationToken: 'next-page',
+        })
+        .onSecondCall()
+        .resolves({ Contents: [{ Key: secondKey }] });
+      requestStub.withArgs('S3', 'deleteObjects').resolves();
+
+      try {
+        await awsDeploy.cleanupArtifactsForEmptyChangeSet();
+
+        const deleteCall = requestStub
+          .getCalls()
+          .find((call) => call.args[0] === 'S3' && call.args[1] === 'deleteObjects');
+        expect(deleteCall.args[2]).to.deep.equal({
+          Bucket: awsDeploy.bucketName,
+          Delete: {
+            Objects: [{ Key: firstKey }, { Key: secondKey }],
+          },
+        });
+      } finally {
+        awsDeploy.provider.request.restore();
+      }
     });
   });
 

--- a/test/unit/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.test.js
@@ -153,12 +153,12 @@ describe('cleanupS3Bucket', () => {
     it('should return an empty array if there are less than 4 directories available', async () => {
       const serviceObjects = {
         Contents: [
-          { Key: `${s3Key}151224711231-2016-08-18T15:42:00/artifact.zip` },
-          { Key: `${s3Key}151224711231-2016-08-18T15:42:00/cloudformation.json` },
-          { Key: `${s3Key}141264711231-2016-08-18T15:42:00/artifact.zip` },
-          { Key: `${s3Key}141264711231-2016-08-18T15:42:00/cloudformation.json` },
-          { Key: `${s3Key}141321321541-2016-08-18T11:23:02/artifact.zip` },
-          { Key: `${s3Key}141321321541-2016-08-18T11:23:02/cloudformation.json` },
+          { Key: `${s3Key}/151224711231-2016-08-18T15:42:00/artifact.zip` },
+          { Key: `${s3Key}/151224711231-2016-08-18T15:42:00/cloudformation.json` },
+          { Key: `${s3Key}/141264711231-2016-08-18T15:42:00/artifact.zip` },
+          { Key: `${s3Key}/141264711231-2016-08-18T15:42:00/cloudformation.json` },
+          { Key: `${s3Key}/141321321541-2016-08-18T11:23:02/artifact.zip` },
+          { Key: `${s3Key}/141321321541-2016-08-18T11:23:02/cloudformation.json` },
         ],
       };
 
@@ -178,14 +178,14 @@ describe('cleanupS3Bucket', () => {
     it('should return an empty array if there are exactly 4 directories available', async () => {
       const serviceObjects = {
         Contents: [
-          { Key: `${s3Key}151224711231-2016-08-18T15:42:00/artifact.zip` },
-          { Key: `${s3Key}151224711231-2016-08-18T15:42:00/cloudformation.json` },
-          { Key: `${s3Key}141264711231-2016-08-18T15:42:00/artifact.zip` },
-          { Key: `${s3Key}141264711231-2016-08-18T15:42:00/cloudformation.json` },
-          { Key: `${s3Key}141321321541-2016-08-18T11:23:02/artifact.zip` },
-          { Key: `${s3Key}141321321541-2016-08-18T11:23:02/cloudformation.json` },
-          { Key: `${s3Key}142003031341-2016-08-18T12:46:04/artifact.zip` },
-          { Key: `${s3Key}142003031341-2016-08-18T12:46:04/cloudformation.json` },
+          { Key: `${s3Key}/151224711231-2016-08-18T15:42:00/artifact.zip` },
+          { Key: `${s3Key}/151224711231-2016-08-18T15:42:00/cloudformation.json` },
+          { Key: `${s3Key}/141264711231-2016-08-18T15:42:00/artifact.zip` },
+          { Key: `${s3Key}/141264711231-2016-08-18T15:42:00/cloudformation.json` },
+          { Key: `${s3Key}/141321321541-2016-08-18T11:23:02/artifact.zip` },
+          { Key: `${s3Key}/141321321541-2016-08-18T11:23:02/cloudformation.json` },
+          { Key: `${s3Key}/142003031341-2016-08-18T12:46:04/artifact.zip` },
+          { Key: `${s3Key}/142003031341-2016-08-18T12:46:04/cloudformation.json` },
         ],
       };
 
@@ -303,10 +303,10 @@ describe('cleanupS3Bucket', () => {
 
     it('should remove all old service files from the S3 bucket if available', async () => {
       const objectsToRemove = [
-        { Key: `${s3Key}113304333331-2016-08-18T13:40:06/artifact.zip` },
-        { Key: `${s3Key}113304333331-2016-08-18T13:40:06/cloudformation.json` },
-        { Key: `${s3Key}141264711231-2016-08-18T15:42:00/artifact.zip` },
-        { Key: `${s3Key}141264711231-2016-08-18T15:42:00/cloudformation.json` },
+        { Key: `${s3Key}/113304333331-2016-08-18T13:40:06/artifact.zip` },
+        { Key: `${s3Key}/113304333331-2016-08-18T13:40:06/cloudformation.json` },
+        { Key: `${s3Key}/141264711231-2016-08-18T15:42:00/artifact.zip` },
+        { Key: `${s3Key}/141264711231-2016-08-18T15:42:00/cloudformation.json` },
       ];
 
       return awsDeploy.removeObjects(objectsToRemove).then(() => {
@@ -405,6 +405,28 @@ describe('cleanupS3Bucket', () => {
             Objects: [{ Key: firstKey }, { Key: secondKey }],
           },
         });
+      } finally {
+        awsDeploy.provider.request.restore();
+      }
+    });
+
+    it('should not rewrite delete failures as list failures', async () => {
+      const deploymentDirectory = '151224711231-2016-08-18T15:42:00';
+      const artifactKey = `${s3Key}/${deploymentDirectory}/artifact.zip`;
+      const deleteError = new Error('delete denied');
+      deleteError.statusCode = 403;
+      const requestStub = sinon.stub(awsDeploy.provider, 'request');
+      awsDeploy.serverless.service.package.artifactDirectoryName = `${s3Key}/${deploymentDirectory}`;
+      requestStub.withArgs('S3', 'listObjectsV2').resolves({
+        Contents: [{ Key: artifactKey }],
+      });
+      requestStub.withArgs('S3', 'deleteObjects').rejects(deleteError);
+
+      try {
+        await awsDeploy.cleanupArtifactsForEmptyChangeSet();
+        throw new Error('Expected cleanupArtifactsForEmptyChangeSet to reject');
+      } catch (error) {
+        expect(error).to.equal(deleteError);
       } finally {
         awsDeploy.provider.request.restore();
       }

--- a/test/unit/lib/plugins/aws/remove/index.test.js
+++ b/test/unit/lib/plugins/aws/remove/index.test.js
@@ -135,7 +135,7 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     });
   });
 
-  it('lists all paginated S3 objects before deleting bucket contents', async () => {
+  it('deletes each page of S3 objects as it is listed', async () => {
     const listObjectsV2Stub = sinon
       .stub()
       .onFirstCall()
@@ -170,12 +170,22 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       Prefix: `serverless/${serverless.service.service}/dev/`,
       ContinuationToken: 'next-page',
     });
-    expect(innerDeleteObjectsStub).to.be.calledWithExactly({
+    expect(innerDeleteObjectsStub).to.have.been.calledTwice;
+    expect(innerDeleteObjectsStub.firstCall.args[0]).to.deep.equal({
       Bucket: 'resource-id',
       Delete: {
-        Objects: [{ Key: 'first' }, { Key: 'second' }],
+        Objects: [{ Key: 'first' }],
       },
     });
+    expect(innerDeleteObjectsStub.secondCall.args[0]).to.deep.equal({
+      Bucket: 'resource-id',
+      Delete: {
+        Objects: [{ Key: 'second' }],
+      },
+    });
+    expect(innerDeleteObjectsStub.firstCall.calledAfter(listObjectsV2Stub.firstCall)).to.be.true;
+    expect(listObjectsV2Stub.secondCall.calledAfter(innerDeleteObjectsStub.firstCall)).to.be.true;
+    expect(innerDeleteObjectsStub.secondCall.calledAfter(listObjectsV2Stub.secondCall)).to.be.true;
   });
 
   it('deletes S3 bucket objects in batches of 1000', async () => {
@@ -365,7 +375,7 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     });
   });
 
-  it('should list and delete paginated object versions and delete markers', async () => {
+  it('deletes each page of object versions as it is listed', async () => {
     const listObjectVersionsStub = sinon
       .stub()
       .onFirstCall()
@@ -413,15 +423,25 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       KeyMarker: 'next-key',
       VersionIdMarker: 'next-version',
     });
-    expect(innerDeleteObjectsStub).to.be.calledWithExactly({
+    expect(innerDeleteObjectsStub).to.have.been.calledTwice;
+    expect(innerDeleteObjectsStub.firstCall.args[0]).to.deep.equal({
       Bucket: 'bucket',
       Delete: {
-        Objects: [
-          { Key: 'object1', VersionId: 'v1' },
-          { Key: 'object2', VersionId: 'v2' },
-        ],
+        Objects: [{ Key: 'object1', VersionId: 'v1' }],
       },
     });
+    expect(innerDeleteObjectsStub.secondCall.args[0]).to.deep.equal({
+      Bucket: 'bucket',
+      Delete: {
+        Objects: [{ Key: 'object2', VersionId: 'v2' }],
+      },
+    });
+    expect(innerDeleteObjectsStub.firstCall.calledAfter(listObjectVersionsStub.firstCall)).to.be
+      .true;
+    expect(listObjectVersionsStub.secondCall.calledAfter(innerDeleteObjectsStub.firstCall)).to.be
+      .true;
+    expect(innerDeleteObjectsStub.secondCall.calledAfter(listObjectVersionsStub.secondCall)).to.be
+      .true;
   });
 
   it('should throw an error when cannot list object versions from the bucket', async () => {
@@ -476,6 +496,30 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
         },
       })
     ).to.be.eventually.rejected.and.have.property('code', 'CANNOT_DELETE_S3_OBJECTS_GENERIC');
+  });
+
+  it('does not rewrite deleteObjects access denied failures as list failures', async () => {
+    const deleteError = new Error('delete denied');
+    deleteError.code = 'AccessDenied';
+
+    try {
+      await runServerless({
+        command: 'remove',
+        fixture: 'function',
+        awsRequestStubMap: {
+          ...awsRequestStubMap,
+          S3: {
+            ...awsRequestStubMap.S3,
+            listObjectsV2: { Contents: [{ Key: 'first' }] },
+            deleteObjects: sinon.stub().rejects(deleteError),
+            headBucket: {},
+          },
+        },
+      });
+      throw new Error('Expected remove to reject');
+    } catch (error) {
+      expect(error).to.equal(deleteError);
+    }
   });
 
   it('should throw an error when deleteObjects operation was not successfull due to "AccessDenied"', async () => {

--- a/test/unit/lib/plugins/aws/remove/index.test.js
+++ b/test/unit/lib/plugins/aws/remove/index.test.js
@@ -135,6 +135,71 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     });
   });
 
+  it('lists all paginated S3 objects before deleting bucket contents', async () => {
+    const listObjectsV2Stub = sinon
+      .stub()
+      .onFirstCall()
+      .returns({
+        Contents: [{ Key: 'first' }],
+        NextContinuationToken: 'next-page',
+      })
+      .onSecondCall()
+      .returns({ Contents: [{ Key: 'second' }] });
+    const innerDeleteObjectsStub = sinon.stub().resolves();
+
+    await runServerless({
+      fixture: 'function',
+      command: 'remove',
+      awsRequestStubMap: {
+        ...awsRequestStubMap,
+        S3: {
+          deleteObjects: innerDeleteObjectsStub,
+          listObjectsV2: listObjectsV2Stub,
+          headBucket: {},
+        },
+      },
+    });
+
+    expect(listObjectsV2Stub).to.have.been.calledTwice;
+    expect(listObjectsV2Stub.secondCall.args[0]).to.include({
+      Bucket: 'resource-id',
+      ContinuationToken: 'next-page',
+    });
+    expect(innerDeleteObjectsStub).to.be.calledWithExactly({
+      Bucket: 'resource-id',
+      Delete: {
+        Objects: [{ Key: 'first' }, { Key: 'second' }],
+      },
+    });
+  });
+
+  it('deletes S3 bucket objects in batches of 1000', async () => {
+    const objects = Array.from({ length: 1001 }, (ignored, index) => ({ Key: `object-${index}` }));
+    const innerDeleteObjectsStub = sinon.stub().resolves();
+
+    await runServerless({
+      fixture: 'function',
+      command: 'remove',
+      awsRequestStubMap: {
+        ...awsRequestStubMap,
+        S3: {
+          deleteObjects: innerDeleteObjectsStub,
+          listObjectsV2: { Contents: objects },
+          headBucket: {},
+        },
+      },
+    });
+
+    expect(innerDeleteObjectsStub).to.have.been.calledTwice;
+    expect(innerDeleteObjectsStub.firstCall.args[0].Delete.Objects).to.have.lengthOf(1000);
+    expect(innerDeleteObjectsStub.secondCall.args[0]).to.deep.equal({
+      Bucket: 'resource-id',
+      Delete: {
+        Objects: objects.slice(1000),
+      },
+    });
+  });
+
   it('skips attempts to remove S3 objects if S3 bucket not found', async () => {
     const { awsNaming } = await runServerless({
       fixture: 'function',
@@ -293,6 +358,93 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
         ],
       },
     });
+  });
+
+  it('should list and delete paginated object versions and delete markers', async () => {
+    const listObjectVersionsStub = sinon
+      .stub()
+      .onFirstCall()
+      .returns({
+        Versions: [{ Key: 'object1', VersionId: 'v1' }],
+        NextKeyMarker: 'next-key',
+        NextVersionIdMarker: 'next-version',
+      })
+      .onSecondCall()
+      .returns({
+        DeleteMarkers: [{ Key: 'object2', VersionId: 'v2' }],
+      });
+    const innerDeleteObjectsStub = sinon.stub().resolves();
+
+    const { serverless } = await runServerless({
+      command: 'remove',
+      fixture: 'function',
+      configExt: {
+        provider: {
+          deploymentPrefix: 'serverless',
+          deploymentBucket: {
+            name: 'bucket',
+            versioning: true,
+          },
+        },
+      },
+      awsRequestStubMap: {
+        ...awsRequestStubMap,
+        S3: {
+          listObjectVersions: listObjectVersionsStub,
+          deleteObjects: innerDeleteObjectsStub,
+          headBucket: {},
+        },
+      },
+    });
+
+    expect(listObjectVersionsStub).to.have.been.calledTwice;
+    expect(listObjectVersionsStub.firstCall.args[0]).to.deep.equal({
+      Bucket: 'bucket',
+      Prefix: `serverless/${serverless.service.service}/dev`,
+    });
+    expect(listObjectVersionsStub.secondCall.args[0]).to.deep.equal({
+      Bucket: 'bucket',
+      Prefix: `serverless/${serverless.service.service}/dev`,
+      KeyMarker: 'next-key',
+      VersionIdMarker: 'next-version',
+    });
+    expect(innerDeleteObjectsStub).to.be.calledWithExactly({
+      Bucket: 'bucket',
+      Delete: {
+        Objects: [
+          { Key: 'object1', VersionId: 'v1' },
+          { Key: 'object2', VersionId: 'v2' },
+        ],
+      },
+    });
+  });
+
+  it('should throw an error when cannot list object versions from the bucket', async () => {
+    await expect(
+      runServerless({
+        command: 'remove',
+        fixture: 'function',
+        configExt: {
+          provider: {
+            deploymentBucket: {
+              name: 'bucket',
+              versioning: true,
+            },
+          },
+        },
+        awsRequestStubMap: {
+          ...awsRequestStubMap,
+          S3: {
+            listObjectVersions: () => {
+              const err = new Error('ff');
+              err.providerError = { statusCode: 403 };
+              throw err;
+            },
+            headBucket: {},
+          },
+        },
+      })
+    ).to.be.eventually.rejected.and.have.property('code', 'AWS_S3_LIST_OBJECTS_V2_ACCESS_DENIED');
   });
 
   it('should throw an error when deleteObjects operation was not successfull', async () => {

--- a/test/unit/lib/plugins/aws/remove/index.test.js
+++ b/test/unit/lib/plugins/aws/remove/index.test.js
@@ -147,7 +147,7 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       .returns({ Contents: [{ Key: 'second' }] });
     const innerDeleteObjectsStub = sinon.stub().resolves();
 
-    await runServerless({
+    const { serverless } = await runServerless({
       fixture: 'function',
       command: 'remove',
       awsRequestStubMap: {
@@ -161,8 +161,13 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     });
 
     expect(listObjectsV2Stub).to.have.been.calledTwice;
+    expect(listObjectsV2Stub.firstCall.args[0]).to.include({
+      Bucket: 'resource-id',
+      Prefix: `serverless/${serverless.service.service}/dev/`,
+    });
     expect(listObjectsV2Stub.secondCall.args[0]).to.include({
       Bucket: 'resource-id',
+      Prefix: `serverless/${serverless.service.service}/dev/`,
       ContinuationToken: 'next-page',
     });
     expect(innerDeleteObjectsStub).to.be.calledWithExactly({
@@ -300,7 +305,7 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
 
     expect(listObjectVersionsStub).to.be.calledWithExactly({
       Bucket: 'bucket',
-      Prefix: `serverless/${serverless.service.service}/dev`,
+      Prefix: `serverless/${serverless.service.service}/dev/`,
     });
   });
 
@@ -345,7 +350,7 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
 
     expect(listObjectVersionsStub).to.be.calledWithExactly({
       Bucket: 'bucket',
-      Prefix: `serverless/${serverless.service.service}/dev`,
+      Prefix: `serverless/${serverless.service.service}/dev/`,
     });
 
     expect(innerDeleteObjectsStub).to.be.calledWithExactly({
@@ -400,11 +405,11 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     expect(listObjectVersionsStub).to.have.been.calledTwice;
     expect(listObjectVersionsStub.firstCall.args[0]).to.deep.equal({
       Bucket: 'bucket',
-      Prefix: `serverless/${serverless.service.service}/dev`,
+      Prefix: `serverless/${serverless.service.service}/dev/`,
     });
     expect(listObjectVersionsStub.secondCall.args[0]).to.deep.equal({
       Bucket: 'bucket',
-      Prefix: `serverless/${serverless.service.service}/dev`,
+      Prefix: `serverless/${serverless.service.service}/dev/`,
       KeyMarker: 'next-key',
       VersionIdMarker: 'next-version',
     });

--- a/test/unit/lib/plugins/aws/rollback.test.js
+++ b/test/unit/lib/plugins/aws/rollback.test.js
@@ -130,7 +130,7 @@ describe('AwsRollback', () => {
           expect(
             listObjectsStub.calledWithExactly('S3', 'listObjectsV2', {
               Bucket: awsRollback.bucketName,
-              Prefix: `${s3Key}`,
+              Prefix: `${s3Key}/`,
             })
           ).to.be.equal(true);
           awsRollback.provider.request.restore();
@@ -163,7 +163,7 @@ describe('AwsRollback', () => {
           expect(
             listObjectsStub.calledWithExactly('S3', 'listObjectsV2', {
               Bucket: awsRollback.bucketName,
-              Prefix: `${s3Key}`,
+              Prefix: `${s3Key}/`,
             })
           ).to.be.equal(true);
           awsRollback.provider.request.restore();
@@ -192,7 +192,7 @@ describe('AwsRollback', () => {
         expect(
           listObjectsStub.calledWithExactly('S3', 'listObjectsV2', {
             Bucket: awsRollback.bucketName,
-            Prefix: `${s3Key}`,
+            Prefix: `${s3Key}/`,
           })
         ).to.be.equal(true);
         awsRollback.provider.request.restore();
@@ -228,7 +228,7 @@ describe('AwsRollback', () => {
         'listObjectsV2',
         {
           Bucket: awsRollback.bucketName,
-          Prefix: `${s3Key}`,
+          Prefix: `${s3Key}/`,
           ContinuationToken: 'next-page',
         },
       ]);

--- a/test/unit/lib/plugins/aws/rollback.test.js
+++ b/test/unit/lib/plugins/aws/rollback.test.js
@@ -40,6 +40,7 @@ describe('AwsRollback', () => {
   );
 
   afterEach(() => {
+    if (provider.request.restore) provider.request.restore();
     serverless.pluginManager.spawn.restore();
   });
 
@@ -196,6 +197,97 @@ describe('AwsRollback', () => {
         ).to.be.equal(true);
         awsRollback.provider.request.restore();
       });
+    });
+
+    it('should resolve when the target deployment is found on a later S3 page', async () => {
+      const requestStub = sinon.stub(awsRollback.provider, 'request');
+      requestStub
+        .withArgs('S3', 'listObjectsV2')
+        .onFirstCall()
+        .resolves({
+          Contents: [],
+          NextContinuationToken: 'next-page',
+        })
+        .onSecondCall()
+        .resolves({
+          Contents: [
+            {
+              Key: 'serverless/rollback/dev/1476779096930-2016-10-18T08:24:56.930Z/compiled-cloudformation-template.json',
+            },
+          ],
+        });
+      requestStub.withArgs('S3', 'getObject').resolves({ Body: '{}' });
+
+      await awsRollback.setStackToUpdate();
+
+      expect(awsRollback.serverless.service.package.artifactDirectoryName).to.equal(
+        'serverless/rollback/dev/1476779096930-2016-10-18T08:24:56.930Z'
+      );
+      expect(requestStub.secondCall.args).to.deep.equal([
+        'S3',
+        'listObjectsV2',
+        {
+          Bucket: awsRollback.bucketName,
+          Prefix: `${s3Key}`,
+          ContinuationToken: 'next-page',
+        },
+      ]);
+    });
+
+    it('should read the state file for the selected deployment', async () => {
+      const requestStub = sinon.stub(awsRollback.provider, 'request');
+      requestStub.withArgs('S3', 'listObjectsV2').resolves({
+        Contents: [
+          {
+            Key: 'serverless/rollback/dev/1476779096930-2016-10-18T08:24:56.930Z/compiled-cloudformation-template.json',
+          },
+        ],
+      });
+      requestStub.withArgs('S3', 'getObject').resolves({
+        Body: JSON.stringify({ service: { service: 'rollback' } }),
+      });
+
+      await awsRollback.setStackToUpdate();
+
+      expect(requestStub).to.have.been.calledWithExactly('S3', 'getObject', {
+        Bucket: awsRollback.bucketName,
+        Key: 'serverless/rollback/dev/1476779096930-2016-10-18T08:24:56.930Z/serverless-state.json',
+      });
+    });
+
+    it('should continue when the selected deployment has no state file', async () => {
+      const requestStub = sinon.stub(awsRollback.provider, 'request');
+      requestStub.withArgs('S3', 'listObjectsV2').resolves({
+        Contents: [
+          {
+            Key: 'serverless/rollback/dev/1476779096930-2016-10-18T08:24:56.930Z/compiled-cloudformation-template.json',
+          },
+        ],
+      });
+      requestStub.withArgs('S3', 'getObject').throws({
+        code: 'AWS_S3_GET_OBJECT_NO_SUCH_KEY',
+      });
+
+      await expect(awsRollback.setStackToUpdate()).to.eventually.be.fulfilled;
+    });
+
+    it('should reject rollback for unsupported console deployment state', async () => {
+      const requestStub = sinon.stub(awsRollback.provider, 'request');
+      requestStub.withArgs('S3', 'listObjectsV2').resolves({
+        Contents: [
+          {
+            Key: 'serverless/rollback/dev/1476779096930-2016-10-18T08:24:56.930Z/compiled-cloudformation-template.json',
+          },
+        ],
+      });
+      requestStub.withArgs('S3', 'getObject').resolves({
+        Body: JSON.stringify({ console: true }),
+      });
+
+      await expect(awsRollback.setStackToUpdate()).to.be.eventually.rejected.and.have.property(
+        'code',
+        'CONSOLE_ACTIVATION_MISMATCH_ROLLBACK'
+      );
     });
   });
 });

--- a/test/unit/lib/plugins/aws/utils/find-and-group-deployments.test.js
+++ b/test/unit/lib/plugins/aws/utils/find-and-group-deployments.test.js
@@ -12,6 +12,10 @@ describe('#findAndGroupDeployments()', () => {
     expect(findAndGroupDeployments(s3Response, 'serverless', 'test', 'dev')).to.deep.equal([]);
   });
 
+  it('should return an empty result when Contents is missing', () => {
+    expect(findAndGroupDeployments({}, 'serverless', 'test', 'dev')).to.deep.equal([]);
+  });
+
   it('should group stacks', () => {
     const s3Objects = [
       {
@@ -73,5 +77,48 @@ describe('#findAndGroupDeployments()', () => {
     expect(findAndGroupDeployments(s3Response, 'serverless', 'test', 'dev')).to.deep.equal(
       expected
     );
+  });
+
+  it('should group deployment keys with regex-significant service, stage, and prefix values', () => {
+    const s3Response = {
+      Contents: [
+        {
+          Key: 'serverless.v1/service+name/dev.prod/1476779096930-2016-10-18T08:24:56.930Z/artifact.zip',
+        },
+        {
+          Key: 'serverlessXv1/service+name/dev.prod/1476779096930-2016-10-18T08:24:56.930Z/ignored.zip',
+        },
+      ],
+    };
+
+    expect(
+      findAndGroupDeployments(s3Response, 'serverless.v1', 'service+name', 'dev.prod')
+    ).to.deep.equal([
+      [
+        {
+          directory: '1476779096930-2016-10-18T08:24:56.930Z',
+          file: 'artifact.zip',
+        },
+      ],
+    ]);
+  });
+
+  it('should preserve nested object paths inside deployment directories', () => {
+    const s3Response = {
+      Contents: [
+        {
+          Key: 'serverless/test/dev/1476779096930-2016-10-18T08:24:56.930Z/nested/artifact.zip',
+        },
+      ],
+    };
+
+    expect(findAndGroupDeployments(s3Response, 'serverless', 'test', 'dev')).to.deep.equal([
+      [
+        {
+          directory: '1476779096930-2016-10-18T08:24:56.930Z',
+          file: 'nested/artifact.zip',
+        },
+      ],
+    ]);
   });
 });

--- a/test/unit/lib/plugins/aws/utils/parse-deployment-object-key.test.js
+++ b/test/unit/lib/plugins/aws/utils/parse-deployment-object-key.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const { expect } = require('chai');
+const parseDeploymentObjectKey = require('../../../../../../lib/plugins/aws/utils/parse-deployment-object-key');
+
+describe('test/unit/lib/plugins/aws/utils/parse-deployment-object-key.test.js', () => {
+  it('parses a valid deployment object key', () => {
+    expect(
+      parseDeploymentObjectKey(
+        'serverless/test/dev/151224711231-2016-08-18T15:43:00/artifact.zip',
+        'serverless',
+        'test',
+        'dev'
+      )
+    ).to.deep.equal({
+      directory: '151224711231-2016-08-18T15:43:00',
+      file: 'artifact.zip',
+    });
+  });
+
+  it('preserves nested file paths after the deployment directory', () => {
+    expect(
+      parseDeploymentObjectKey(
+        'serverless/test/dev/151224711231-2016-08-18T15:43:00/nested/artifact.zip',
+        'serverless',
+        'test',
+        'dev'
+      )
+    ).to.deep.equal({
+      directory: '151224711231-2016-08-18T15:43:00',
+      file: 'nested/artifact.zip',
+    });
+  });
+
+  for (const [description, key, prefix, service, stage] of [
+    [
+      'wrong prefix',
+      'other/test/dev/151224711231-2016-08-18T15:43:00/artifact.zip',
+      'serverless',
+      'test',
+      'dev',
+    ],
+    [
+      'wrong service',
+      'serverless/other/dev/151224711231-2016-08-18T15:43:00/artifact.zip',
+      'serverless',
+      'test',
+      'dev',
+    ],
+    [
+      'wrong stage',
+      'serverless/test/prod/151224711231-2016-08-18T15:43:00/artifact.zip',
+      'serverless',
+      'test',
+      'dev',
+    ],
+    [
+      'missing file',
+      'serverless/test/dev/151224711231-2016-08-18T15:43:00/',
+      'serverless',
+      'test',
+      'dev',
+    ],
+    [
+      'non deployment directory',
+      'serverless/test/dev/not-a-deployment/artifact.zip',
+      'serverless',
+      'test',
+      'dev',
+    ],
+  ]) {
+    it(`returns null for ${description}`, () => {
+      expect(parseDeploymentObjectKey(key, prefix, service, stage)).to.equal(null);
+    });
+  }
+
+  it('returns null when key is empty or missing', () => {
+    expect(parseDeploymentObjectKey('', 'serverless', 'test', 'dev')).to.equal(null);
+    expect(parseDeploymentObjectKey(null, 'serverless', 'test', 'dev')).to.equal(null);
+  });
+});


### PR DESCRIPTION
Add pagination for listObjectsV2 and listObjectVersions calls to handle buckets with more than 1000 objects. Batch deleteObjects calls to respect the S3 API limit of 1000 keys per request. Replace regex-based deployment key parsing with literal string matching to avoid incorrect matches when service, stage, or prefix values contain regex-significant characters.