### PR TITLE
Fix AWS variable source validation message

### DIFF
--- a/lib/configuration/variables/sources/instance-dependent/get-aws.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-aws.js
@@ -15,7 +15,7 @@ module.exports = (serverlessInstance) => {
 
       address = ensureString(address, {
         Error: ServerlessError,
-        errorMessage: 'Non-string address argument in variable "sls" source: %v',
+        errorMessage: 'Non-string address argument in variable "aws" source: %v',
         errorCode: 'INVALID_AWS_SOURCE_ADDRESS',
       });
 


### PR DESCRIPTION
- Correct the non-string address validation message for the `aws` variable source.
- The message previously referenced the unrelated `sls` source.