### PR TITLE
Fix paginated deploy list output

### DIFF
--- a/lib/plugins/aws/deploy-list.js
+++ b/lib/plugins/aws/deploy-list.js
@@ -31,12 +31,19 @@ class AwsDeployList {
     const stage = this.provider.getStage();
     const prefix = this.provider.getDeploymentPrefix();
 
-    let response;
+    const response = { Contents: [] };
+    let ContinuationToken;
+
     try {
-      response = await this.provider.request('S3', 'listObjectsV2', {
-        Bucket: this.bucketName,
-        Prefix: `${prefix}/${service}/${stage}/`,
-      });
+      do {
+        const page = await this.provider.request('S3', 'listObjectsV2', {
+          Bucket: this.bucketName,
+          Prefix: `${prefix}/${service}/${stage}/`,
+          ...(ContinuationToken ? { ContinuationToken } : {}),
+        });
+        response.Contents.push(...(page?.Contents || []));
+        ContinuationToken = page && page.NextContinuationToken;
+      } while (ContinuationToken);
     } catch (err) {
       if (err.code === 'AWS_S3_LIST_OBJECTS_V2_ACCESS_DENIED') {
         throw new ServerlessError(

--- a/test/unit/lib/plugins/aws/deploy-list.test.js
+++ b/test/unit/lib/plugins/aws/deploy-list.test.js
@@ -2,6 +2,7 @@
 
 const sinon = require('sinon');
 const expect = require('chai').expect;
+const proxyquire = require('proxyquire');
 const AwsDeployList = require('../../../../../lib/plugins/aws/deploy-list');
 const AwsProvider = require('../../../../../lib/plugins/aws/provider');
 const Serverless = require('../../../../../lib/serverless');
@@ -66,6 +67,135 @@ describe('AwsDeployList', () => {
         })
       ).to.be.equal(true);
       awsDeployList.provider.request.restore();
+    });
+
+    it('should display deployments across paginated object listings', async () => {
+      const listObjectsStub = sinon
+        .stub(awsDeployList.provider, 'request')
+        .onFirstCall()
+        .resolves({
+          Contents: [{ Key: `${s3Key}/113304333331-2016-08-18T13:40:06/artifact.zip` }],
+          NextContinuationToken: 'next-page',
+        })
+        .onSecondCall()
+        .resolves({
+          Contents: [{ Key: `${s3Key}/903940390431-2016-08-18T23:42:08/artifact.zip` }],
+        });
+
+      try {
+        await awsDeployList.listDeployments();
+
+        expect(listObjectsStub).to.have.been.calledTwice;
+        expect(listObjectsStub.firstCall.args).to.deep.equal([
+          'S3',
+          'listObjectsV2',
+          {
+            Bucket: awsDeployList.bucketName,
+            Prefix: `${s3Key}/`,
+          },
+        ]);
+        expect(listObjectsStub.secondCall.args).to.deep.equal([
+          'S3',
+          'listObjectsV2',
+          {
+            Bucket: awsDeployList.bucketName,
+            Prefix: `${s3Key}/`,
+            ContinuationToken: 'next-page',
+          },
+        ]);
+      } finally {
+        awsDeployList.provider.request.restore();
+      }
+    });
+
+    it('should print no deployments in case paginated listings contain no deployments', async () => {
+      const listObjectsStub = sinon
+        .stub(awsDeployList.provider, 'request')
+        .onFirstCall()
+        .resolves({ Contents: [], NextContinuationToken: 'next-page' })
+        .onSecondCall()
+        .resolves({ Contents: [] });
+
+      try {
+        await awsDeployList.listDeployments();
+
+        expect(listObjectsStub).to.have.been.calledTwice;
+        expect(listObjectsStub.secondCall.args).to.deep.equal([
+          'S3',
+          'listObjectsV2',
+          {
+            Bucket: awsDeployList.bucketName,
+            Prefix: `${s3Key}/`,
+            ContinuationToken: 'next-page',
+          },
+        ]);
+      } finally {
+        awsDeployList.provider.request.restore();
+      }
+    });
+
+    it('should print a deployment directory split across paginated object listings as one group', async () => {
+      const writeTextStub = sinon.stub();
+      const ProxiedAwsDeployList = proxyquire('../../../../../lib/plugins/aws/deploy-list', {
+        '../../utils/serverless-utils/log': {
+          log: { notice: sinon.stub() },
+          writeText: writeTextStub,
+        },
+      });
+      const proxiedDeployList = new ProxiedAwsDeployList(serverless, {
+        stage: 'dev',
+        region: 'us-east-1',
+      });
+      proxiedDeployList.bucketName = 'deployment-bucket';
+      const listObjectsStub = sinon
+        .stub(proxiedDeployList.provider, 'request')
+        .onFirstCall()
+        .resolves({
+          Contents: [{ Key: `${s3Key}/113304333331-2016-08-18T13:40:06/artifact.zip` }],
+          NextContinuationToken: 'next-page',
+        })
+        .onSecondCall()
+        .resolves({
+          Contents: [{ Key: `${s3Key}/113304333331-2016-08-18T13:40:06/cloudformation.json` }],
+        });
+
+      try {
+        await proxiedDeployList.listDeployments();
+
+        expect(listObjectsStub).to.have.been.calledTwice;
+        expect(
+          writeTextStub.getCalls().filter((call) => call.args.includes('Timestamp: 113304333331'))
+        ).to.have.length(1);
+        expect(writeTextStub.calledWith('  - artifact.zip')).to.equal(true);
+        expect(writeTextStub.calledWith('  - cloudformation.json')).to.equal(true);
+      } finally {
+        proxiedDeployList.provider.request.restore();
+      }
+    });
+
+    it('should translate access denied from a later page', async () => {
+      const listObjectsStub = sinon
+        .stub(awsDeployList.provider, 'request')
+        .onFirstCall()
+        .resolves({ Contents: [], NextContinuationToken: 'next-page' })
+        .onSecondCall()
+        .rejects(
+          Object.assign(new Error('denied'), { code: 'AWS_S3_LIST_OBJECTS_V2_ACCESS_DENIED' })
+        );
+
+      try {
+        await awsDeployList.listDeployments();
+        throw new Error('Expected listDeployments to throw');
+      } catch (error) {
+        expect(listObjectsStub).to.have.been.calledTwice;
+        expect(error).to.have.property('code', 'AWS_S3_LIST_OBJECTS_V2_ACCESS_DENIED');
+        expect(error).to.have.property(
+          'message',
+          'Could not list objects in the deployment bucket. Make sure you have sufficient permissions to access it.'
+        );
+      } finally {
+        awsDeployList.provider.request.restore();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- List all deployment artifact pages before rendering deploy list output.
- Preserve existing grouping and access-denied behavior.
- Add coverage for paginated, empty, split-directory, and later-page access-denied cases.

## Tests
- npx mocha --config \"test/mocha/unit.cjs\" \"test/unit/lib/plugins/aws/deploy-list.test.js\"
- npm run lint
- npm run prettier-check
- git diff --check