### PR TITLE
Stream layer artifact hashing to avoid buffering whole zip

### DIFF
--- a/lib/plugins/aws/package/compile/layers.js
+++ b/lib/plugins/aws/package/compile/layers.js
@@ -16,7 +16,7 @@ const getLayerArtifactHash = async (layerArtifactPath, layerForHash) =>
       .on('data', (chunk) => {
         sha.update(chunk);
       })
-      .on('end', () => {
+      .on('close', () => {
         resolve(sha.digest('hex'));
       })
       .on('error', reject);

--- a/lib/plugins/aws/package/compile/layers.js
+++ b/lib/plugins/aws/package/compile/layers.js
@@ -2,9 +2,25 @@
 
 const crypto = require('crypto');
 const path = require('path');
-const fsp = require('fs').promises;
+const fs = require('fs');
 const getLambdaLayerArtifactPath = require('../../utils/get-lambda-layer-artifact-path');
 const { log } = require('../../../../utils/serverless-utils/log');
+
+const getLayerArtifactHash = async (layerArtifactPath, layerForHash) =>
+  new Promise((resolve, reject) => {
+    const sha = crypto.createHash('sha1');
+    sha.update(JSON.stringify(layerForHash));
+
+    const readStream = fs.createReadStream(layerArtifactPath);
+    readStream
+      .on('data', (chunk) => {
+        sha.update(chunk);
+      })
+      .on('end', () => {
+        resolve(sha.digest('hex'));
+      })
+      .on('error', reject);
+  });
 
 class AwsCompileLayers {
   constructor(serverless, options) {
@@ -58,66 +74,60 @@ class AwsCompileLayers {
       this.provider.serverless.service,
       this.provider.naming
     );
-    return fsp.readFile(layerArtifactPath).then((layerArtifactBinary) => {
-      const layerForHash = structuredClone(newLayer);
-      delete layerForHash.Properties.Content.S3Key;
-      const sha = crypto
-        .createHash('sha1')
-        .update(JSON.stringify(layerForHash))
-        .update(layerArtifactBinary)
-        .digest('hex');
-      if (layerObject.retain) {
-        layerLogicalId = `${layerLogicalId}${sha}`;
-        newLayer.DeletionPolicy = 'Retain';
-      }
-      const newLayerObject = {
-        [layerLogicalId]: newLayer,
-      };
+    const layerForHash = structuredClone(newLayer);
+    delete layerForHash.Properties.Content.S3Key;
+    const sha = await getLayerArtifactHash(layerArtifactPath, layerForHash);
+    if (layerObject.retain) {
+      layerLogicalId = `${layerLogicalId}${sha}`;
+      newLayer.DeletionPolicy = 'Retain';
+    }
+    const newLayerObject = {
+      [layerLogicalId]: newLayer,
+    };
 
-      if (layerObject.allowedAccounts) {
-        layerObject.allowedAccounts.map((account) => {
-          const newPermission = this.cfLambdaLayerPermissionTemplate();
-          newPermission.Properties.LayerVersionArn = { Ref: layerLogicalId };
-          newPermission.Properties.Principal = account;
-          let layerPermLogicalId = this.provider.naming.getLambdaLayerPermissionLogicalId(
-            layerName,
-            account
-          );
-          if (layerObject.retain) {
-            layerPermLogicalId = `${layerPermLogicalId}${sha}`;
-            newPermission.DeletionPolicy = 'Retain';
-          }
-          newLayerObject[layerPermLogicalId] = newPermission;
-          return newPermission;
-        });
-      }
-
-      Object.assign(
-        this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-        newLayerObject
-      );
-
-      // Add layer to Outputs section
-      const layerOutputLogicalId = this.provider.naming.getLambdaLayerOutputLogicalId(layerName);
-      const newLayerOutput = this.cfOutputLayerTemplate();
-
-      newLayerOutput.Value = { Ref: layerLogicalId };
-
-      const layerHashOutputLogicalId =
-        this.provider.naming.getLambdaLayerHashOutputLogicalId(layerName);
-      const newLayerHashOutput = this.cfOutputLayerHashTemplate();
-      newLayerHashOutput.Value = sha;
-
-      const layerS3KeyOutputLogicalId =
-        this.provider.naming.getLambdaLayerS3KeyOutputLogicalId(layerName);
-      const newLayerS3KeyOutput = this.cfOutputLayerS3KeyTemplate();
-      newLayerS3KeyOutput.Value = newLayer.Properties.Content.S3Key;
-
-      Object.assign(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
-        [layerOutputLogicalId]: newLayerOutput,
-        [layerHashOutputLogicalId]: newLayerHashOutput,
-        [layerS3KeyOutputLogicalId]: newLayerS3KeyOutput,
+    if (layerObject.allowedAccounts) {
+      layerObject.allowedAccounts.map((account) => {
+        const newPermission = this.cfLambdaLayerPermissionTemplate();
+        newPermission.Properties.LayerVersionArn = { Ref: layerLogicalId };
+        newPermission.Properties.Principal = account;
+        let layerPermLogicalId = this.provider.naming.getLambdaLayerPermissionLogicalId(
+          layerName,
+          account
+        );
+        if (layerObject.retain) {
+          layerPermLogicalId = `${layerPermLogicalId}${sha}`;
+          newPermission.DeletionPolicy = 'Retain';
+        }
+        newLayerObject[layerPermLogicalId] = newPermission;
+        return newPermission;
       });
+    }
+
+    Object.assign(
+      this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+      newLayerObject
+    );
+
+    // Add layer to Outputs section
+    const layerOutputLogicalId = this.provider.naming.getLambdaLayerOutputLogicalId(layerName);
+    const newLayerOutput = this.cfOutputLayerTemplate();
+
+    newLayerOutput.Value = { Ref: layerLogicalId };
+
+    const layerHashOutputLogicalId =
+      this.provider.naming.getLambdaLayerHashOutputLogicalId(layerName);
+    const newLayerHashOutput = this.cfOutputLayerHashTemplate();
+    newLayerHashOutput.Value = sha;
+
+    const layerS3KeyOutputLogicalId =
+      this.provider.naming.getLambdaLayerS3KeyOutputLogicalId(layerName);
+    const newLayerS3KeyOutput = this.cfOutputLayerS3KeyTemplate();
+    newLayerS3KeyOutput.Value = newLayer.Properties.Content.S3Key;
+
+    Object.assign(this.serverless.service.provider.compiledCloudFormationTemplate.Outputs, {
+      [layerOutputLogicalId]: newLayerOutput,
+      [layerHashOutputLogicalId]: newLayerHashOutput,
+      [layerS3KeyOutputLogicalId]: newLayerS3KeyOutput,
     });
   }
 

--- a/test/unit/lib/plugins/aws/package/compile/layers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/layers.test.js
@@ -1,7 +1,12 @@
 'use strict';
 
+const crypto = require('crypto');
+const fs = require('fs');
 const path = require('path');
 const chai = require('chai');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const { getTmpDirPath } = require('../../../../../../utils/fs');
 const runServerless = require('../../../../../../utils/run-serverless');
 
 const expect = chai.expect;
@@ -91,6 +96,73 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
       'Current Lambda layer version'
     );
     expect(cfOutputs.LayerLambdaLayerQualifiedArn.Value.Ref).to.equals('LayerLambdaLayer');
+  });
+
+  it('hashes layer artifacts with streams instead of buffering the whole zip', async () => {
+    const packagePath = getTmpDirPath();
+    const layerArtifactPath = path.join(packagePath, 'layer.zip');
+    fs.mkdirSync(packagePath, { recursive: true });
+    fs.writeFileSync(layerArtifactPath, 'layer artifact content');
+
+    const readFileStub = sinon.stub().rejects(new Error('layer artifact should not be buffered'));
+    const createReadStreamStub = sinon
+      .stub()
+      .callsFake((filePath) => fs.createReadStream(filePath));
+    const fakeFs = Object.create(fs);
+    Object.defineProperty(fakeFs, 'promises', { value: { readFile: readFileStub } });
+    fakeFs.createReadStream = createReadStreamStub;
+
+    const AwsCompileLayers = proxyquire(
+      '../../../../../../../lib/plugins/aws/package/compile/layers',
+      {
+        fs: fakeFs,
+      }
+    );
+
+    const layerObject = { path: 'layer' };
+    const testNaming = {
+      getLayerArtifactName: sinon.stub().returns('layer.zip'),
+      getLambdaLayerLogicalId: sinon.stub().returns('LayerLambdaLayer'),
+      getLambdaLayerOutputLogicalId: sinon.stub().returns('LayerLambdaLayerQualifiedArn'),
+      getLambdaLayerHashOutputLogicalId: sinon.stub().returns('LayerLambdaLayerHash'),
+      getLambdaLayerS3KeyOutputLogicalId: sinon.stub().returns('LayerLambdaLayerS3Key'),
+      getLambdaLayerPermissionLogicalId: sinon.stub().returns('LayerLambdaLayerPermission'),
+    };
+    const testService = {
+      package: { artifactDirectoryName: 'artifact-dir', path: packagePath },
+      provider: { compiledCloudFormationTemplate: { Resources: {}, Outputs: {} } },
+      getLayer: sinon.stub().withArgs('layer').returns(layerObject),
+    };
+    const testProvider = {
+      serverless: { service: testService },
+      naming: testNaming,
+      resolveLayerArtifactName: sinon.stub().withArgs('layer').returns(layerArtifactPath),
+    };
+    const testServerless = {
+      serviceDir: packagePath,
+      service: testService,
+      getProvider: sinon.stub().withArgs('aws').returns(testProvider),
+    };
+
+    const awsCompileLayers = new AwsCompileLayers(testServerless, {});
+    await awsCompileLayers.compileLayer('layer');
+
+    expect(createReadStreamStub).to.have.been.calledOnceWithExactly(layerArtifactPath);
+    expect(readFileStub).to.not.have.been.called;
+
+    const layerForHash = structuredClone(
+      testService.provider.compiledCloudFormationTemplate.Resources.LayerLambdaLayer
+    );
+    delete layerForHash.Properties.Content.S3Key;
+    const expectedHash = crypto
+      .createHash('sha1')
+      .update(JSON.stringify(layerForHash))
+      .update(fs.readFileSync(layerArtifactPath))
+      .digest('hex');
+
+    expect(
+      testService.provider.compiledCloudFormationTemplate.Outputs.LayerLambdaLayerHash.Value
+    ).to.equal(expectedHash);
   });
 
   describe('`layers[].retain` property', () => {


### PR DESCRIPTION
Replaces `fsp.readFile()` in `compileLayer()` with a streaming SHA-1 over `fs.createReadStream()`. The previous code materialized the entire layer zip in memory before feeding it to `crypto.createHash('sha1')`, which remained an OOM risk for large layers after PR #205 fixed the function-artifact and change-detection hashing paths.

The hash bytes are unchanged: `crypto.Hash.update()` is incremental, so `update(JSON.stringify(layerForHash))` + per-chunk update(chunk) produces the same digest as a single update of the full buffer. A new unit test locks this in by computing the expected hash with the original buffered shape and asserting equality against the streaming output, while also asserting `fs.createReadStream` is used and `fs.promises.readFile` is not.

This addresses the last whole-artifact buffering site flagged during the #189 review.