### PR TITLE
Harden CloudFormation variable and Ref resolvers

### DIFF
--- a/lib/configuration/variables/sources/instance-dependent/get-cf.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-cf.js
@@ -51,7 +51,7 @@ module.exports = (serverlessInstance) => {
       })();
 
       if (!result) return { value: null };
-      const outputs = result.Stacks[0].Outputs;
+      const outputs = result.Stacks[0].Outputs || [];
       const output = outputs.find((x) => x.OutputKey === outputLogicalId);
 
       return { value: output ? output.OutputValue : null };

--- a/lib/plugins/aws/utils/resolve-cf-import-value.js
+++ b/lib/plugins/aws/utils/resolve-cf-import-value.js
@@ -7,7 +7,7 @@ async function resolveCfImportValue(provider, name, sdkParams = {}) {
     const targetExportMeta = (result.Exports || []).find((exportMeta) => exportMeta.Name === name);
     if (targetExportMeta) return targetExportMeta.Value;
     if (result.NextToken) {
-      return resolveCfImportValue(provider, name, { NextToken: result.NextToken });
+      return resolveCfImportValue(provider, name, { ...sdkParams, NextToken: result.NextToken });
     }
 
     throw new ServerlessError(

--- a/lib/plugins/aws/utils/resolve-cf-import-value.js
+++ b/lib/plugins/aws/utils/resolve-cf-import-value.js
@@ -4,7 +4,7 @@ const ServerlessError = require('../../../serverless-error');
 
 async function resolveCfImportValue(provider, name, sdkParams = {}) {
   return provider.request('CloudFormation', 'listExports', sdkParams).then((result) => {
-    const targetExportMeta = result.Exports.find((exportMeta) => exportMeta.Name === name);
+    const targetExportMeta = (result.Exports || []).find((exportMeta) => exportMeta.Name === name);
     if (targetExportMeta) return targetExportMeta.Value;
     if (result.NextToken) {
       return resolveCfImportValue(provider, name, { NextToken: result.NextToken });

--- a/lib/plugins/aws/utils/resolve-cf-ref-value.js
+++ b/lib/plugins/aws/utils/resolve-cf-ref-value.js
@@ -10,7 +10,7 @@ async function resolveCfRefValue(provider, resourceLogicalId, sdkParams = {}) {
       Object.assign(sdkParams, { StackName: provider.naming.getStackName() })
     )
     .then((result) => {
-      const targetStackResource = result.StackResourceSummaries.find(
+      const targetStackResource = (result.StackResourceSummaries || []).find(
         (stackResource) => stackResource.LogicalResourceId === resourceLogicalId
       );
       if (targetStackResource) return targetStackResource.PhysicalResourceId;
@@ -19,7 +19,7 @@ async function resolveCfRefValue(provider, resourceLogicalId, sdkParams = {}) {
       }
 
       throw new ServerlessError(
-        `Could not resolve Ref with name ${resourceLogicalId}. Are you sure this value matches one resource logical ID ?`,
+        `Could not resolve Ref with name ${resourceLogicalId}. Are you sure this value matches a resource logical ID?`,
         'CF_REF_RESOLUTION'
       );
     });

--- a/lib/plugins/aws/utils/resolve-cf-ref-value.js
+++ b/lib/plugins/aws/utils/resolve-cf-ref-value.js
@@ -4,18 +4,20 @@ const ServerlessError = require('../../../serverless-error');
 
 async function resolveCfRefValue(provider, resourceLogicalId, sdkParams = {}) {
   return provider
-    .request(
-      'CloudFormation',
-      'listStackResources',
-      Object.assign(sdkParams, { StackName: provider.naming.getStackName() })
-    )
+    .request('CloudFormation', 'listStackResources', {
+      ...sdkParams,
+      StackName: provider.naming.getStackName(),
+    })
     .then((result) => {
       const targetStackResource = (result.StackResourceSummaries || []).find(
         (stackResource) => stackResource.LogicalResourceId === resourceLogicalId
       );
       if (targetStackResource) return targetStackResource.PhysicalResourceId;
       if (result.NextToken) {
-        return resolveCfRefValue(provider, resourceLogicalId, { NextToken: result.NextToken });
+        return resolveCfRefValue(provider, resourceLogicalId, {
+          ...sdkParams,
+          NextToken: result.NextToken,
+        });
       }
 
       throw new ServerlessError(

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/get-cf.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/get-cf.test.js
@@ -20,6 +20,7 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-c
         existing: '${cf:existing.someOutput}',
         existingInRegion: '${cf(eu-west-1):existing.someOutput}',
         noOutput: '${cf:existing.unrecognizedOutput, null}',
+        noOutputs: '${cf:noOutputs.someOutput, null}',
         noStack: '${cf:notExisting.someOutput, null}',
         missingAddress: '${cf:}',
         invalidAddress: '${cf:invalid}',
@@ -38,6 +39,9 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-c
                 { Outputs: [{ OutputKey: 'someOutput', OutputValue: region || 'someValue' }] },
               ],
             };
+          }
+          if (StackName === 'noOutputs') {
+            return { Stacks: [{}] };
           }
           if (StackName === 'notExisting') {
             throw Object.assign(new Error('Stack with id not-existing does not exist'), {
@@ -72,6 +76,12 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-c
   it('should resolve null on missing output', () => {
     if (variablesMeta.get('custom\0noOutput')) throw variablesMeta.get('custom\0noOutput').error;
     expect(configuration.custom.noOutput).to.equal(null);
+  });
+  it('should resolve null when stack has no outputs', () => {
+    if (variablesMeta.get('custom\0noOutputs')) {
+      throw variablesMeta.get('custom\0noOutputs').error;
+    }
+    expect(configuration.custom.noOutputs).to.equal(null);
   });
   it('should resolve null on missing stack', () => {
     if (variablesMeta.get('custom\0noStack')) throw variablesMeta.get('custom\0noStack').error;

--- a/test/unit/lib/plugins/aws/utils/resolve-cf-import-value.test.js
+++ b/test/unit/lib/plugins/aws/utils/resolve-cf-import-value.test.js
@@ -22,4 +22,34 @@ describe('#resolveCfImportValue', () => {
     const result = await resolveCfImportValue(provider, 'exportName');
     expect(result).to.equal('exportValue');
   });
+
+  it('should continue pagination when a page has no exports', async () => {
+    const requests = [];
+    const provider = {
+      request: async (service, method, params) => {
+        requests.push({ service, method, params });
+        if (!params.NextToken) return { NextToken: 'next-page' };
+        return {
+          Exports: [
+            {
+              Name: 'exportName',
+              Value: 'exportValue',
+            },
+          ],
+        };
+      },
+    };
+
+    const result = await resolveCfImportValue(provider, 'exportName');
+
+    expect(result).to.equal('exportValue');
+    expect(requests).to.deep.equal([
+      { service: 'CloudFormation', method: 'listExports', params: {} },
+      {
+        service: 'CloudFormation',
+        method: 'listExports',
+        params: { NextToken: 'next-page' },
+      },
+    ]);
+  });
 });

--- a/test/unit/lib/plugins/aws/utils/resolve-cf-import-value.test.js
+++ b/test/unit/lib/plugins/aws/utils/resolve-cf-import-value.test.js
@@ -25,6 +25,7 @@ describe('#resolveCfImportValue', () => {
 
   it('should continue pagination when a page has no exports', async () => {
     const requests = [];
+    const sdkParams = { SomeParam: 'kept' };
     const provider = {
       request: async (service, method, params) => {
         requests.push({ service, method, params });
@@ -40,15 +41,16 @@ describe('#resolveCfImportValue', () => {
       },
     };
 
-    const result = await resolveCfImportValue(provider, 'exportName');
+    const result = await resolveCfImportValue(provider, 'exportName', sdkParams);
 
     expect(result).to.equal('exportValue');
+    expect(sdkParams).to.deep.equal({ SomeParam: 'kept' });
     expect(requests).to.deep.equal([
-      { service: 'CloudFormation', method: 'listExports', params: {} },
+      { service: 'CloudFormation', method: 'listExports', params: { SomeParam: 'kept' } },
       {
         service: 'CloudFormation',
         method: 'listExports',
-        params: { NextToken: 'next-page' },
+        params: { SomeParam: 'kept', NextToken: 'next-page' },
       },
     ]);
   });

--- a/test/unit/lib/plugins/aws/utils/resolve-cf-ref-value.test.js
+++ b/test/unit/lib/plugins/aws/utils/resolve-cf-ref-value.test.js
@@ -28,6 +28,7 @@ describe('#resolveCfRefValue', () => {
 
   it('should continue pagination when a page has no stack resources', async () => {
     const requests = [];
+    const sdkParams = { SomeParam: 'kept' };
     const provider = {
       naming: {
         getStackName: () => 'stack-name',
@@ -46,19 +47,20 @@ describe('#resolveCfRefValue', () => {
       },
     };
 
-    const result = await resolveCfRefValue(provider, 'myDB');
+    const result = await resolveCfRefValue(provider, 'myDB', sdkParams);
 
     expect(result).to.equal('stack-name-db-id');
+    expect(sdkParams).to.deep.equal({ SomeParam: 'kept' });
     expect(requests).to.deep.equal([
       {
         service: 'CloudFormation',
         method: 'listStackResources',
-        params: { StackName: 'stack-name' },
+        params: { SomeParam: 'kept', StackName: 'stack-name' },
       },
       {
         service: 'CloudFormation',
         method: 'listStackResources',
-        params: { NextToken: 'next-page', StackName: 'stack-name' },
+        params: { SomeParam: 'kept', NextToken: 'next-page', StackName: 'stack-name' },
       },
     ]);
   });

--- a/test/unit/lib/plugins/aws/utils/resolve-cf-ref-value.test.js
+++ b/test/unit/lib/plugins/aws/utils/resolve-cf-ref-value.test.js
@@ -25,4 +25,63 @@ describe('#resolveCfRefValue', () => {
     const result = await resolveCfRefValue(provider, 'myDB');
     expect(result).to.equal('stack-name-db-id');
   });
+
+  it('should continue pagination when a page has no stack resources', async () => {
+    const requests = [];
+    const provider = {
+      naming: {
+        getStackName: () => 'stack-name',
+      },
+      request: async (service, method, params) => {
+        requests.push({ service, method, params });
+        if (!params.NextToken) return { NextToken: 'next-page' };
+        return {
+          StackResourceSummaries: [
+            {
+              LogicalResourceId: 'myDB',
+              PhysicalResourceId: 'stack-name-db-id',
+            },
+          ],
+        };
+      },
+    };
+
+    const result = await resolveCfRefValue(provider, 'myDB');
+
+    expect(result).to.equal('stack-name-db-id');
+    expect(requests).to.deep.equal([
+      {
+        service: 'CloudFormation',
+        method: 'listStackResources',
+        params: { StackName: 'stack-name' },
+      },
+      {
+        service: 'CloudFormation',
+        method: 'listStackResources',
+        params: { NextToken: 'next-page', StackName: 'stack-name' },
+      },
+    ]);
+  });
+
+  it('should report a clear error when no resource matches', async () => {
+    const provider = {
+      naming: {
+        getStackName: () => 'stack-name',
+      },
+      request: async () => ({ StackResourceSummaries: [] }),
+    };
+
+    let error;
+    try {
+      await resolveCfRefValue(provider, 'missingResource');
+    } catch (caughtError) {
+      error = caughtError;
+    }
+
+    expect(error).to.have.property(
+      'message',
+      'Could not resolve Ref with name missingResource. Are you sure this value matches a resource logical ID?'
+    );
+    expect(error).to.have.property('code', 'CF_REF_RESOLUTION');
+  });
 });


### PR DESCRIPTION
## Summary
- Treat omitted CloudFormation Outputs, Exports, and StackResourceSummaries as empty arrays.
- Fix the user-facing Ref resolution error message grammar.
- Add focused resolver coverage for optional response arrays and pagination.

## Tests
- npx mocha --config \"test/mocha/unit.cjs\" \"test/unit/lib/configuration/variables/sources/instance-dependent/get-cf.test.js\" \"test/unit/lib/plugins/aws/utils/resolve-cf-import-value.test.js\" \"test/unit/lib/plugins/aws/utils/resolve-cf-ref-value.test.js\"
- npm run lint
- npm run prettier-check
- git diff --check