### PR TITLE
Fix CloudWatch Logs subscription filter classification

### DIFF
--- a/lib/plugins/aws/deploy/lib/check-for-changes.js
+++ b/lib/plugins/aws/deploy/lib/check-for-changes.js
@@ -303,21 +303,20 @@ module.exports = {
         logGroupName,
       })
       .catch(() => ({ subscriptionFilters: [] }));
-    if (response.subscriptionFilters.length === 0) {
+    const subscriptionFilters = response.subscriptionFilters || [];
+    if (subscriptionFilters.length === 0) {
       log.debug('no subscription filters detected');
       return false;
     }
 
     const stackName = this.provider.naming.getStackName();
     const oldSubscriptionFilters = await Promise.all(
-      response.subscriptionFilters.map(async (subscriptionFilter) => {
+      subscriptionFilters.map(async (subscriptionFilter) => {
         const { destinationArn, filterName } = subscriptionFilter;
         const logicalId = this.getLogicalIdFromFilterName(filterName);
-        const isInternal = await this.isInternalSubscriptionFilter(
-          stackName,
-          logicalId,
-          filterName
-        );
+        const isInternal = logicalId
+          ? await this.isInternalSubscriptionFilter(stackName, logicalId, filterName)
+          : false;
 
         return { destinationArn, logicalId, filterName, isInternal };
       })
@@ -386,8 +385,11 @@ module.exports = {
     // Filter name format:
     // {stack name}-{logical id}-{random alphanumeric characters}
     // Note that the stack name can include hyphens
+    if (typeof filterName !== 'string') return null;
     const split = filterName.split('-');
-    return split[split.length - 2];
+    if (split.length < 3) return null;
+    const logicalId = split[split.length - 2];
+    return /^[A-Za-z][A-Za-z0-9]*$/.test(logicalId) ? logicalId : null;
   },
 
   async isInternalSubscriptionFilter(stackName, logicalResourceId, physicalResourceId) {

--- a/test/unit/lib/plugins/aws/deploy/lib/check-for-changes.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/check-for-changes.test.js
@@ -18,6 +18,23 @@ const fsp = fs.promises;
 // Configure chai
 const expect = require('chai').expect;
 
+function createAwsDeployTestInstance() {
+  const options = {
+    stage: 'dev',
+    region: 'us-east-1',
+  };
+  const serverless = new Serverless({ commands: [], options: {} });
+  const provider = new AwsProvider(serverless, options);
+  serverless.setProvider('aws', provider);
+  serverless.service.service = 'my-service';
+  const awsDeploy = new AwsDeploy(serverless, options);
+  Object.assign(
+    awsDeploy,
+    require('../../../../../../../lib/plugins/aws/deploy/lib/check-for-changes.js')
+  );
+  return awsDeploy;
+}
+
 describe('checkForChanges', () => {
   let serverless;
   let provider;
@@ -1248,6 +1265,83 @@ describe('test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js', () => {
   });
 
   describe('checkLogGroupSubscriptionFilterResourceLimitExceeded', () => {
+    it('treats omitted subscriptionFilters as no filters', async () => {
+      const awsDeploy = createAwsDeployTestInstance();
+      const requestStub = sandbox.stub(awsDeploy.provider, 'request').resolves({});
+
+      try {
+        const result = await awsDeploy.fixLogGroupSubscriptionFilters({
+          accountId: '123456789012',
+          region: 'us-east-1',
+          partition: 'aws',
+          logGroupName: 'someLogGroupName',
+          cloudwatchLogEvents: [],
+        });
+
+        expect(result).to.equal(false);
+        expect(requestStub).to.have.been.calledOnceWithExactly(
+          'CloudWatchLogs',
+          'describeSubscriptionFilters',
+          { logGroupName: 'someLogGroupName' }
+        );
+        expect(requestStub.calledWith('CloudFormation', 'describeStackResource')).to.equal(false);
+        expect(requestStub.calledWith('CloudWatchLogs', 'deleteSubscriptionFilter')).to.equal(
+          false
+        );
+      } finally {
+        awsDeploy.provider.request.restore();
+      }
+    });
+
+    it('treats malformed external subscription filter names as external without CloudFormation lookup', async () => {
+      const awsDeploy = createAwsDeployTestInstance();
+      const requestStub = sandbox.stub(awsDeploy.provider, 'request').callsFake(async (service) => {
+        if (service === 'CloudWatchLogs') {
+          return {
+            subscriptionFilters: [
+              {
+                filterName: 'externalFilter',
+                destinationArn: 'arn:aws:lambda:us-east-1:123456789012:function:external-1',
+              },
+              {
+                filterName: 'external--suffix',
+                destinationArn: 'arn:aws:lambda:us-east-1:123456789012:function:external-2',
+              },
+            ],
+          };
+        }
+        throw new Error(`Unexpected ${service} request`);
+      });
+
+      try {
+        await expect(
+          awsDeploy.fixLogGroupSubscriptionFilters({
+            accountId: '123456789012',
+            region: 'us-east-1',
+            partition: 'aws',
+            logGroupName: 'someLogGroupName',
+            cloudwatchLogEvents: [
+              {
+                FunctionName: 'service-dev-fn1',
+                functionName: 'Fn1',
+                logGroupName: 'someLogGroupName',
+                logSubscriptionSerialNumber: 1,
+              },
+            ],
+          })
+        ).to.eventually.be.rejected.and.have.property(
+          'code',
+          'CLOUDWATCHLOG_LOG_GROUP_EVENT_PER_FUNCTION_LIMIT_EXCEEDED'
+        );
+        expect(requestStub.calledWith('CloudFormation', 'describeStackResource')).to.equal(false);
+        expect(requestStub.calledWith('CloudWatchLogs', 'deleteSubscriptionFilter')).to.equal(
+          false
+        );
+      } finally {
+        awsDeploy.provider.request.restore();
+      }
+    });
+
     it('does not crash when cloudwatchLog event uses __proto__ as the log group name', async () => {
       const deleteStub = sandbox.stub();
       let serverless;


### PR DESCRIPTION
- Treat omitted CloudWatch Logs subscription filter lists as empty.
- Avoid CloudFormation lookups for malformed external subscription filter names.
- Add regression coverage for empty and malformed external subscription filter cases.
