### PR TITLE
Fix custom bucket unknown region validation

### DIFF
--- a/lib/plugins/aws/deploy/lib/ensure-valid-bucket-exists.js
+++ b/lib/plugins/aws/deploy/lib/ensure-valid-bucket-exists.js
@@ -38,7 +38,7 @@ module.exports = {
       }
 
       if (result.BucketRegion === 'EU') result.BucketRegion = 'eu-west-1';
-      if (result.BucketRegion !== this.provider.getRegion()) {
+      if (result.BucketRegion && result.BucketRegion !== this.provider.getRegion()) {
         throw new ServerlessError(
           'Deployment bucket is not in the same region as the lambda function',
           'DEPLOYMENT_BUCKET_INVALID_REGION'

--- a/test/unit/lib/plugins/aws/deploy/index.test.js
+++ b/test/unit/lib/plugins/aws/deploy/index.test.js
@@ -1236,6 +1236,45 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
     ).to.eventually.have.been.rejected.and.have.property('code', 'DEPLOYMENT_BUCKET_NOT_FOUND');
   });
 
+  it('with existing stack - with custom deployment bucket and unknown region', async () => {
+    const headBucketStub = sinon.stub().returns({});
+    const awsRequestStubMap = {
+      ...baseAwsRequestStubMap,
+      ECR: {
+        describeRepositories: sinon.stub().throws({
+          providerError: { code: 'RepositoryNotFoundException' },
+        }),
+      },
+      Lambda: {
+        getFunction: {
+          Configuration: { LastModified: '2020-05-20T15:31:44.359Z' },
+        },
+      },
+      S3: {
+        headBucket: headBucketStub,
+        listObjectsV2: { Contents: [] },
+      },
+      CloudFormation: {
+        describeStacks: { Stacks: [{}] },
+        validateTemplate: {},
+      },
+    };
+
+    await runServerless({
+      fixture: 'function',
+      command: 'deploy',
+      awsRequestStubMap,
+      lastLifecycleHookName: 'aws:deploy:deploy:checkForChanges',
+      configExt: {
+        provider: {
+          deploymentBucket: 'bucket-name',
+        },
+      },
+    });
+
+    expect(headBucketStub).to.be.calledOnce;
+  });
+
   it('with existing stack - with custom deployment bucket in different region', async () => {
     const awsRequestStubMap = {
       ...baseAwsRequestStubMap,


### PR DESCRIPTION
- Allow custom deployment bucket validation to proceed when `headBucket` succeeds but does not report a bucket region.
- Preserve the existing invalid-region error when S3 does report a mismatched bucket region.