### PR TITLE
Adjust deprecation schedules to remove things deprecated in 1.x and 2.x in 4.0.0 and delay everything else until 5.0.0

### DIFF
--- a/docs/events/alexa-skill.md
+++ b/docs/events/alexa-skill.md
@@ -39,4 +39,6 @@ The previous syntax of this event didn't require a skill ID as parameter, but ac
 
 Omitting the skill id will make your Lambda function publicly available, which will allow any other skill developer to invoke it.
 
+The bare `alexaSkill` event form without a skill ID is scheduled for removal in osls v4.0.0. Use `alexaSkill: <appId>` or the object form with `appId` instead.
+
 (This is important, as [opposed to custom HTTPS endpoints](https://developer.amazon.com/docs/custom-skills/handle-requests-sent-by-alexa.html#request-verify), there's no way to validate the request was sent by your skill.)

--- a/docs/events/event-bridge.md
+++ b/docs/events/event-bridge.md
@@ -2,7 +2,7 @@
 
 The [EventBridge](https://aws.amazon.com/eventbridge/) makes it possible to connect applications using data from external sources (e.g. own applications, SaaS) or AWS services. The `eventBridge` event types helps setting up AWS Lambda functions to react to events coming in via the EventBridge.
 
-_Note_: Prior to CLI version `2.27.0`, `eventBridge` resources were provisioned with Custom Resources. With `2.27.0` an optional support for native CloudFormation was introduced and can be turned on by setting `provider.eventBridge.useCloudFormation: true`. It is recommended to migrate to native CloudFormation as it's by default with v3. It also adds the ability to define `eventBus` with CF intrinsic functions as values.
+_Note_: Prior to CLI version `2.27.0`, `eventBridge` resources were provisioned with Custom Resources. Native CloudFormation support is the default in v3. The `provider.eventBridge.useCloudFormation` compatibility setting is no longer needed and is scheduled for removal in osls v4.0.0. Native CloudFormation also adds the ability to define `eventBus` with CF intrinsic functions as values.
 
 ## Setting up a scheduled event
 
@@ -114,13 +114,7 @@ functions:
 
 ### Reusing an existing event bus
 
-If you want to reuse an existing event bus, you can define it with literal `arn` or with a reference to an existing event bus name via CF intrinsic functions. Referencing via intrinsic functions is available only if you use native CloudFormation support with `provider.eventBridge.useCloudFormation: true` setting:
-
-```yml
-provider:
-  eventBridge:
-    useCloudFormation: true
-```
+If you want to reuse an existing event bus, you can define it with literal `arn` or with a reference to an existing event bus name via CF intrinsic functions. Referencing via intrinsic functions is available with the native CloudFormation support used by default in v3.
 
 Using literal `arn`:
 

--- a/docs/events/http-api.md
+++ b/docs/events/http-api.md
@@ -429,7 +429,7 @@ provider:
 
 In the above example, the tag project: myProject will be applied to API Gateway and API Gateway Stage.
 
-The `provider.httpApi.useProviderTags` property is no longer effective and is scheduled for removal in osls v4.0.0.
+The `provider.httpApi.useProviderTags` property is no longer effective and is scheduled for removal in osls v5.0.0.
 
 _Note: If the API Gateway has any existing tags applied outside of osls, they will be removed during deployment._
 

--- a/docs/events/http-api.md
+++ b/docs/events/http-api.md
@@ -419,17 +419,17 @@ provider:
 
 ## Tags
 
-When using HTTP API, it is possible to tag the corresponding API Gateway resources. By setting `provider.httpApi.useProviderTags` to `true`, all tags defined on `provider.tags` will be applied to API Gateway and API Gateway Stage.
+When using HTTP API, all tags defined on `provider.tags` are applied to API Gateway and API Gateway Stage by default.
 
 ```yaml
 provider:
   tags:
     project: myProject
-  httpApi:
-    useProviderTags: true
 ```
 
 In the above example, the tag project: myProject will be applied to API Gateway and API Gateway Stage.
+
+The `provider.httpApi.useProviderTags` property is no longer effective and is scheduled for removal in osls v4.0.0.
 
 _Note: If the API Gateway has any existing tags applied outside of osls, they will be removed during deployment._
 

--- a/docs/events/websocket.md
+++ b/docs/events/websocket.md
@@ -282,6 +282,8 @@ provider:
 
 When using Websocket API, it is possible to tag the corresponding API Gateway resources. By setting `provider.websocket.useProviderTags` to `true`, all tags defined on `provider.tags` will be applied to API Gateway and API Gateway Stage.
 
+This opt-in exists to prepare for osls v5.0.0, where provider tags will be applied to Websocket API Gateway by default.
+
 ```yaml
 provider:
   tags:

--- a/docs/events/websocket.md
+++ b/docs/events/websocket.md
@@ -282,7 +282,7 @@ provider:
 
 When using Websocket API, it is possible to tag the corresponding API Gateway resources. By setting `provider.websocket.useProviderTags` to `true`, all tags defined on `provider.tags` will be applied to API Gateway and API Gateway Stage.
 
-This opt-in exists to prepare for osls v5.0.0, where provider tags will be applied to Websocket API Gateway by default.
+This opt-in exists to prepare for osls v4.0.0, where provider tags will be applied to Websocket API Gateway by default. Starting with osls v4.0.0, `provider.websocket.useProviderTags` will be deprecated and scheduled for removal in osls v5.0.0.
 
 ```yaml
 provider:

--- a/docs/guides/configuration-validation.md
+++ b/docs/guides/configuration-validation.md
@@ -10,7 +10,7 @@ If you were presented with configuration error (or a warning, depending on `conf
 
 **Note**: In a warning mode (with `configValidationMode: warn` set in configuration) osls commands are not blocked in any way, e.g. `sls deploy` will still attempt to deploy the service normally (still depending on the source of the warning, success of a deployment may vary)
 
-When the setting is not explicitly specified, osls defaults to `configValidationMode: warn`. If you find this functionality problematic, you may also turn it off with `configValidationMode: off` setting.
+When the setting is not explicitly specified, osls defaults to `configValidationMode: warn`. Starting with osls v4.0.0, the default will change to `configValidationMode: error`. If you find this functionality problematic, you may also turn it off with `configValidationMode: off` setting.
 
 ## Configuration
 

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -48,9 +48,11 @@ Learn more about configuration validation here: ./configuration-validation.md
 
 Deprecation code: `VARIABLES_RESOLUTION_MODE`
 
-Removal target: osls v5.0.0
+Removal targets: `20210219` mode in osls v4.0.0; property in osls v5.0.0
 
-Starting with v3.0.0, `variablesResolutionMode` is no longer effective because the new variables resolver is used by default. Drop it to avoid future validation errors. The `variablesResolutionMode` property is scheduled for removal from accepted configuration in osls v5.0.0.
+Starting with v3.0.0, `variablesResolutionMode` is no longer effective because the new variables resolver is used by default. Drop it to avoid future validation errors.
+
+The old `variablesResolutionMode: 20210219` mode is scheduled to be rejected in osls v4.0.0. The `variablesResolutionMode` property itself, including the no-op `20210326` value, is scheduled for removal from accepted configuration in osls v5.0.0.
 
 Learn more about configuration validation here: ./configuration-validation.md
 

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -36,7 +36,9 @@ Note:
 
 Deprecation code: `CONSOLE_CONFIGURATION`
 
-Starting with v3.24.0, osls will no longer recognize inner `console` configuration. All Serverless Console related configuration is expected to be maintained at https://console.serverless.com
+Removal target: osls v5.0.0
+
+Starting with v3.24.0, osls no longer recognizes inner `console` configuration. All Serverless Console related configuration is expected to be maintained at https://console.serverless.com. The `console` property is scheduled for removal from accepted configuration in osls v5.0.0.
 
 Learn more about configuration validation here: ./configuration-validation.md
 
@@ -46,7 +48,9 @@ Learn more about configuration validation here: ./configuration-validation.md
 
 Deprecation code: `VARIABLES_RESOLUTION_MODE`
 
-Starting with Serverless Framework v4.0.0, `variablesResolutionMode` is no longer recognized as a supported configuration property. Drop it to avoid validation errors
+Removal target: osls v5.0.0
+
+Starting with v3.0.0, `variablesResolutionMode` is no longer effective because the new variables resolver is used by default. Drop it to avoid future validation errors. The `variablesResolutionMode` property is scheduled for removal from accepted configuration in osls v5.0.0.
 
 Learn more about configuration validation here: ./configuration-validation.md
 
@@ -56,7 +60,9 @@ Learn more about configuration validation here: ./configuration-validation.md
 
 Deprecation code: `PROJECT_DIR`
 
-Starting with Serverless Framework v4.0.0, `projectDir` is no longer recognized as a supported configuration property. Drop it to avoid validation errors
+Removal target: osls v5.0.0
+
+The `projectDir` option is no longer used and is ignored. Drop it to avoid future validation errors. The `projectDir` property is scheduled for removal from accepted configuration in osls v5.0.0.
 
 Learn more about configuration validation here: ./configuration-validation.md
 
@@ -66,19 +72,23 @@ Learn more about configuration validation here: ./configuration-validation.md
 
 Deprecation code: `CLI_OPTIONS_SCHEMA_V3`
 
+Removal target: osls v4.0.0
+
 Internal handling of CLI arguments was improved with type awareness for options. Now each option definition is expected have `type` defined in its settings.
 
 Possible values are `string`, `boolean` and `multiple`. Check [Defining options](./plugins#defining-options) documentation for more info.
 
 If you rely on a plugin which does not set types (yet) please report the issue at its issue tracker.
 
-Starting with v4.0.0 any option extensions which does not have `type` defined will be communicated with a thrown error
+Starting with osls v4.0.0, option extensions that do not have `type` defined will be communicated with a thrown error.
 
 <a name="PROVIDER_IAM_SETTINGS_V3"><div>&nbsp;</div></a>
 
 ## Grouping IAM settings under `provider.iam`
 
-Deprecation code: `PROVIDER_IAM_SETTINGS_v3`
+Deprecation code: `PROVIDER_IAM_SETTINGS_V3`
+
+Removal target: osls v4.0.0
 
 All IAM-related settings of _provider_ including `iamRoleStatements`, `iamManagedPolicies`, `role` and `cfnRole` are also now supported at `iam` property. Refer to the [IAM Guide](./iam.md).
 
@@ -90,7 +100,7 @@ All IAM-related settings of _provider_ including `iamRoleStatements`, `iamManage
 
 In addition `iam.role.permissionBoundary` can also be set at `iam.role.permissionsBoundary` (which matches CloudFormation property name).
 
-Starting with v4.0.0 old versions of settings will no longer be supported
+Starting with osls v4.0.0, the old settings will no longer be supported.
 
 <a name="CONFIG_VALIDATION_MODE_DEFAULT_V3"><div>&nbsp;</div></a>
 
@@ -98,7 +108,9 @@ Starting with v4.0.0 old versions of settings will no longer be supported
 
 Deprecation code: `CONFIG_VALIDATION_MODE_DEFAULT_V3`
 
-Starting with Serverless Framework v4.0.0, configuration errors are thrown by default. This is changing from the previous default, `configValidationMode: warn`
+Removal target: osls v4.0.0
+
+Starting with osls v4.0.0, configuration errors are thrown by default. This is changing from the previous default, `configValidationMode: warn`.
 
 Learn more about configuration validation here: ./configuration-validation.md
 
@@ -108,7 +120,9 @@ Learn more about configuration validation here: ./configuration-validation.md
 
 Deprecation code: `PACKAGE_PATTERNS`
 
-Support for `package.include` and `package.exclude` will be removed with v4.0.0. Instead please use `package.patterns` with which both _include_ and _exclude_ (prefixed with `!`) rules can be configured.
+Removal target: osls v4.0.0
+
+Support for `package.include` and `package.exclude` is scheduled for removal in osls v4.0.0. Instead please use `package.patterns` with which both _include_ and _exclude_ (prefixed with `!`) rules can be configured.
 
 Check [Packaging Patterns](./packaging.md#patterns) documentation for more info.
 
@@ -118,7 +132,9 @@ Check [Packaging Patterns](./packaging.md#patterns) documentation for more info.
 
 Deprecation code: `AWS_WEBSOCKET_API_USE_PROVIDER_TAGS`
 
-Starting with v4.0.0, `provider.tags` will be applied to Websocket Api Gateway by default
+Removal target: osls v5.0.0
+
+Starting with osls v5.0.0, `provider.tags` will be applied to Websocket Api Gateway by default.
 Set `provider.websocket.useProviderTags` to `true` to adapt to the new behavior now.
 
 <a name="LAMBDA_HASHING_VERSION_PROPERTY"><div>&nbsp;</div></a>
@@ -127,17 +143,23 @@ Set `provider.websocket.useProviderTags` to `true` to adapt to the new behavior 
 
 Deprecation code: `LAMBDA_HASHING_VERSION_PROPERTY`
 
+Removal target: osls v4.0.0
+
 Lambda version hashes were improved with a better algorithm (that fixed determinism issues). It is used by default starting with v3.0.0.
 
-If you previously opted-in to use new algorithm by setting `provider.lambdaHashingVersion: 20201221`, you can safely remove that property from your configuration in v3.
+If you previously opted-in to use the new algorithm by setting `provider.lambdaHashingVersion: 20201221`, you can safely remove that property from your configuration in v3. The `provider.lambdaHashingVersion` property and old `20200924` hashing path are scheduled for removal in osls v4.0.0.
 
-<a name="AwS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN"><div>&nbsp;</div></a>
+<a name="AWS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN"><div>&nbsp;</div></a>
 
 ## AWS EventBridge lambda event triggers based on Custom Resources
 
 Deprecation code: `AWS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN`
 
-Support for provisioning AWS EventBridge resources without native CloudFormation resources is deprecated and will no longer be maintained. If you want to upgrade to native CloudFormation, remove "eventBridge.useCloudFormation" setting from your configuration. If you are currently using "eventBridge.useCloudFormation" set to `true` to enable native CloudFormation, you can safely remove this setting from your configuration.
+Removal target: osls v4.0.0
+
+Support for provisioning AWS EventBridge resources without native CloudFormation resources is deprecated and will no longer be maintained. The custom resource path and `provider.eventBridge.useCloudFormation` compatibility setting are scheduled for removal in osls v4.0.0.
+
+If you want to upgrade to native CloudFormation, remove `provider.eventBridge.useCloudFormation` from your configuration. If you are currently using `provider.eventBridge.useCloudFormation` set to `true` to enable native CloudFormation, you can safely remove this setting from your configuration.
 
 Note that to migrate away from the legacy behavior, you will need to remove (or comment) EventBridge triggers, deploy, re-add them and re-deploy in order to migrate from the legacy behavior.
 
@@ -147,13 +169,17 @@ Note that to migrate away from the legacy behavior, you will need to remove (or 
 
 Deprecation code: `AWS_HTTP_API_USE_PROVIDER_TAGS_PROPERTY`
 
-Starting with "v3.0.0", property `provider.httpApi.useProviderTags` is no longer effective as provider tags are applied to Http Api Gateway by default. You can safely remove this property from your configuration.
+Removal target: osls v4.0.0
+
+Starting with v3.0.0, property `provider.httpApi.useProviderTags` is no longer effective as provider tags are applied to Http Api Gateway by default. You can safely remove this property from your configuration. The property is scheduled for removal in osls v4.0.0.
 
 <a name="NEW_VARIABLES_RESOLVER"><div>&nbsp;</div></a>
 
 ## New variables resolver
 
 Deprecation code: `NEW_VARIABLES_RESOLVER`
+
+Removal target: osls v4.0.0
 
 A more robust and powerful variable resolver engine was introduced (disabled by default) in Serverless Framework v2. It is used by default in v3.
 
@@ -172,13 +198,17 @@ variablesResolutionMode: 20210326
 
 In v3, the `variablesResolutionMode` option can be removed as the new engine becomes the default.
 
+Plugins that extend variables resolution must use `configurationVariablesSources`. The old `variableResolvers` extension path is scheduled for removal in osls v4.0.0.
+
 <a name="KINESIS_CONSUMER_NAME_CONTAINING_SERVICE"><div>&nbsp;</div></a>
 
 ## Kinesis consumer name will be changed to ensure more uniqueness
 
 Deprecation code: `KINESIS_CONSUMER_NAME_CONTAINING_SERVICE`
 
-Starting with v4.0.0, Kinesis consumer name will be changed. This will lead to downtime during re-deployment. Specifically, the naming pattern will be changed from `${functionName}${streamName}Consumer` to `${functionName}${streamName}${serviceName}${stage}Consumer`.
+Removal target: osls v5.0.0
+
+Starting with osls v5.0.0, Kinesis consumer name will be changed. This will lead to downtime during re-deployment. Specifically, the naming pattern will be changed from `${functionName}${streamName}Consumer` to `${functionName}${streamName}${serviceName}${stage}Consumer`.
 
 Adapt to this convention now by setting `provider.kinesis.consumerNamingMode` to `serviceSpecific` in your serverless.yml file.
 
@@ -190,4 +220,6 @@ The consequence for consumer name change is there will be some downtime during d
 
 Deprecation code: `ALEXA_SKILL_EVENT_WITHOUT_APP_ID`
 
-Starting with v3.0.0, support for `alexaSkill` event without `appId` provided will be removed.
+Removal target: osls v4.0.0
+
+Starting with osls v4.0.0, support for the bare `alexaSkill` event form without `appId` provided will be removed. Use `alexaSkill: <appId>` or the object form with `appId` instead.

--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -36,9 +36,9 @@ Note:
 
 Deprecation code: `CONSOLE_CONFIGURATION`
 
-Removal target: osls v5.0.0
+Removal target: osls v4.0.0
 
-Starting with v3.24.0, osls no longer recognizes inner `console` configuration. All Serverless Console related configuration is expected to be maintained at https://console.serverless.com. The `console` property is scheduled for removal from accepted configuration in osls v5.0.0.
+Starting with v3.24.0, osls no longer recognizes inner `console` configuration. All Serverless Console related configuration is expected to be maintained at https://console.serverless.com. The `console` property is scheduled for removal from accepted configuration in osls v4.0.0.
 
 Learn more about configuration validation here: ./configuration-validation.md
 
@@ -134,10 +134,10 @@ Check [Packaging Patterns](./packaging.md#patterns) documentation for more info.
 
 Deprecation code: `AWS_WEBSOCKET_API_USE_PROVIDER_TAGS`
 
-Removal target: osls v5.0.0
+Behavior change target: osls v4.0.0; field removal target: osls v5.0.0
 
-Starting with osls v5.0.0, `provider.tags` will be applied to Websocket Api Gateway by default.
-Set `provider.websocket.useProviderTags` to `true` to adapt to the new behavior now.
+Starting with osls v4.0.0, `provider.tags` will be applied to Websocket Api Gateway by default.
+Set `provider.websocket.useProviderTags` to `true` in v3 to adapt to the new behavior now. Starting with osls v4.0.0, this field will be deprecated and scheduled for removal in osls v5.0.0.
 
 <a name="LAMBDA_HASHING_VERSION_PROPERTY"><div>&nbsp;</div></a>
 
@@ -171,9 +171,9 @@ Note that to migrate away from the legacy behavior, you will need to remove (or 
 
 Deprecation code: `AWS_HTTP_API_USE_PROVIDER_TAGS_PROPERTY`
 
-Removal target: osls v4.0.0
+Removal target: osls v5.0.0
 
-Starting with v3.0.0, property `provider.httpApi.useProviderTags` is no longer effective as provider tags are applied to Http Api Gateway by default. You can safely remove this property from your configuration. The property is scheduled for removal in osls v4.0.0.
+Starting with v3.0.0, property `provider.httpApi.useProviderTags` is no longer effective as provider tags are applied to Http Api Gateway by default. You can safely remove this property from your configuration. The property is scheduled for removal in osls v5.0.0.
 
 <a name="NEW_VARIABLES_RESOLVER"><div>&nbsp;</div></a>
 

--- a/docs/guides/functions.md
+++ b/docs/guides/functions.md
@@ -926,6 +926,8 @@ functions:
 
 In `v3`, Lambda version hashes are generated using an improved algorithm that fixes determinism issues. If you are still using the old hashing algorithm, you can follow the guide below to migrate to new default version.
 
+The `provider.lambdaHashingVersion` property and old hashing algorithm compatibility path are scheduled for removal in osls v4.0.0.
+
 Please keep in mind that these changes require two deployments with manual configuration adjustment between them. It also creates two additional versions and temporarily overrides descriptions of your functions. Migration will need to be done separately for each of your environments/stages.
 
 1. Run `sls deploy` with additional `--enforce-hash-update` flag: that flag will override the description for Lambda functions, which will force the creation of new versions.

--- a/docs/guides/serverless.yml.md
+++ b/docs/guides/serverless.yml.md
@@ -121,8 +121,6 @@ provider:
     Name: data-protection-policy
   # KMS key ARN to use for encryption for all functions
   kmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash
-  # Version of hashing algorithm used by osls for function packaging
-  lambdaHashingVersion: 20201221
   # Use function versioning (enabled by default)
   versionFunctions: false
   # Processor architecture: 'x86_64' or 'arm64' via Graviton2 (default: x86_64)

--- a/docs/guides/variables.md
+++ b/docs/guides/variables.md
@@ -499,7 +499,7 @@ functions:
 
 ### Exporting a function
 
-_Note: the method described below works by default in Serverless v3, but it requires the `variablesResolutionMode: 20210326` option in v2. In v3, `variablesResolutionMode` is obsolete and scheduled for removal in osls v5.0.0._
+_Note: the method described below works by default in Serverless v3, but it requires the `variablesResolutionMode: 20210326` option in v2. In v3, `variablesResolutionMode` is obsolete; the old `20210219` mode is scheduled to be rejected in osls v4.0.0, and the property itself is scheduled for removal in osls v5.0.0._
 
 A variable resolver function receives an object with the following properties:
 

--- a/docs/guides/variables.md
+++ b/docs/guides/variables.md
@@ -499,7 +499,7 @@ functions:
 
 ### Exporting a function
 
-_Note: the method described below works by default in Serverless v3, but it requires the `variablesResolutionMode: 20210326` option in v2._
+_Note: the method described below works by default in Serverless v3, but it requires the `variablesResolutionMode: 20210326` option in v2. In v3, `variablesResolutionMode` is obsolete and scheduled for removal in osls v5.0.0._
 
 A variable resolver function receives an object with the following properties:
 

--- a/lib/classes/config-schema-handler/index.js
+++ b/lib/classes/config-schema-handler/index.js
@@ -138,7 +138,7 @@ class ConfigSchemaHandler {
         if (!this.serverless.configurationInput.configValidationMode) {
           this.serverless._logDeprecation(
             'CONFIG_VALIDATION_MODE_DEFAULT_V3',
-            'Starting with the next major, osls will throw on configuration errors by' +
+            'Starting with osls 4.0.0, osls will throw on configuration errors by' +
               ' default. Adapt to this behavior now by adding "configValidationMode: error" to' +
               ' the service configuration'
           );

--- a/lib/classes/service.js
+++ b/lib/classes/service.js
@@ -275,21 +275,24 @@ class Service {
       this.serverless._logDeprecation(
         'PROJECT_DIR',
         'The "projectDir" option is no longer used and is ignored. ' +
-          'You can safely remove it from the configuration'
+          'You can safely remove it from the configuration. ' +
+          'This property is scheduled for removal in osls 5.0.0.'
       );
     }
     if (userConfig.variablesResolutionMode != null) {
       this.serverless._logDeprecation(
         'VARIABLES_RESOLUTION_MODE',
-        'Starting with v3.0, the "variablesResolutionMode" option is now useless. ' +
-          'You can safely remove it from the configuration'
+        'Starting with v3.0, the "variablesResolutionMode" option is no longer effective. ' +
+          'You can safely remove it from the configuration. ' +
+          'This property is scheduled for removal in osls 5.0.0.'
       );
     }
     if (userConfig.console != null) {
       this.serverless._logDeprecation(
         'CONSOLE_CONFIGURATION',
         'Starting with v3.24.0, the "console" option is no longer recognized. ' +
-          'Please remove it from the configuration'
+          'Please remove it from the configuration. ' +
+          'This property is scheduled for removal in osls 5.0.0.'
       );
     }
     return this;

--- a/lib/classes/service.js
+++ b/lib/classes/service.js
@@ -280,10 +280,15 @@ class Service {
       );
     }
     if (userConfig.variablesResolutionMode != null) {
+      const oldVariablesResolutionModeMessage =
+        userConfig.variablesResolutionMode === '20210219'
+          ? 'The "20210219" mode is scheduled to be rejected in osls 4.0.0. '
+          : '';
       this.serverless._logDeprecation(
         'VARIABLES_RESOLUTION_MODE',
         'Starting with v3.0, the "variablesResolutionMode" option is no longer effective. ' +
           'You can safely remove it from the configuration. ' +
+          oldVariablesResolutionModeMessage +
           'This property is scheduled for removal in osls 5.0.0.'
       );
     }

--- a/lib/classes/service.js
+++ b/lib/classes/service.js
@@ -297,7 +297,7 @@ class Service {
         'CONSOLE_CONFIGURATION',
         'Starting with v3.24.0, the "console" option is no longer recognized. ' +
           'Please remove it from the configuration. ' +
-          'This property is scheduled for removal in osls 5.0.0.'
+          'This property is scheduled for removal in osls 4.0.0.'
       );
     }
     return this;

--- a/lib/cli/commands-schema/resolve-final.js
+++ b/lib/cli/commands-schema/resolve-final.js
@@ -117,7 +117,7 @@ module.exports = (loadedPlugins, { providerName, configuration }) => {
             `${plugin.constructor.name} for "${Array.from(optionNames).join('", "')}"`
         ).join('\n - ')}\n` +
         'Please report this issue in plugin issue tracker.\n' +
-        'Starting with next major release, this will be communicated with a thrown error.',
+        'Starting with osls 4.0.0, this will be communicated with a thrown error.',
       { serviceConfig: configuration }
     );
   }

--- a/lib/configuration/variables/sources/resolve-external-plugin-sources.js
+++ b/lib/configuration/variables/sources/resolve-external-plugin-sources.js
@@ -53,8 +53,8 @@ module.exports = (configuration, resolverConfiguration, externalPlugins) => {
         'NEW_VARIABLES_RESOLVER',
         `Plugin "${pluginName}" attempts to extend old variables resolver. ` +
           'Ensure to rely on latest version of a plugin and if this warning is ' +
-          'still displayed please report the problem at plugin issue tracker' +
-          'Starting with next major release, ' +
+          'still displayed please report the problem at plugin issue tracker. ' +
+          'Starting with osls 4.0.0, ' +
           'old variables resolver will not be supported.\n',
         { serviceConfig: configuration }
       );

--- a/lib/plugins/aws/package/compile/events/alexa-skill.js
+++ b/lib/plugins/aws/package/compile/events/alexa-skill.js
@@ -32,7 +32,7 @@ class AwsCompileAlexaSkillEvents {
         ) {
           this.serverless._logDeprecation(
             'ALEXA_SKILL_EVENT_WITHOUT_APP_ID',
-            'Starting with next major version, support for alexaSkill event without appId specified will be removed.'
+            'Starting with osls 4.0.0, support for the bare alexaSkill event form without appId specified will be removed.'
           );
         }
       },

--- a/lib/plugins/aws/package/compile/events/event-bridge/index.js
+++ b/lib/plugins/aws/package/compile/events/event-bridge/index.js
@@ -28,14 +28,15 @@ class AwsCompileEventBridgeEvents {
               'Support for provisioning AWS EventBridge resources without native CloudFormation' +
                 ' resources is deprecated and will no longer be maintained. If you want to' +
                 ' upgrade to native CloudFormation, remove "eventBridge.useCloudFormation"' +
-                ' setting from your configuration.'
+                ' setting from your configuration. This compatibility path is scheduled for' +
+                ' removal in osls 4.0.0.'
             );
           } else if (useCloudFormation === true) {
             this.serverless._logDeprecation(
               'AWS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN',
               'Provisioning AWS EventBridge resources with native CloudFormation is now' +
                 ' enabled by default. Please remove "eventBridge.useCloudFormation" from your' +
-                ' configuration as this setting will not be recognized in the next major release.'
+                ' configuration as this setting will be removed in osls 4.0.0.'
             );
           }
         } else if (useCloudFormation != null) {
@@ -43,7 +44,7 @@ class AwsCompileEventBridgeEvents {
             'AWS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN',
             'Your service does not configure any "eventBridge" events. Please remove' +
               ' "eventBridge.useCloudFormation" from your configuration as this setting' +
-              ' will not be recognized in the next major release.'
+              ' will be removed in osls 4.0.0.'
           );
         }
       },
@@ -221,7 +222,7 @@ class AwsCompileEventBridgeEvents {
             }
 
             const eventBusName = EventBus;
-            // Custom resources will be deprecated in next major release
+            // Custom resources are scheduled for removal in osls 4.0.0.
             if (!shouldUseCloudFormation) {
               const results = this.compileWithCustomResource({
                 eventBusName,

--- a/lib/plugins/aws/package/compile/events/http-api.js
+++ b/lib/plugins/aws/package/compile/events/http-api.js
@@ -52,7 +52,7 @@ class HttpApiEvents {
         ) {
           this.serverless._logDeprecation(
             'AWS_HTTP_API_USE_PROVIDER_TAGS_PROPERTY',
-            'Property "provider.httpApi.useProviderTags" is no longer effective as provider tags are applied to Http Api Gateway by default. You can safely remove this property from your configuration. This property is scheduled for removal in osls 4.0.0.'
+            'Property "provider.httpApi.useProviderTags" is no longer effective as provider tags are applied to Http Api Gateway by default. You can safely remove this property from your configuration. This property is scheduled for removal in osls 5.0.0.'
           );
         }
       },

--- a/lib/plugins/aws/package/compile/events/http-api.js
+++ b/lib/plugins/aws/package/compile/events/http-api.js
@@ -52,7 +52,7 @@ class HttpApiEvents {
         ) {
           this.serverless._logDeprecation(
             'AWS_HTTP_API_USE_PROVIDER_TAGS_PROPERTY',
-            'Property "provider.httpApi.useProviderTags" is no longer effective as provider tags are applied to Http Api Gateway by default. You can safely remove this property from your configuration.'
+            'Property "provider.httpApi.useProviderTags" is no longer effective as provider tags are applied to Http Api Gateway by default. You can safely remove this property from your configuration. This property is scheduled for removal in osls 4.0.0.'
           );
         }
       },

--- a/lib/plugins/aws/package/compile/events/stream.js
+++ b/lib/plugins/aws/package/compile/events/stream.js
@@ -24,7 +24,7 @@ class AwsCompileStreamEvents {
         ) {
           this.serverless._logDeprecation(
             'KINESIS_CONSUMER_NAME_CONTAINING_SERVICE',
-            'Starting with v4.0.0 Kinesis streams naming scheme will change. Adapt to new schema by setting`provider.kinesis.consumerNamingMode` property to `serviceSpecific`.'
+            'Starting with osls 5.0.0, Kinesis streams naming scheme will change. Adapt to new schema by setting `provider.kinesis.consumerNamingMode` property to `serviceSpecific`.'
           );
         }
       },

--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.js
@@ -18,10 +18,11 @@ module.exports = {
     ) {
       this.serverless._logDeprecation(
         'AWS_WEBSOCKET_API_USE_PROVIDER_TAGS',
-        'Starting with osls 5.0.0, the provider tags ' +
+        'Starting with osls 4.0.0, the provider tags ' +
           'will be applied to Websocket Api Gateway by default. \n' +
           'Set "provider.websocket.useProviderTags" to "true" ' +
-          'to adapt to the new behavior now.'
+          'to adapt to the new behavior now. Starting with osls 4.0.0, this field ' +
+          'will be deprecated and scheduled for removal in osls 5.0.0.'
       );
     }
 

--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.js
@@ -18,7 +18,7 @@ module.exports = {
     ) {
       this.serverless._logDeprecation(
         'AWS_WEBSOCKET_API_USE_PROVIDER_TAGS',
-        'Starting with next major version, the provider tags ' +
+        'Starting with osls 5.0.0, the provider tags ' +
           'will be applied to Websocket Api Gateway by default. \n' +
           'Set "provider.websocket.useProviderTags" to "true" ' +
           'to adapt to the new behavior now.'

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -72,7 +72,8 @@ class AwsCompileFunctions {
             'LAMBDA_HASHING_VERSION_PROPERTY',
             'Resolution of lambda version hashes with the "20200924" algorithm is deprecated.' +
               ' It is highly recommend to migrate to new default algorithm. Please see' +
-              ' the deprecation documentation for more details about the migration process.'
+              ' the deprecation documentation for more details about the migration process.' +
+              ' This compatibility path is scheduled for removal in osls 4.0.0.'
           );
         }
 
@@ -81,7 +82,8 @@ class AwsCompileFunctions {
             'LAMBDA_HASHING_VERSION_PROPERTY',
             'Setting "20201221" for "provider.lambdaHashingVersion" is no longer effective as' +
               ' new hashing algorithm is now used by default. You can safely remove this' +
-              ' property from your configuration.'
+              ' property from your configuration. This property is scheduled for removal in osls' +
+              ' 4.0.0.'
           );
         }
       },

--- a/lib/plugins/package/package.js
+++ b/lib/plugins/package/package.js
@@ -47,8 +47,8 @@ class Package {
         ) {
           this.serverless._logDeprecation(
             'PACKAGE_PATTERNS',
-            'Support for "package.include" and "package.exclude" will be removed in the next' +
-              ' major release. Please use "package.patterns" instead'
+            'Support for "package.include" and "package.exclude" will be removed in osls' +
+              ' 4.0.0. Please use "package.patterns" instead'
           );
         }
       },

--- a/lib/utils/report-deprecated-properties.js
+++ b/lib/utils/report-deprecated-properties.js
@@ -17,7 +17,7 @@ const getMessage = (props, serviceConfig) => {
     const details = warnings
       .map(([oldProp, newProp]) => `  "${oldProp}" -> "${newProp}"`)
       .join('\n');
-    return `Starting with version 4.0.0, following ${what} will be replaced:\n${details}`;
+    return `Starting with osls 4.0.0, following ${what} will no longer be supported:\n${details}`;
   }
   return null;
 };


### PR DESCRIPTION
And we may choose to cancel or further delay some deprecations slated for 5.0.0 later too.