### PR TITLE
Remove standalone upgrade command

### DIFF
--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -30,20 +30,6 @@ Note:
 - The `serverless.yml` setting is ineffective for deprecations reported before the configuration is read.
 - `SLS_DEPRECATION_DISABLE` and `disabledDeprecations` remain respected, and no errors will be thrown for mentioned deprecation codes.
 
-<a name="STANDALONE_UPGRADE_COMMAND_DEPRECATED"><div>&nbsp;</div></a>
-
-## Command `sls upgrade`
-
-Deprecation code: `STANDALONE_UPGRADE_COMMAND_DEPRECATED`
-
-Removal target: osls v4.0.0
-
-The standalone `sls upgrade` command no longer updates osls and is scheduled for removal in osls v4.0.0. Use npm to upgrade osls instead:
-
-```sh
-npm install -g osls@latest
-```
-
 <a name="VARIABLES_RESOLUTION_MODE"><div>&nbsp;</div></a>
 
 ## Property `variablesResolutionMode`

--- a/lib/cli/commands-schema/no-service.js
+++ b/lib/cli/commands-schema/no-service.js
@@ -142,18 +142,6 @@ commands.set('plugin search', {
     "It's applicable only in context of a standalone executable instance " +
     'in non Windows environment.';
 
-  commands.set('upgrade', {
-    usage: 'Deprecated: upgrade osls',
-    isHidden: true,
-    noSupportNotice,
-    options: {
-      major: {
-        usage: 'Deprecated compatibility option',
-        type: 'boolean',
-      },
-    },
-    lifecycleEvents: ['upgrade'],
-  });
   commands.set('uninstall', {
     usage: 'Uninstall osls',
     isHidden,

--- a/lib/cli/triage.js
+++ b/lib/cli/triage.js
@@ -31,7 +31,6 @@ module.exports = async () => {
     'install',
     'plugin list',
     'plugin search',
-    'upgrade',
     'uninstall',
   ]).has(command);
 

--- a/lib/plugins/standalone.js
+++ b/lib/plugins/standalone.js
@@ -2,23 +2,12 @@
 
 const path = require('path');
 const { log, progress, style } = require('../utils/serverless-utils/log');
-const ServerlessError = require('../serverless-error');
 const standaloneUtils = require('../utils/standalone');
 const { remove } = require('../utils/fs/remove');
 const cliCommandsSchema = require('../cli/commands-schema');
 
 const BINARY_PATH = standaloneUtils.path;
 const mainProgress = progress.get('main');
-const upgradeCommandDeprecationMessage = [
-  'The standalone `sls upgrade` command is deprecated and no longer updates osls.',
-  'It is scheduled for removal in osls v4.0.0.',
-  '',
-  'Upgrade osls via npm instead:',
-  '',
-  '  npm install -g osls@latest',
-  '',
-  'More info: https://github.com/oss-serverless/osls/blob/main/docs/guides/deprecations.md#STANDALONE_UPGRADE_COMMAND_DEPRECATED',
-].join('\n');
 
 module.exports = class Standalone {
   constructor(serverless, cliOptions) {
@@ -26,25 +15,14 @@ module.exports = class Standalone {
     this.cliOptions = cliOptions;
 
     this.commands = {
-      upgrade: {
-        ...cliCommandsSchema.get('upgrade'),
-      },
       uninstall: {
         ...cliCommandsSchema.get('uninstall'),
       },
     };
 
     this.hooks = {
-      'upgrade:upgrade': async () => this.upgrade(),
       'uninstall:uninstall': async () => this.uninstall(),
     };
-  }
-
-  async upgrade() {
-    throw new ServerlessError(
-      upgradeCommandDeprecationMessage,
-      'STANDALONE_UPGRADE_COMMAND_DEPRECATED'
-    );
   }
 
   async uninstall() {

--- a/lib/utils/standalone.js
+++ b/lib/utils/standalone.js
@@ -2,44 +2,6 @@
 
 const os = require('os');
 
-const platform = (() => {
-  switch (process.platform) {
-    case 'darwin':
-      return 'macos';
-    default:
-      return process.platform;
-  }
-})();
-const arch = (() => {
-  switch (process.arch) {
-    case 'x32':
-      return 'x86';
-    case 'arm':
-      return 'armv6';
-    case 'arm64':
-      if (process.platform === 'darwin') {
-        // Handle case of M1 Macs that are using x64 binary via Rosetta
-        return 'x64';
-      }
-      return 'armv6';
-    default:
-      return process.arch;
-  }
-})();
-
 module.exports = {
-  resolveLatestTag: async () => {
-    const response = await fetch(
-      'https://api.github.com/repos/serverless/serverless/releases/latest'
-    );
-    const data = await response.json();
-    return data.tag_name;
-  },
-  resolveUrl: (tagName) => {
-    return (
-      `https://github.com/serverless/serverless/releases/download/${tagName}/` +
-      `serverless-${platform}-${arch}`
-    );
-  },
   path: `${os.homedir()}/.serverless/bin/serverless`,
 };

--- a/test/unit/lib/plugins/standalone.test.js
+++ b/test/unit/lib/plugins/standalone.test.js
@@ -5,7 +5,6 @@ const fsp = fs.promises;
 const os = require('os');
 const path = require('path');
 const proxyquire = require('proxyquire');
-const sinon = require('sinon');
 const { expect } = require('chai');
 
 const { remove } = require('../../../../lib/utils/fs/remove');
@@ -14,45 +13,19 @@ const loadStandalone = ({ binaryPath, removeStub } = {}) =>
   proxyquire('../../../../lib/plugins/standalone', {
     '../utils/standalone': {
       path: binaryPath,
-      resolveLatestTag: sinon.stub().throws(new Error('Unexpected latest tag lookup')),
-      resolveUrl: sinon.stub().throws(new Error('Unexpected download URL lookup')),
     },
     '../utils/fs/remove': { remove: removeStub || remove },
   });
 
 describe('test/unit/lib/plugins/standalone.test.js', () => {
   let tmpDir;
-  let originalFetch;
 
   beforeEach(async () => {
     tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'standalone-plugin-'));
-    originalFetch = globalThis.fetch;
   });
 
   afterEach(async () => {
-    globalThis.fetch = originalFetch;
     await remove(tmpDir);
-  });
-
-  it('rejects upgrade because the command is deprecated', async () => {
-    const binaryPath = path.join(tmpDir, 'install', 'serverless');
-    globalThis.fetch = sinon.stub().throws(new Error('Unexpected download'));
-    const Standalone = loadStandalone({ binaryPath });
-    const standalone = new Standalone(
-      { pluginManager: { commandRunStartTime: Date.now() } },
-      { major: true }
-    );
-
-    let error;
-    try {
-      await standalone.upgrade();
-    } catch (caughtError) {
-      error = caughtError;
-    }
-
-    expect(error).to.have.property('code', 'STANDALONE_UPGRADE_COMMAND_DEPRECATED');
-    expect(error.message).to.include('npm install -g osls@latest');
-    expect(globalThis.fetch).to.not.have.been.called;
   });
 
   it('recursively removes the standalone install directory on uninstall', async () => {

--- a/test/unit/lib/utils/standalone.test.js
+++ b/test/unit/lib/utils/standalone.test.js
@@ -1,9 +1,0 @@
-'use strict';
-
-const { expect } = require('chai');
-const standalone = require('../../../../lib/utils/standalone');
-
-describe('#standalone', () => {
-  it('Should resolve standalone url', () =>
-    expect(standalone.resolveUrl('v2.8.0')).to.match(/^https:\/\//));
-});


### PR DESCRIPTION
- Remove the deprecated standalone `upgrade` command registration and hook from 4.x.
- Drop the dead standalone release lookup/download URL helpers and their obsolete unit test.
- Remove the v3 deprecation guide entry now that the command is removed in 4.x.
