### PR TITLE
Fix paginated deployment artifact comparison

### DIFF
--- a/lib/plugins/aws/deploy/lib/check-for-changes.js
+++ b/lib/plugins/aws/deploy/lib/check-for-changes.js
@@ -69,9 +69,17 @@ module.exports = {
       Prefix: `${prefix}/${service}/${stage}/`,
     };
 
-    const result = await (async () => {
+    const result = { Contents: [] };
+    let ContinuationToken;
+
+    do {
       try {
-        return await this.provider.request('S3', 'listObjectsV2', params);
+        const page = await this.provider.request('S3', 'listObjectsV2', {
+          ...params,
+          ...(ContinuationToken ? { ContinuationToken } : {}),
+        });
+        result.Contents.push(...(page?.Contents ?? []));
+        ContinuationToken = page && page.NextContinuationToken;
       } catch (error) {
         if (!error.message.includes('The specified bucket does not exist')) throw error;
         const stackName = this.provider.naming.getStackName();
@@ -84,7 +92,8 @@ module.exports = {
           'DEPLOYMENT_BUCKET_DOES_NOT_EXIST'
         );
       }
-    })();
+    } while (ContinuationToken);
+
     const deploymentObjects = (result?.Contents ?? []).flatMap((object) => {
       const entry = parseDeploymentObjectKey(object.Key, prefix, service, stage);
       if (!entry) return [];

--- a/test/unit/lib/plugins/aws/deploy/lib/check-for-changes.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/check-for-changes.test.js
@@ -276,6 +276,97 @@ describe('checkForChanges', () => {
         { Key: `${s3Key}/151224711231-2016-08-18T15:43:00/artifact.zip` },
       ]);
     });
+
+    it('should select the newest deployment directory across paginated results', async () => {
+      listObjectsV2Stub
+        .onFirstCall()
+        .resolves({
+          Contents: [
+            { Key: `${s3Key}/141264711231-2016-08-18T15:42:00/artifact.zip` },
+            { Key: `${s3Key}/141264711231-2016-08-18T15:42:00/cloudformation.json` },
+          ],
+          NextContinuationToken: 'next-page',
+        })
+        .onSecondCall()
+        .resolves({
+          Contents: [
+            { Key: `${s3Key}/151224711231-2016-08-18T15:43:00/artifact.zip` },
+            { Key: `${s3Key}/151224711231-2016-08-18T15:43:00/cloudformation.json` },
+          ],
+        });
+
+      const result = await awsDeploy.getMostRecentObjects();
+
+      expect(listObjectsV2Stub).to.have.been.calledTwice;
+      expect(listObjectsV2Stub.firstCall.args).to.deep.equal([
+        'S3',
+        'listObjectsV2',
+        {
+          Bucket: awsDeploy.bucketName,
+          Prefix: 'serverless/my-service/dev/',
+        },
+      ]);
+      expect(listObjectsV2Stub.secondCall.args).to.deep.equal([
+        'S3',
+        'listObjectsV2',
+        {
+          Bucket: awsDeploy.bucketName,
+          Prefix: 'serverless/my-service/dev/',
+          ContinuationToken: 'next-page',
+        },
+      ]);
+      expect(result).to.deep.equal([
+        { Key: `${s3Key}/151224711231-2016-08-18T15:43:00/cloudformation.json` },
+        { Key: `${s3Key}/151224711231-2016-08-18T15:43:00/artifact.zip` },
+      ]);
+    });
+
+    it('should collect the latest deployment directory when it is split across pages', async () => {
+      listObjectsV2Stub
+        .onFirstCall()
+        .resolves({
+          Contents: [{ Key: `${s3Key}/151224711231-2016-08-18T15:43:00/artifact.zip` }],
+          NextContinuationToken: 'next-page',
+        })
+        .onSecondCall()
+        .resolves({
+          Contents: [{ Key: `${s3Key}/151224711231-2016-08-18T15:43:00/cloudformation.json` }],
+        });
+
+      const result = await awsDeploy.getMostRecentObjects();
+
+      expect(listObjectsV2Stub).to.have.been.calledTwice;
+      expect(result).to.deep.equal([
+        { Key: `${s3Key}/151224711231-2016-08-18T15:43:00/cloudformation.json` },
+        { Key: `${s3Key}/151224711231-2016-08-18T15:43:00/artifact.zip` },
+      ]);
+    });
+
+    it('should translate missing bucket errors from later pages', async () => {
+      listObjectsV2Stub
+        .onFirstCall()
+        .resolves({ Contents: [], NextContinuationToken: 'next-page' })
+        .onSecondCall()
+        .rejects(new ServerlessError('The specified bucket does not exist'));
+
+      let error;
+      try {
+        await awsDeploy.getMostRecentObjects();
+      } catch (caughtError) {
+        error = caughtError;
+      }
+
+      expect(listObjectsV2Stub).to.have.been.calledTwice;
+      expect(error).to.have.property('code', 'DEPLOYMENT_BUCKET_DOES_NOT_EXIST');
+      expect(error).to.have.property(
+        'message',
+        [
+          `The serverless deployment bucket "${awsDeploy.bucketName}" does not exist.`,
+          'Create it manually if you want to reuse the CloudFormation stack "my-service-dev",',
+          'or delete the stack if it is no longer required.',
+        ].join(' ')
+      );
+    });
   });
 
   describe('#getFunctionsEarliestLastModifiedDate()', () => {


### PR DESCRIPTION
## Summary
- List all deployment artifact pages before selecting the latest deployment directory.
- Preserve existing missing-bucket error translation across paginated S3 responses.
- Add coverage for latest directories on later pages and split across pages.

## Tests
- npx mocha --config \"test/mocha/unit.cjs\" \"test/unit/lib/plugins/aws/deploy/lib/check-for-changes.test.js\"
- npm run lint
- npm run prettier-check
- git diff --check