### PR TITLE
Deprecate standalone upgrade command

### DIFF
--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -30,6 +30,20 @@ Note:
 - The `serverless.yml` setting is ineffective for deprecations reported before the configuration is read.
 - `SLS_DEPRECATION_DISABLE` and `disabledDeprecations` remain respected, and no errors will be thrown for mentioned deprecation codes.
 
+<a name="STANDALONE_UPGRADE_COMMAND_DEPRECATED"><div>&nbsp;</div></a>
+
+## Command `sls upgrade`
+
+Deprecation code: `STANDALONE_UPGRADE_COMMAND_DEPRECATED`
+
+Removal target: osls v4.0.0
+
+The standalone `sls upgrade` command no longer updates osls and is scheduled for removal in osls v4.0.0. Use npm to upgrade osls instead:
+
+```sh
+npm install -g osls@latest
+```
+
 <a name="CONSOLE_CONFIGURATION"><div>&nbsp;</div></a>
 
 ## Property `console`

--- a/lib/cli/commands-schema/no-service.js
+++ b/lib/cli/commands-schema/no-service.js
@@ -143,12 +143,12 @@ commands.set('plugin search', {
     'in non Windows environment.';
 
   commands.set('upgrade', {
-    usage: 'Upgrade osls',
-    isHidden,
+    usage: 'Deprecated: upgrade osls',
+    isHidden: true,
     noSupportNotice,
     options: {
       major: {
-        usage: 'Enable upgrade to a new major release',
+        usage: 'Deprecated compatibility option',
         type: 'boolean',
       },
     },

--- a/lib/plugins/standalone.js
+++ b/lib/plugins/standalone.js
@@ -1,26 +1,24 @@
 'use strict';
 
-const fs = require('fs');
-const fsp = require('fs').promises;
-const os = require('os');
 const path = require('path');
-const stream = require('stream');
-const { Readable } = require('stream');
-const { promisify } = require('util');
 const { log, progress, style } = require('../utils/serverless-utils/log');
-const currentVersion = require('../../package').version;
 const ServerlessError = require('../serverless-error');
 const standaloneUtils = require('../utils/standalone');
-const safeMoveFile = require('../utils/fs/safe-move-file');
 const { remove } = require('../utils/fs/remove');
 const cliCommandsSchema = require('../cli/commands-schema');
 
-const pipeline = promisify(stream.pipeline);
-
-const BINARY_TMP_PATH = path.resolve(os.tmpdir(), 'serverless-binary-tmp');
-
 const BINARY_PATH = standaloneUtils.path;
 const mainProgress = progress.get('main');
+const upgradeCommandDeprecationMessage = [
+  'The standalone `sls upgrade` command is deprecated and no longer updates osls.',
+  'It is scheduled for removal in osls v4.0.0.',
+  '',
+  'Upgrade osls via npm instead:',
+  '',
+  '  npm install -g osls@latest',
+  '',
+  'More info: https://github.com/oss-serverless/osls/blob/main/docs/guides/deprecations.md#STANDALONE_UPGRADE_COMMAND_DEPRECATED',
+].join('\n');
 
 module.exports = class Standalone {
   constructor(serverless, cliOptions) {
@@ -43,58 +41,9 @@ module.exports = class Standalone {
   }
 
   async upgrade() {
-    mainProgress.notice('Resolving latest standalone version', { isMainEvent: true });
-    const tagName = await standaloneUtils.resolveLatestTag();
-    const latestVersion = tagName.slice(1);
-    if (latestVersion === currentVersion) {
-      log.notice();
-      log.notice.skip(
-        `Already at latest version ${style.aside(
-          `(${Math.floor(
-            (Date.now() - this.serverless.pluginManager.commandRunStartTime) / 1000
-          )}s)`
-        )}`
-      );
-      return;
-    }
-    const currentMajor = Number(currentVersion.split('.')[0]);
-    const latestMajor = Number(latestVersion.split('.')[0]);
-    if (latestMajor > currentMajor && !this.cliOptions.major) {
-      throw new ServerlessError(
-        [
-          'Cannot upgrade to a new major release without introducing a breaking changes',
-          '',
-          'If you\'ve confirmed it\'s safe and want to upgrade, run "sls upgrade --major"',
-          '',
-          'Note: Service is safe to upgrade if no deprecations are logged during its deployment.',
-          `      Check https://github.com/serverless/serverless/releases/tag/v${latestMajor}.0.0 ` +
-            'for list of all breaking changes',
-        ].join('\n'),
-        'CANNOT_UPGRADE_MAJOR'
-      );
-    }
-    mainProgress.notice('Downloading latest standalone version', { isMainEvent: true });
-    const executableUrl = standaloneUtils.resolveUrl(tagName);
-    const standaloneResponse = await fetch(executableUrl);
-    if (!standaloneResponse.ok) {
-      throw new ServerlessError(
-        'Sorry unable to `upgrade` at this point ' +
-          `(server rejected request with ${standaloneResponse.status})`,
-        'UPGRADE_ERROR'
-      );
-    }
-    await remove(BINARY_TMP_PATH);
-    await pipeline(
-      Readable.fromWeb(standaloneResponse.body),
-      fs.createWriteStream(BINARY_TMP_PATH)
-    );
-    await safeMoveFile(BINARY_TMP_PATH, BINARY_PATH);
-    await fsp.chmod(BINARY_PATH, 0o755);
-    log.notice();
-    log.notice.success(
-      `Successfully upgraded to ${tagName} ${style.aside(
-        `(${Math.floor((Date.now() - this.serverless.pluginManager.commandRunStartTime) / 1000)}s)`
-      )}`
+    throw new ServerlessError(
+      upgradeCommandDeprecationMessage,
+      'STANDALONE_UPGRADE_COMMAND_DEPRECATED'
     );
   }
 

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -58,9 +58,7 @@ class Serverless {
           'Cannot run a local osls installation with an outdated global version.',
           'Please upgrade via:',
           '',
-          colors.bold(
-            isStandaloneExecutable ? 'serverless upgrade --major' : 'npm install -g osls'
-          ),
+          colors.bold('npm install -g osls@latest'),
           colors.gray('Note: The latest release can run any locally installed osls version.'),
           '',
           'Alternatively run locally installed version directly via:',

--- a/test/unit/lib/plugins/standalone.test.js
+++ b/test/unit/lib/plugins/standalone.test.js
@@ -10,28 +10,14 @@ const { expect } = require('chai');
 
 const { remove } = require('../../../../lib/utils/fs/remove');
 
-const binaryTmpPath = path.resolve(os.tmpdir(), 'serverless-binary-tmp');
-
-const createFetchResponse = (contents) => ({
-  ok: true,
-  body: new ReadableStream({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(contents));
-      controller.close();
-    },
-  }),
-});
-
-const loadStandalone = ({ binaryPath, removeStub, safeMoveFile } = {}) =>
+const loadStandalone = ({ binaryPath, removeStub } = {}) =>
   proxyquire('../../../../lib/plugins/standalone', {
     '../utils/standalone': {
       path: binaryPath,
-      resolveLatestTag: sinon.stub().resolves('v999.0.0'),
-      resolveUrl: sinon.stub().returns('https://example.com/serverless'),
+      resolveLatestTag: sinon.stub().throws(new Error('Unexpected latest tag lookup')),
+      resolveUrl: sinon.stub().throws(new Error('Unexpected download URL lookup')),
     },
     '../utils/fs/remove': { remove: removeStub || remove },
-    '../utils/fs/safe-move-file':
-      safeMoveFile || require('../../../../lib/utils/fs/safe-move-file'),
   });
 
 describe('test/unit/lib/plugins/standalone.test.js', () => {
@@ -46,29 +32,27 @@ describe('test/unit/lib/plugins/standalone.test.js', () => {
   afterEach(async () => {
     globalThis.fetch = originalFetch;
     await remove(tmpDir);
-    await remove(binaryTmpPath);
   });
 
-  it('removes a stale temporary binary before upgrade download', async () => {
+  it('rejects upgrade because the command is deprecated', async () => {
     const binaryPath = path.join(tmpDir, 'install', 'serverless');
-    const removedPaths = [];
-    const removeStub = async (targetPath) => {
-      removedPaths.push(targetPath);
-      await remove(targetPath);
-    };
-    await fsp.writeFile(binaryTmpPath, 'stale');
-    await fsp.mkdir(path.dirname(binaryPath), { recursive: true });
-    globalThis.fetch = sinon.stub().resolves(createFetchResponse('new binary'));
-    const Standalone = loadStandalone({ binaryPath, removeStub });
+    globalThis.fetch = sinon.stub().throws(new Error('Unexpected download'));
+    const Standalone = loadStandalone({ binaryPath });
     const standalone = new Standalone(
       { pluginManager: { commandRunStartTime: Date.now() } },
       { major: true }
     );
 
-    await standalone.upgrade();
+    let error;
+    try {
+      await standalone.upgrade();
+    } catch (caughtError) {
+      error = caughtError;
+    }
 
-    expect(removedPaths).to.include(binaryTmpPath);
-    expect(await fsp.readFile(binaryPath, 'utf8')).to.equal('new binary');
+    expect(error).to.have.property('code', 'STANDALONE_UPGRADE_COMMAND_DEPRECATED');
+    expect(error.message).to.include('npm install -g osls@latest');
+    expect(globalThis.fetch).to.not.have.been.called;
   });
 
   it('recursively removes the standalone install directory on uninstall', async () => {


### PR DESCRIPTION
- Deprecate `sls upgrade` on v3 by replacing the broken standalone download flow with a clear error.
- Hide the upgrade command from help while keeping `--major` accepted for compatibility.
- Document the v4 removal target and update tests/fallback messaging to point users at `npm install -g osls@latest`.

---

Closes #269.