### PR TITLE
feat(schedule): add support for groupName

### DIFF
--- a/docs/events/schedule.md
+++ b/docs/events/schedule.md
@@ -91,6 +91,7 @@ The default method is `eventBus`, which configures an `AWS::Event::Rule`.
 By default, `scheduler` uses the function execution role as the target role and the `default` schedule group.
 
 You can provide:
+
 - roleArn to use a dedicated role for EventBridge Scheduler.
 - groupName to use another EventBridge Scheduler schedule group.
 

--- a/docs/events/schedule.md
+++ b/docs/events/schedule.md
@@ -88,8 +88,11 @@ However, `AWS::Scheduler::Schedule` has much higher limits (1,000,000 events), a
 `method` can be set in order to migrate to this trigger type seamlessly. It also allows you to specify a timezone to run your event based on local time.
 The default method is `eventBus`, which configures an `AWS::Event::Rule`.
 
-By default, `scheduler` uses the function execution role as target role.
-You can provide `roleArn` to use a dedicated role for EventBridge Scheduler.
+By default, `scheduler` uses the function execution role as the target role and the `default` schedule group.
+
+You can provide:
+- roleArn to use a dedicated role for EventBridge Scheduler.
+- groupName to use another EventBridge Scheduler schedule group.
 
 ```yaml
 functions:
@@ -99,6 +102,7 @@ functions:
       - schedule:
           method: scheduler
           roleArn: arn:aws:iam::123456789012:role/scheduler-execution-role
+          groupName: custom-scheduler-group
           rate:
             - cron(0 0/4 ? * MON-FRI *)
           timezone: America/New_York

--- a/lib/plugins/aws/package/compile/events/schedule.js
+++ b/lib/plugins/aws/package/compile/events/schedule.js
@@ -85,6 +85,17 @@ class AwsCompileScheduledEvents {
             roleArn: {
               anyOf: [{ type: 'string' }, { $ref: '#/definitions/awsCfFunction' }],
             },
+            groupName: {
+              anyOf: [
+                {
+                  type: 'string',
+                  minLength: 1,
+                  maxLength: 64,
+                  pattern: '^[0-9a-zA-Z-_.]+$',
+                },
+                { $ref: '#/definitions/awsCfFunction' },
+              ],
+            },
             timezone: {
               type: 'string',
               pattern: '[\\w\\-\\/]+',
@@ -124,6 +135,7 @@ class AwsCompileScheduledEvents {
             let Description;
             let method;
             let roleArn;
+            let groupName;
             let timezone;
 
             if (typeof event.schedule === 'object') {
@@ -137,6 +149,7 @@ class AwsCompileScheduledEvents {
               InputPath = event.schedule.inputPath;
               InputTransformer = event.schedule.inputTransformer;
               Name = event.schedule.name;
+              groupName = event.schedule.groupName;
               timezone = event.schedule.timezone;
               Description = event.schedule.description;
 
@@ -186,6 +199,12 @@ class AwsCompileScheduledEvents {
                   'SCHEDULE_PARAMETER_NOT_SUPPORTED'
                 );
               }
+              if (groupName && method !== METHOD_SCHEDULER) {
+                throw new ServerlessError(
+                  'Cannot setup "schedule" event: "groupName" is only supported with "scheduler" mode',
+                  'SCHEDULE_PARAMETER_NOT_SUPPORTED'
+                );
+              }
             } else {
               ScheduleExpressions = [event.schedule];
               State = 'ENABLED';
@@ -227,6 +246,7 @@ class AwsCompileScheduledEvents {
                       Mode: 'OFF',
                     },
                     Name,
+                    GroupName: groupName,
                     Description,
                     ScheduleExpressionTimezone: timezone,
                   },

--- a/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
@@ -380,6 +380,37 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
       .and.have.property('code', 'SCHEDULE_PARAMETER_NOT_SUPPORTED');
   });
 
+  it('should throw when passing "groupName" to method:eventBus resources', async () => {
+    const events = [
+      {
+        schedule: {
+          rate: 'rate(15 minutes)',
+          method: METHOD_EVENT_BUS,
+          groupName: 'custom-scheduler-group',
+        },
+      },
+    ];
+
+    await expect(run(events))
+      .to.be.eventually.rejectedWith(ServerlessError)
+      .and.have.property('code', 'SCHEDULE_PARAMETER_NOT_SUPPORTED');
+  });
+
+  it('should throw when passing "groupName" without method:scheduler specified', async () => {
+    const events = [
+      {
+        schedule: {
+          rate: 'rate(15 minutes)',
+          groupName: 'custom-scheduler-group',
+        },
+      },
+    ];
+
+    await expect(run(events))
+      .to.be.eventually.rejectedWith(ServerlessError)
+      .and.have.property('code', 'SCHEDULE_PARAMETER_NOT_SUPPORTED');
+  });
+
   it('should have not scheduler policies when there are no scheduler schedules', async () => {
     const events = [
       {
@@ -452,5 +483,21 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
     expect(scheduleCfResources[0].Properties.Target.RoleArn).to.equal(
       'arn:aws:iam::123456789012:role/scheduler-execution-role'
     );
+  });
+
+  it('should pass explicit schedule groupName to method:scheduler resources', async () => {
+    const events = [
+      {
+        schedule: {
+          rate: 'rate(15 minutes)',
+          method: METHOD_SCHEDULER,
+          groupName: 'custom-scheduler-group',
+        },
+      },
+    ];
+
+    const { scheduleCfResources } = await run(events);
+
+    expect(scheduleCfResources[0].Properties.GroupName).to.equal('custom-scheduler-group');
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -195,6 +195,7 @@ export interface AWS {
                   };
                   method?: 'eventBus' | 'scheduler';
                   roleArn?: AwsCfFunction | string;
+                  groupName?: AwsCfFunction | string;
                   timezone?: string;
                 };
           }


### PR DESCRIPTION
relates to #143 

## Summary

Allow `schedule.groupName` when using `method: scheduler`.

By default, osls omits `GroupName`, so EventBridge Scheduler uses the AWS `default` schedule group. This change only opts in when `groupName` is explicitly configured.

## Why

`method: scheduler` currently always creates `AWS::Scheduler::Schedule` resources in the default schedule group. That makes it hard to use IAM conditions or ABAC policies scoped to dedicated scheduler groups, and forces projects to either loosen permissions or avoid `method: scheduler`.

CloudFormation already supports this through the optional `GroupName` property on `AWS::Scheduler::Schedule`, so this exposes that capability in osls.