### PR TITLE
Fix SSM encrypted region test error reference

### DIFF
--- a/test/unit/lib/configuration/variables/sources/instance-dependent/get-ssm.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/get-ssm.test.js
@@ -125,7 +125,7 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-s
       throw variablesMeta.get('custom\0encryptedWithSkipDecrypt').error;
     }
     if (variablesMeta.get('custom\0encryptedWithSkipDecryptAndRegion')) {
-      throw variablesMeta.get('custom\0encryptedWithSkipDecrypt').error;
+      throw variablesMeta.get('custom\0encryptedWithSkipDecryptAndRegion').error;
     }
     expect(configuration.custom.existingEncrypted).to.deep.equal({ someSecret: 'someValue' });
     expect(configuration.custom.existingEncryptedDirect).to.equal('12345678901234567890');


### PR DESCRIPTION
- Fix the SSM encrypted-region test to throw the matching variable resolution error.
- Prevents the test from reporting the wrong variable key if the region-specific case fails.