### PR TITLE
Fix circular JSON error in AWS request cache keys

### DIFF
--- a/lib/aws/request.js
+++ b/lib/aws/request.js
@@ -8,7 +8,7 @@ const { log } = require('../utils/serverless-utils/log');
 const { HttpsProxyAgent } = require('https-proxy-agent');
 const https = require('https');
 const fs = require('fs');
-const deepSortObjectByKey = require('../utils/deep-sort-object-by-key');
+const { toCacheKey } = require('../utils/to-cache-key');
 const ensureString = require('type/string/ensure');
 const isObject = require('type/object/is');
 const wait = require('../utils/sleep');
@@ -101,9 +101,7 @@ const getServiceInstance = memoize(
     return new Service(serviceParams);
   },
   {
-    normalizer: ([service, method]) => {
-      return [JSON.stringify(deepSortObjectByKey(service)), method].join('|');
-    },
+    normalizer: ([service, method]) => `${toCacheKey(service)}|${method}`,
   }
 );
 
@@ -231,13 +229,9 @@ async function awsRequest(service, method, ...args) {
 
 awsRequest.memoized = memoize(awsRequest, {
   promise: true,
-  normalizer: ([service, method, args]) => {
+  normalizer: ([service, method, ...args]) => {
     if (!isObject(service)) service = { name: ensureString(service) };
-    return [
-      JSON.stringify(deepSortObjectByKey(service)),
-      method,
-      JSON.stringify(deepSortObjectByKey(args)),
-    ].join('|');
+    return [toCacheKey(service), method, toCacheKey(args)].join('|');
   },
 });
 

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -19,7 +19,7 @@ const {
 } = require('../../aws/credentials');
 const { cfValue } = require('../../utils/aws-schema-get-cf-value');
 const reportDeprecatedProperties = require('../../utils/report-deprecated-properties');
-const deepSortObjectByKey = require('../../utils/deep-sort-object-by-key');
+const { toCacheKey } = require('../../utils/to-cache-key');
 const { getByPath } = require('../../utils/object-path');
 const { methodDescriptor } = require('../../utils/property-descriptors');
 const { hasOwn } = require('../../utils/safe-object');
@@ -2439,9 +2439,7 @@ Object.defineProperties(
       },
       {
         promise: true,
-        normalizer: (args) => {
-          return JSON.stringify(deepSortObjectByKey(args[0]));
-        },
+        normalizer: (args) => toCacheKey(args[0]),
       }
     ),
     resolveImageUriAndShaFromUri: methodDescriptor(

--- a/lib/utils/to-cache-key.js
+++ b/lib/utils/to-cache-key.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const isPlainObject = require('type/plain-object/is');
+
+// NUL-prefixed tags cannot collide with a real (JSON-sourced) param value.
+const nul = String.fromCharCode(0);
+
+// Stable per-process identity for opaque, identity-by-reference values (SDK
+// clients, credentials, HTTP agents) so we never serialize their internals.
+let nextIdentityId = 0;
+const identityIds = new WeakMap();
+
+const identityToken = (value) => {
+  let token = identityIds.get(value);
+  if (token === undefined) {
+    token = `${nul}ref:${(nextIdentityId += 1)}`;
+    identityIds.set(value, token);
+  }
+  return token;
+};
+
+const canonicalize = (value, ancestors) => {
+  if (value === null) return null;
+
+  const type = typeof value;
+  if (type !== 'object') {
+    if (type === 'function') return identityToken(value);
+    if (type === 'bigint') return `${nul}bigint:${value}`;
+    return value;
+  }
+
+  const isArray = Array.isArray(value);
+  if (!isArray && !isPlainObject(value)) return identityToken(value);
+
+  // Tokenize cyclic references instead of recursing into them.
+  if (ancestors.has(value)) return identityToken(value);
+  ancestors.add(value);
+  const canonical = isArray
+    ? value.map((item) => canonicalize(item, ancestors))
+    : Object.fromEntries(
+        Object.entries(value)
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([key, item]) => [key, canonicalize(item, ancestors)])
+      );
+  ancestors.delete(value);
+  return canonical;
+};
+
+const toCacheKey = (value) => {
+  const json = JSON.stringify(canonicalize(value, new WeakSet()));
+  return json === undefined ? '' : json;
+};
+
+module.exports = { toCacheKey, canonicalize, identityToken };

--- a/test/unit/lib/aws/request.test.js
+++ b/test/unit/lib/aws/request.test.js
@@ -518,5 +518,39 @@ describe('#request', () => {
         return expect(promiseStub.callCount).to.equal(2);
       });
     });
+
+    it('does not throw when credentials transitively reference a live proxy agent', async () => {
+      const promiseStub = sinon.stub().resolves({ ok: true });
+      class FakeCF {
+        describeStacks() {
+          return { promise: promiseStub };
+        }
+      }
+      const { HttpsProxyAgent } = require('https-proxy-agent');
+      const agent = new HttpsProxyAgent('http://proxy.example.com:3128');
+      const socket = { _httpMessage: {} };
+      socket._httpMessage.agent = agent;
+      agent.sockets = { 'host:443:': [socket] };
+      class Credentials {}
+      const credentials = Object.assign(new Credentials(), {
+        client: { config: { httpOptions: { agent } } },
+      });
+
+      const awsRequest = proxyquire('../../../../lib/aws/request', {
+        './sdk-v2': { CloudFormation: FakeCF },
+      });
+      const service = {
+        name: 'CloudFormation',
+        params: { region: 'us-east-1', credentials, useCache: true },
+      };
+
+      const [first, second] = await Promise.all([
+        awsRequest.memoized(service, 'describeStacks', { StackName: 's' }),
+        awsRequest.memoized(service, 'describeStacks', { StackName: 's' }),
+      ]);
+      expect(first).to.deep.equal({ ok: true });
+      expect(second).to.deep.equal({ ok: true });
+      return expect(promiseStub).to.have.been.calledOnce;
+    });
   });
 });

