### PR TITLE
Ignore inherited AWS region options

### DIFF
--- a/lib/configuration/variables/sources/instance-dependent/get-aws.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-aws.js
@@ -2,6 +2,7 @@
 
 const ensureString = require('type/string/ensure');
 const ServerlessError = require('../../../../serverless-error');
+const { hasOwn } = require('../../../../utils/safe-object');
 
 module.exports = (serverlessInstance) => {
   return {
@@ -27,8 +28,12 @@ module.exports = (serverlessInstance) => {
           return { value: Account };
         }
         case 'region': {
-          let region = options.region;
-          if (!region) region = await resolveConfigurationProperty(['provider', 'region']);
+          let region;
+          if (hasOwn(options, 'region') && options.region) {
+            region = options.region;
+          } else {
+            region = await resolveConfigurationProperty(['provider', 'region']);
+          }
           if (!region) region = 'us-east-1';
           return { value: region };
         }

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/get-aws.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/get-aws.test.js
@@ -105,4 +105,23 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-a
     );
     expect(configuration.custom.region).to.equal('eu-central-1');
   });
+
+  it('should ignore inherited region from options', async () => {
+    const source = getAwsSource({
+      getProvider: () => ({
+        constructor: {
+          getProviderName: () => 'aws',
+        },
+        request: async () => ({ Account: '1234567890' }),
+      }),
+    });
+
+    const result = await source.resolve({
+      address: 'region',
+      options: Object.create({ region: 'eu-central-1' }),
+      resolveConfigurationProperty: async () => 'eu-west-1',
+    });
+
+    expect(result.value).to.equal('eu-west-1');
+  });
 });


### PR DESCRIPTION
Ignore inherited region option values when resolving aws:region.