### PR TITLE
Fix API Gateway stage update edge cases

### DIFF
--- a/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/update-stage.js
+++ b/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/update-stage.js
@@ -137,7 +137,7 @@ async function resolveRestApiId() {
       this.provider
         .request('APIGateway', 'getRestApis', { position, limit: 500 })
         .then((result) => {
-          const restApi = result.items.find((api) => api.name === apiName);
+          const restApi = (result.items || []).find((api) => api.name === apiName);
           if (restApi) return restApi.id;
           if (result.position) return resolveFromAws(result.position);
           return null;
@@ -174,9 +174,10 @@ async function resolveDeploymentId() {
         limit: 500,
       })
       .then((res) => {
-        if (res.items.length) {
+        const deployments = res.items || [];
+        if (deployments.length) {
           // there will ever only be 1 deployment associated
-          const deployment = res.items.shift();
+          const deployment = deployments[0];
           return deployment.id;
         }
         return null;
@@ -310,7 +311,7 @@ function handleTags() {
   );
 
   const restApiId = this.apiGatewayRestApiId;
-  const stageName = this.options.stage;
+  const stageName = this.provider.getApiGatewayStage();
   const region = this.options.region;
   const partition = this.partition;
   const resourceArn = `arn:${partition}:apigateway:${region}::/restapis/${restApiId}/stages/${stageName}`;

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/update-stage.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/update-stage.test.js
@@ -562,7 +562,6 @@ describe('#updateStage()', () => {
         position: undefined,
       })
       .resolves({
-        items: [],
         position: 'foobarfoo1',
       });
     providerRequestStub
@@ -577,6 +576,22 @@ describe('#updateStage()', () => {
     return updateStage.call(context).then(() => {
       expect(context.apiGatewayRestApiId).to.equal('devRestApiId');
     });
+  });
+
+  it('should handle getDeployments responses without items', async () => {
+    context.state.service.provider.tracing = { apiGateway: false };
+    providerRequestStub
+      .withArgs('APIGateway', 'getDeployments', {
+        restApiId: 'devRestApiId',
+        limit: 500,
+      })
+      .resolves({});
+
+    await updateStage.call(context);
+
+    expect(context.apiGatewayDeploymentId).to.equal(null);
+    expect(providerRequestStub.calledWith('APIGateway', 'getStage')).to.equal(false);
+    expect(providerRequestStub.calledWith('APIGateway', 'createStage')).to.equal(false);
   });
 
   it(
@@ -890,6 +905,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/u
     const getStageStub = sinon.stub().resolves({});
     const createStageStub = sinon.stub();
     const updateStageStub = sinon.stub();
+    const tagResourceStub = sinon.stub();
     const stage = 'dev';
 
     await updateConfig({
@@ -915,7 +931,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/u
           updateStage: updateStageStub,
           getDeployments: getDeploymentsStub,
           getRestApis: { items: [{ id: 'api-id', name: `${serviceConfig.service}-${stage}` }] },
-          tagResource: {},
+          tagResource: tagResourceStub,
         },
         CloudFormation: {
           describeStacks: { Stacks: [{}] },
@@ -961,6 +977,9 @@ describe('test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/u
     expect(getStageStub.args[0][0].stageName).to.be.equal('customStage');
     expect(createStageStub.args[0][0].stageName).to.be.equal('customStage');
     expect(updateStageStub.args[0][0].stageName).to.be.equal('customStage');
+    expect(tagResourceStub.args[0][0].resourceArn)
+      .to.be.a('string')
+      .and.satisfy((arn) => arn.endsWith('/stages/customStage'));
     const accessLogSettingsDestinationArn = updateStageStub.args[0][0].patchOperations.filter(
       (op) => op.path === '/accessLogSettings/destinationArn'
     )[0].value;


### PR DESCRIPTION
- Treat omitted API Gateway REST API and deployment lists as empty.
- Use the configured API Gateway stage when building stage tag ARNs.
- Add regression coverage for omitted list outputs and custom-stage tag targeting.
