### PR TITLE
Harden CloudWatch Logs subscription filter discovery

### DIFF
--- a/lib/plugins/aws/deploy/lib/check-for-changes.js
+++ b/lib/plugins/aws/deploy/lib/check-for-changes.js
@@ -31,6 +31,14 @@ function isCloudFormationMissingResourceError(error) {
   );
 }
 
+function isCloudWatchLogsResourceNotFoundError(error) {
+  const providerError = error && error.providerError;
+  const errorCode =
+    (providerError && (providerError.code || providerError.Code || providerError.name)) ||
+    (error && (error.code || error.Code || error.name));
+  return errorCode === 'ResourceNotFoundException';
+}
+
 module.exports = {
   async checkForChanges() {
     this.serverless.service.provider.shouldNotDeploy = false;
@@ -321,7 +329,10 @@ module.exports = {
       .request('CloudWatchLogs', 'describeSubscriptionFilters', {
         logGroupName,
       })
-      .catch(() => ({ subscriptionFilters: [] }));
+      .catch((error) => {
+        if (isCloudWatchLogsResourceNotFoundError(error)) return { subscriptionFilters: [] };
+        throw error;
+      });
     const subscriptionFilters = response.subscriptionFilters || [];
     if (subscriptionFilters.length === 0) {
       log.debug('no subscription filters detected');

--- a/test/unit/lib/plugins/aws/deploy/lib/check-for-changes.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/check-for-changes.test.js
@@ -1347,13 +1347,11 @@ describe('test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js', () => {
 
     it('treats missing log groups during subscription filter discovery as no filters', async () => {
       const awsDeploy = createAwsDeployTestInstance();
-      const requestStub = sandbox
-        .stub(awsDeploy.provider, 'request')
-        .rejects(
-          Object.assign(new Error('missing log group'), {
-            providerError: { code: 'ResourceNotFoundException' },
-          })
-        );
+      const requestStub = sandbox.stub(awsDeploy.provider, 'request').rejects(
+        Object.assign(new Error('missing log group'), {
+          providerError: { code: 'ResourceNotFoundException' },
+        })
+      );
 
       try {
         const result = await awsDeploy.fixLogGroupSubscriptionFilters({

--- a/test/unit/lib/plugins/aws/deploy/lib/check-for-changes.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/check-for-changes.test.js
@@ -1345,6 +1345,63 @@ describe('test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js', () => {
       }
     });
 
+    it('treats missing log groups during subscription filter discovery as no filters', async () => {
+      const awsDeploy = createAwsDeployTestInstance();
+      const requestStub = sandbox
+        .stub(awsDeploy.provider, 'request')
+        .rejects(
+          Object.assign(new Error('missing log group'), {
+            providerError: { code: 'ResourceNotFoundException' },
+          })
+        );
+
+      try {
+        const result = await awsDeploy.fixLogGroupSubscriptionFilters({
+          accountId: '123456789012',
+          region: 'us-east-1',
+          partition: 'aws',
+          logGroupName: 'missingLogGroup',
+          cloudwatchLogEvents: [],
+        });
+
+        expect(result).to.equal(false);
+        expect(requestStub).to.have.been.calledOnceWithExactly(
+          'CloudWatchLogs',
+          'describeSubscriptionFilters',
+          { logGroupName: 'missingLogGroup' }
+        );
+        expect(requestStub.calledWith('CloudFormation', 'describeStackResource')).to.equal(false);
+        expect(requestStub.calledWith('CloudWatchLogs', 'deleteSubscriptionFilter')).to.equal(
+          false
+        );
+      } finally {
+        awsDeploy.provider.request.restore();
+      }
+    });
+
+    it('surfaces CloudWatch Logs access errors during subscription filter discovery', async () => {
+      const awsDeploy = createAwsDeployTestInstance();
+      sandbox.stub(awsDeploy.provider, 'request').rejects(
+        Object.assign(new Error('denied'), {
+          providerError: { code: 'AccessDeniedException' },
+        })
+      );
+
+      try {
+        await expect(
+          awsDeploy.fixLogGroupSubscriptionFilters({
+            accountId: '123456789012',
+            region: 'us-east-1',
+            partition: 'aws',
+            logGroupName: 'someLogGroupName',
+            cloudwatchLogEvents: [],
+          })
+        ).to.be.rejectedWith('denied');
+      } finally {
+        awsDeploy.provider.request.restore();
+      }
+    });
+
     it('treats malformed external subscription filter names as external without CloudFormation lookup', async () => {
       const awsDeploy = createAwsDeployTestInstance();
       const requestStub = sandbox.stub(awsDeploy.provider, 'request').callsFake(async (service) => {


### PR DESCRIPTION
## Summary
- Treat missing log groups as empty during subscription-filter discovery.
- Surface unexpected CloudWatch Logs discovery failures instead of silently assuming no filters.
- Cover missing-log-group and access-denied behavior.

## Tests
- npx mocha --config \"test/mocha/unit.cjs\" \"test/unit/lib/plugins/aws/deploy/lib/check-for-changes.test.js\"
- npm run lint
- git diff --check