### PR TITLE
Avoid deploy function no-op buffering

### DIFF
--- a/lib/plugins/aws/deploy-function.js
+++ b/lib/plugins/aws/deploy-function.js
@@ -528,20 +528,22 @@ class AwsDeployFunction {
         artifactFilePath = functionObject.package.artifact;
       }
 
-      const remoteHash =
-        this.serverless.service.provider.remoteFunctionData.Configuration.CodeSha256;
-      const localHash = await getHashForFilePath(artifactFilePath);
+      if (!this.options.force) {
+        const remoteHash =
+          this.serverless.service.provider.remoteFunctionData.Configuration.CodeSha256;
+        const localHash = await getHashForFilePath(artifactFilePath);
 
-      if (remoteHash === localHash && !this.options.force) {
-        log.notice();
-        log.notice.skip(
-          `Code did not change. Function deployment skipped. ${style.aside(
-            `(${Math.floor(
-              (Date.now() - this.serverless.pluginManager.commandRunStartTime) / 1000
-            )}s)`
-          )}`
-        );
-        return;
+        if (remoteHash === localHash) {
+          log.notice();
+          log.notice.skip(
+            `Code did not change. Function deployment skipped. ${style.aside(
+              `(${Math.floor(
+                (Date.now() - this.serverless.pluginManager.commandRunStartTime) / 1000
+              )}s)`
+            )}`
+          );
+          return;
+        }
       }
 
       const [data, stats] = await Promise.all([

--- a/lib/plugins/aws/deploy-function.js
+++ b/lib/plugins/aws/deploy-function.js
@@ -1,13 +1,14 @@
 'use strict';
 
-const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
+const fsp = fs.promises;
 const { isDeepStrictEqual } = require('node:util');
 const wait = require('../../utils/sleep');
 const isObject = require('type/object/is');
 const validate = require('./lib/validate');
 const filesize = require('../../utils/filesize');
+const getHashForFilePath = require('../../utils/get-hash-for-file-path');
 const ServerlessError = require('../../serverless-error');
 const { safeShallowAssign } = require('../../utils/safe-object');
 const { log, style, progress } = require('../../utils/serverless-utils/log');
@@ -527,11 +528,9 @@ class AwsDeployFunction {
         artifactFilePath = functionObject.package.artifact;
       }
 
-      const data = fs.readFileSync(artifactFilePath);
-
       const remoteHash =
         this.serverless.service.provider.remoteFunctionData.Configuration.CodeSha256;
-      const localHash = crypto.createHash('sha256').update(data).digest('base64');
+      const localHash = await getHashForFilePath(artifactFilePath);
 
       if (remoteHash === localHash && !this.options.force) {
         log.notice();
@@ -545,9 +544,13 @@ class AwsDeployFunction {
         return;
       }
 
+      const [data, stats] = await Promise.all([
+        fsp.readFile(artifactFilePath),
+        fsp.stat(artifactFilePath),
+      ]);
+
       params.ZipFile = data;
 
-      const stats = fs.statSync(artifactFilePath);
       mainProgress.notice(`Uploading ${style.aside(`(${filesize(stats.size)})`)}`, {
         isMainEvent: true,
       });

--- a/lib/plugins/aws/deploy-function.js
+++ b/lib/plugins/aws/deploy-function.js
@@ -546,14 +546,11 @@ class AwsDeployFunction {
         }
       }
 
-      const [data, stats] = await Promise.all([
-        fsp.readFile(artifactFilePath),
-        fsp.stat(artifactFilePath),
-      ]);
+      const data = await fsp.readFile(artifactFilePath);
 
       params.ZipFile = data;
 
-      mainProgress.notice(`Uploading ${style.aside(`(${filesize(stats.size)})`)}`, {
+      mainProgress.notice(`Uploading ${style.aside(`(${filesize(data.length)})`)}`, {
         isMainEvent: true,
       });
     }

--- a/test/unit/lib/plugins/aws/deploy-function.test.js
+++ b/test/unit/lib/plugins/aws/deploy-function.test.js
@@ -17,7 +17,7 @@ describe('AwsDeployFunction', () => {
   let AwsDeployFunction;
   let serverless;
   let awsDeployFunction;
-  let cryptoStub;
+  let getHashForFilePathStub;
 
   beforeEach(async () => {
     serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
@@ -51,17 +51,9 @@ describe('AwsDeployFunction', () => {
     };
     await serverless.init();
     serverless.setProvider('aws', new AwsProvider(serverless, options));
-    cryptoStub = {
-      createHash() {
-        return this;
-      },
-      update() {
-        return this;
-      },
-      digest: sinon.stub(),
-    };
+    getHashForFilePathStub = sinon.stub();
     AwsDeployFunction = proxyquire('../../../../../lib/plugins/aws/deploy-function', {
-      crypto: cryptoStub,
+      '../../utils/get-hash-for-file-path': getHashForFilePathStub,
     });
     awsDeployFunction = new AwsDeployFunction(serverless, options);
   });
@@ -187,8 +179,8 @@ describe('AwsDeployFunction', () => {
   describe('#deployFunction()', () => {
     let artifactFilePath;
     let updateFunctionCodeStub;
-    let statSyncStub;
-    let readFileSyncStub;
+    let statStub;
+    let readFileStub;
 
     beforeEach(() => {
       // write a file to disc to simulate that the deployment artifact exists
@@ -196,8 +188,9 @@ describe('AwsDeployFunction', () => {
       artifactFilePath = path.join(awsDeployFunction.packagePath, 'first.zip');
       serverless.utils.writeFileSync(artifactFilePath, 'first.zip file content');
       updateFunctionCodeStub = sinon.stub(awsDeployFunction.provider, 'request').resolves();
-      statSyncStub = sinon.stub(fs, 'statSync').returns({ size: 1024 });
-      readFileSyncStub = sinon.stub(fs, 'readFileSync').returns();
+      statStub = sinon.stub(fs.promises, 'stat').resolves({ size: 1024 });
+      readFileStub = sinon.stub(fs.promises, 'readFile').resolves(Buffer.from('first.zip content'));
+      getHashForFilePathStub.resolves('local-hash-zip-file');
       awsDeployFunction.serverless.service.provider.remoteFunctionData = {
         Configuration: {
           CodeSha256: 'remote-hash-zip-file',
@@ -207,64 +200,65 @@ describe('AwsDeployFunction', () => {
 
     afterEach(() => {
       awsDeployFunction.provider.request.restore();
-      fs.statSync.restore();
-      fs.readFileSync.restore();
+      fs.promises.stat.restore();
+      fs.promises.readFile.restore();
     });
 
     it('should deploy the function if the hashes are different', async () => {
-      cryptoStub.createHash().update().digest.onCall(0).returns('local-hash-zip-file');
+      const data = Buffer.from('first.zip content');
+      readFileStub.resolves(data);
 
       await awsDeployFunction.deployFunction();
 
-      const data = fs.readFileSync(artifactFilePath);
       expect(updateFunctionCodeStub.calledOnce).to.be.equal(true);
-      expect(readFileSyncStub.called).to.equal(true);
+      expect(getHashForFilePathStub).to.have.been.calledWithExactly(artifactFilePath);
+      expect(readFileStub).to.have.been.calledWithExactly(artifactFilePath);
+      expect(statStub).to.have.been.calledWithExactly(artifactFilePath);
       expect(
         updateFunctionCodeStub.calledWithExactly('Lambda', 'updateFunctionCode', {
           FunctionName: 'first',
           ZipFile: data,
         })
       ).to.be.equal(true);
-      expect(readFileSyncStub.calledWithExactly(artifactFilePath)).to.equal(true);
     });
 
     it('should deploy the function if the hashes are same but the "force" option is used', async () => {
       awsDeployFunction.options.force = true;
-      cryptoStub.createHash().update().digest.onCall(0).returns('remote-hash-zip-file');
+      getHashForFilePathStub.resolves('remote-hash-zip-file');
+      const data = Buffer.from('first.zip content');
+      readFileStub.resolves(data);
 
       await awsDeployFunction.deployFunction();
-      const data = fs.readFileSync(artifactFilePath);
 
       expect(updateFunctionCodeStub.calledOnce).to.be.equal(true);
-      expect(readFileSyncStub.called).to.equal(true);
+      expect(getHashForFilePathStub).to.have.been.calledWithExactly(artifactFilePath);
+      expect(readFileStub).to.have.been.calledWithExactly(artifactFilePath);
+      expect(statStub).to.have.been.calledWithExactly(artifactFilePath);
       expect(
         updateFunctionCodeStub.calledWithExactly('Lambda', 'updateFunctionCode', {
           FunctionName: 'first',
           ZipFile: data,
         })
       ).to.be.equal(true);
-      expect(readFileSyncStub.calledWithExactly(artifactFilePath)).to.equal(true);
     });
 
     it('should resolve if the hashes are the same', async () => {
-      cryptoStub.createHash().update().digest.onCall(0).returns('remote-hash-zip-file');
+      getHashForFilePathStub.resolves('remote-hash-zip-file');
 
       await awsDeployFunction.deployFunction();
 
       expect(updateFunctionCodeStub.calledOnce).to.be.equal(false);
-      expect(readFileSyncStub.calledOnce).to.equal(true);
-      expect(readFileSyncStub.calledWithExactly(artifactFilePath)).to.equal(true);
+      expect(getHashForFilePathStub).to.have.been.calledWithExactly(artifactFilePath);
+      expect(readFileStub).to.not.have.been.called;
+      expect(statStub).to.not.have.been.called;
     });
 
     it('should log artifact size', async () => {
-      // awnY7Oi280gp5kTCloXzsqJCO4J766x6hATWqQsN/uM= <-- hash of the local zip file
-      readFileSyncStub.returns(Buffer.from('my-service.zip content'));
-
       await awsDeployFunction.deployFunction();
 
-      expect(readFileSyncStub.calledOnce).to.equal(true);
-      expect(statSyncStub.calledOnce).to.equal(true);
-      expect(readFileSyncStub.calledWithExactly(artifactFilePath)).to.equal(true);
+      expect(readFileStub.calledOnce).to.equal(true);
+      expect(statStub.calledOnce).to.equal(true);
+      expect(readFileStub.calledWithExactly(artifactFilePath)).to.equal(true);
     });
 
     describe('when artifact is provided', () => {
@@ -285,12 +279,14 @@ describe('AwsDeployFunction', () => {
       });
 
       it('should read the provided artifact', async () => {
+        const data = Buffer.from('artifact.zip content');
+        readFileStub.resolves(data);
+
         await awsDeployFunction.deployFunction();
 
-        const data = fs.readFileSync(artifactZipFile);
-
-        expect(readFileSyncStub).to.have.been.calledWithExactly(artifactZipFile);
-        expect(statSyncStub).to.have.been.calledWithExactly(artifactZipFile);
+        expect(getHashForFilePathStub).to.have.been.calledWithExactly(artifactZipFile);
+        expect(readFileStub).to.have.been.calledWithExactly(artifactZipFile);
+        expect(statStub).to.have.been.calledWithExactly(artifactZipFile);
         expect(getFunctionStub).to.have.been.calledWithExactly('first');
         expect(updateFunctionCodeStub.calledOnce).to.equal(true);
         expect(

--- a/test/unit/lib/plugins/aws/deploy-function.test.js
+++ b/test/unit/lib/plugins/aws/deploy-function.test.js
@@ -224,14 +224,13 @@ describe('AwsDeployFunction', () => {
 
     it('should deploy the function if the hashes are same but the "force" option is used', async () => {
       awsDeployFunction.options.force = true;
-      getHashForFilePathStub.resolves('remote-hash-zip-file');
       const data = Buffer.from('first.zip content');
       readFileStub.resolves(data);
 
       await awsDeployFunction.deployFunction();
 
       expect(updateFunctionCodeStub.calledOnce).to.be.equal(true);
-      expect(getHashForFilePathStub).to.have.been.calledWithExactly(artifactFilePath);
+      expect(getHashForFilePathStub).to.not.have.been.called;
       expect(readFileStub).to.have.been.calledWithExactly(artifactFilePath);
       expect(statStub).to.have.been.calledWithExactly(artifactFilePath);
       expect(

--- a/test/unit/lib/plugins/aws/deploy-function.test.js
+++ b/test/unit/lib/plugins/aws/deploy-function.test.js
@@ -179,7 +179,6 @@ describe('AwsDeployFunction', () => {
   describe('#deployFunction()', () => {
     let artifactFilePath;
     let updateFunctionCodeStub;
-    let statStub;
     let readFileStub;
 
     beforeEach(() => {
@@ -188,7 +187,6 @@ describe('AwsDeployFunction', () => {
       artifactFilePath = path.join(awsDeployFunction.packagePath, 'first.zip');
       serverless.utils.writeFileSync(artifactFilePath, 'first.zip file content');
       updateFunctionCodeStub = sinon.stub(awsDeployFunction.provider, 'request').resolves();
-      statStub = sinon.stub(fs.promises, 'stat').resolves({ size: 1024 });
       readFileStub = sinon.stub(fs.promises, 'readFile').resolves(Buffer.from('first.zip content'));
       getHashForFilePathStub.resolves('local-hash-zip-file');
       awsDeployFunction.serverless.service.provider.remoteFunctionData = {
@@ -200,7 +198,6 @@ describe('AwsDeployFunction', () => {
 
     afterEach(() => {
       awsDeployFunction.provider.request.restore();
-      fs.promises.stat.restore();
       fs.promises.readFile.restore();
     });
 
@@ -213,7 +210,6 @@ describe('AwsDeployFunction', () => {
       expect(updateFunctionCodeStub.calledOnce).to.be.equal(true);
       expect(getHashForFilePathStub).to.have.been.calledWithExactly(artifactFilePath);
       expect(readFileStub).to.have.been.calledWithExactly(artifactFilePath);
-      expect(statStub).to.have.been.calledWithExactly(artifactFilePath);
       expect(
         updateFunctionCodeStub.calledWithExactly('Lambda', 'updateFunctionCode', {
           FunctionName: 'first',
@@ -232,7 +228,6 @@ describe('AwsDeployFunction', () => {
       expect(updateFunctionCodeStub.calledOnce).to.be.equal(true);
       expect(getHashForFilePathStub).to.not.have.been.called;
       expect(readFileStub).to.have.been.calledWithExactly(artifactFilePath);
-      expect(statStub).to.have.been.calledWithExactly(artifactFilePath);
       expect(
         updateFunctionCodeStub.calledWithExactly('Lambda', 'updateFunctionCode', {
           FunctionName: 'first',
@@ -249,14 +244,12 @@ describe('AwsDeployFunction', () => {
       expect(updateFunctionCodeStub.calledOnce).to.be.equal(false);
       expect(getHashForFilePathStub).to.have.been.calledWithExactly(artifactFilePath);
       expect(readFileStub).to.not.have.been.called;
-      expect(statStub).to.not.have.been.called;
     });
 
     it('should log artifact size', async () => {
       await awsDeployFunction.deployFunction();
 
       expect(readFileStub.calledOnce).to.equal(true);
-      expect(statStub.calledOnce).to.equal(true);
       expect(readFileStub.calledWithExactly(artifactFilePath)).to.equal(true);
     });
 
@@ -285,7 +278,6 @@ describe('AwsDeployFunction', () => {
 
         expect(getHashForFilePathStub).to.have.been.calledWithExactly(artifactZipFile);
         expect(readFileStub).to.have.been.calledWithExactly(artifactZipFile);
-        expect(statStub).to.have.been.calledWithExactly(artifactZipFile);
         expect(getFunctionStub).to.have.been.calledWithExactly('first');
         expect(updateFunctionCodeStub.calledOnce).to.equal(true);
         expect(


### PR DESCRIPTION
Computes the `deploy function` artifact hash with the streaming hash helper before reading the ZIP buffer.

Previously `deploy function` always loaded the full ZIP with `fs.readFileSync()` before comparing the local hash with the remote Lambda `CodeSha256`. That meant even unchanged functions had to buffer the whole artifact just to decide that deployment could be skipped.

This keeps the required `ZipFile` buffer for actual `updateFunctionCode` calls, but moves it after the no-op hash check. Unchanged functions now stream the hash and return without reading or statting the artifact.

The tests now assert that matching hashes skip `readFile` and `stat`, while changed or forced deployments still read the artifact and pass the same `ZipFile` payload to Lambda.