### PR TITLE
Fix layer path resolution

### DIFF
--- a/lib/plugins/package/lib/package-service.js
+++ b/lib/plugins/package/lib/package-service.js
@@ -202,18 +202,17 @@ module.exports = {
     const layerObject = this.serverless.service.getLayer(layerName);
 
     const zipFileName = `${layerName}.zip`;
+    const layerPath = path.resolve(this.serverless.serviceDir, layerObject.path);
 
     return this.resolveFilePathsLayer(layerName)
-      .then((filePaths) => filePaths.map((f) => path.resolve(path.join(layerObject.path, f))))
+      .then((filePaths) => filePaths.map((filePath) => path.join(layerPath, filePath)))
       .then((filePaths) =>
-        this.zipFiles(filePaths, zipFileName, path.resolve(layerObject.path)).then(
-          (artifactPath) => {
-            layerObject.package = {
-              artifact: artifactPath,
-            };
-            return artifactPath;
-          }
-        )
+        this.zipFiles(filePaths, zipFileName, layerPath).then((artifactPath) => {
+          layerObject.package = {
+            artifact: artifactPath,
+          };
+          return artifactPath;
+        })
       );
   },
 

--- a/test/unit/lib/plugins/package/lib/package-service.test.js
+++ b/test/unit/lib/plugins/package/lib/package-service.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const os = require('os');
 const path = require('path');
 const fsp = require('fs').promises;
 const proxyquire = require('proxyquire').noCallThru();
@@ -189,6 +190,45 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
 
       expect(zippedFiles).to.not.include('.env');
       expect(zippedFiles).to.not.include('.env.stage');
+    });
+  });
+
+  describe('#packageLayer()', () => {
+    it('resolves layer package paths against serviceDir instead of cwd', async () => {
+      const originalCwd = process.cwd();
+      const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), 'sls-cwd-'));
+      const serviceDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'sls-service-'));
+
+      try {
+        process.chdir(cwd);
+
+        const layerObject = { path: 'layer' };
+        const zipFilesStub = sinon.stub().resolves('layer.zip');
+
+        await packageService.packageLayer.call(
+          {
+            serverless: {
+              serviceDir,
+              service: {
+                getLayer: () => layerObject,
+              },
+            },
+            resolveFilePathsLayer: sinon.stub().resolves(['index.js']),
+            zipFiles: zipFilesStub,
+          },
+          'layer'
+        );
+
+        expect(zipFilesStub).to.have.been.calledWithExactly(
+          [path.join(serviceDir, 'layer', 'index.js')],
+          'layer.zip',
+          path.join(serviceDir, 'layer')
+        );
+      } finally {
+        process.chdir(originalCwd);
+        await fsp.rm(cwd, { recursive: true, force: true });
+        await fsp.rm(serviceDir, { recursive: true, force: true });
+      }
     });
   });
 


### PR DESCRIPTION
Resolves layer package paths relative to `serverless.serviceDir` instead of `process.cwd()`.

This cwd dependency was introduced in 3093c8361 when layer packaging started pre-resolving `layerObject.path` with `path.resolve(...)` to support paths like `./layer` and trailing slash variants. That made packaging sensitive to the shell cwd whenever `cwd !== serviceDir`.

The fix anchors the layer path once with `serverless.serviceDir` and uses that same path for both file resolution and ZIP prefix stripping.

Adds a regression test for `packageLayer()` with a different current working directory.