### PR TITLE
Fix deploy function IAM role ARN lookup

### DIFF
--- a/lib/plugins/aws/deploy-function.js
+++ b/lib/plugins/aws/deploy-function.js
@@ -148,7 +148,7 @@ class AwsDeployFunction {
     const data = await this.provider.request('IAM', 'getRole', {
       RoleName: role['Fn::GetAtt'][0],
     });
-    return data.Arn;
+    return data.Role.Arn;
   }
 
   async ensureFunctionState() {

--- a/test/unit/lib/plugins/aws/deploy-function.test.js
+++ b/test/unit/lib/plugins/aws/deploy-function.test.js
@@ -125,7 +125,7 @@ describe('AwsDeployFunction', () => {
         .resolves({ accountId: '123456789012', partition: 'aws' });
       getRoleStub = sinon
         .stub(awsDeployFunction.provider, 'request')
-        .resolves({ Arn: 'arn:aws:iam::123456789012:role/role_2' });
+        .resolves({ Role: { Arn: 'arn:aws:iam::123456789012:role/role_2' } });
 
       serverless.service.resources = {
         Resources: {
@@ -171,6 +171,9 @@ describe('AwsDeployFunction', () => {
       const result = await awsDeployFunction.normalizeArnRole(roleObj);
 
       expect(getRoleStub.calledOnce).to.be.equal(true);
+      expect(getRoleStub.calledWithExactly('IAM', 'getRole', { RoleName: 'role_2' })).to.equal(
+        true
+      );
       expect(getAccountInfoStub).to.not.have.been.called;
       expect(result).to.be.equal('arn:aws:iam::123456789012:role/role_2');
     });


### PR DESCRIPTION
Fix deploy function role normalization so IAM getRole reads Role.Arn from the AWS response.