--- a/test/unit/lib/utils/to-cache-key.test.js
+++ b/test/unit/lib/utils/to-cache-key.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const chai = require('chai');
+const { HttpsProxyAgent } = require('https-proxy-agent');
+const { toCacheKey, canonicalize } = require('../../../../lib/utils/to-cache-key');
+
+const expect = chai.expect;
+
+describe('test/unit/lib/utils/to-cache-key.test.js', () => {
+  it('is stable regardless of key ordering', () => {
+    expect(toCacheKey({ b: 1, a: { d: 4, c: 3 } })).to.equal(
+      toCacheKey({ a: { c: 3, d: 4 }, b: 1 })
+    );
+  });
+
+  it('compares plain objects and arrays structurally', () => {
+    expect(toCacheKey({ x: [1, { y: 2 }] })).to.equal(toCacheKey({ x: [1, { y: 2 }] }));
+    expect(toCacheKey({ x: 1 })).to.not.equal(toCacheKey({ x: 2 }));
+  });
+
+  it('keys non-plain instances by reference identity, without traversing them', () => {
+    class Credentials {
+      constructor(id) {
+        this.accessKeyId = id;
+        Object.defineProperty(this, 'boom', {
+          enumerable: true,
+          get() {
+            throw new Error('must not be traversed');
+          },
+        });
+      }
+    }
+    const a = new Credentials('AKIA');
+    const b = new Credentials('AKIA'); // equal content, different reference
+
+    expect(() => toCacheKey({ credentials: a })).to.not.throw();
+    expect(toCacheKey({ credentials: a })).to.equal(toCacheKey({ credentials: a }));
+    expect(toCacheKey({ credentials: a })).to.not.equal(toCacheKey({ credentials: b }));
+  });
+
+  it('does not throw on the proxy-agent socket cycle', () => {
+    const agent = new HttpsProxyAgent('http://proxy.example.com:3128');
+    const socket = { _httpMessage: {} };
+    socket._httpMessage.agent = agent; // close the cycle
+    agent.sockets = { 'host:443:': [socket] };
+
+    class Credentials {}
+    const credentials = Object.assign(new Credentials(), {
+      client: { config: { httpOptions: { agent } } },
+    });
+    const service = { name: 'CloudFormation', params: { region: 'us-east-1', credentials } };
+
+    expect(() => toCacheKey(service)).to.not.throw();
+    expect(toCacheKey(service)).to.equal(toCacheKey(service));
+  });
+
+  it('neutralises cycles among plain objects instead of throwing', () => {
+    const node = { name: 'a' };
+    node.self = node;
+    expect(() => toCacheKey(node)).to.not.throw();
+  });
+
+  it('serialises shared, non-cyclic subtrees by value', () => {
+    const shared = { k: 1 };
+    expect(toCacheKey({ a: shared, b: shared })).to.equal(toCacheKey({ a: { k: 1 }, b: { k: 1 } }));
+  });
+
+  it('is total over bigint and undefined', () => {
+    expect(() => toCacheKey({ n: 10n, u: undefined })).to.not.throw();
+    expect(toCacheKey(undefined)).to.equal('');
+  });
+
+  it('does not conflate a bigint with its string form', () => {
+    expect(toCacheKey({ v: 10n })).to.not.equal(toCacheKey({ v: '10' }));
+  });
+
+  it('canonicalize sorts plain object keys', () => {
+    expect(canonicalize({ b: 1, a: 2 }, new WeakSet())).to.deep.equal({ a: 2, b: 1 });
+  });
+});


### PR DESCRIPTION
Deploying with an HTTP or HTTPS proxy configured currently fails with `TypeError: Converting circular structure to JSON`, a regression introduced in 3.67.0 when `https-proxy-agent` was upgraded to v9. The AWS request layer memoizes service clients and read requests by building cache keys with `JSON.stringify`, which walked the entire argument graph including the live AWS SDK credential objects and, through them, the global proxy agent. The v9 agent extends Node's `http.Agent`, so once a socket is in use it forms a cycle that `JSON.stringify` cannot serialize.

This replaces that approach with a small `toCacheKey` helper that derives keys from intentional identity rather than by serializing whole object graphs. Plain objects and arrays are still compared by value, but anything we do not own, such as SDK clients, credential objects and HTTP agents, is reduced to a stable per-process reference token and never traversed, so the agent and its socket cycle can never reach `JSON.stringify`. Cyclic plain objects are tokenized rather than throwing. Both request normalizers in `lib/aws/request.js` now use the helper, and the ECR image normalizer in the provider is switched to it for consistency.

Because credential identity is now captured by reference, the same credentials reuse their cache entries exactly as before, while a mid-request credential refresh no longer perturbs the key.

Fixes #281.