### PR TITLE
Don't compare stat.dev when streaming zip entries

### DIFF
--- a/lib/plugins/package/lib/zip-service.js
+++ b/lib/plugins/package/lib/zip-service.js
@@ -57,7 +57,7 @@ const zipMtime = new Date(0);
 const maxConcurrentFileStats = 64;
 
 const getFileMode = (stat) =>
-  stat.mode & 0o100 || process.platform === 'win32' ? 0o100755 : 0o100644;
+  Number(stat.mode) & 0o100 || process.platform === 'win32' ? 0o100755 : 0o100644;
 
 const getCannotReadFileError = (filePath, error) =>
   new ServerlessError(`Cannot read file ${filePath} due to: ${error.message}`, 'CANNOT_READ_FILE');
@@ -89,9 +89,11 @@ const normalizeFileContent = (data, filePath) => {
 };
 
 const assertSameFile = (entry, currentStat) => {
-  const sameIdentity = entry.stat.dev === currentStat.dev && entry.stat.ino === currentStat.ino;
+  // `dev` is excluded: path-stat and handle-stat report a different `dev` for the
+  // same unchanged file on Windows (issue #280). Bigint stats compare exactly.
+  const sameIdentity = entry.stat.ino === currentStat.ino;
   const sameContentMetadata =
-    entry.stat.size === currentStat.size && entry.stat.mtimeMs === currentStat.mtimeMs;
+    entry.stat.size === currentStat.size && entry.stat.mtimeNs === currentStat.mtimeNs;
 
   if (!sameIdentity || !sameContentMetadata) {
     throw new Error('file changed between metadata collection and stream open');
@@ -112,7 +114,7 @@ async function getZipEntryMetadata(filePath, prefix) {
   const fullPath = path.resolve(this.serverless.serviceDir, filePath);
 
   try {
-    const stat = await fsp.stat(fullPath);
+    const stat = await fsp.stat(fullPath, { bigint: true });
 
     return {
       filePath,
@@ -137,7 +139,7 @@ function addFileStream(zipfile, entry, options) {
       .open(entry.fullPath, 'r')
       .then(async (fileHandle) => {
         try {
-          const currentStat = await fileHandle.stat();
+          const currentStat = await fileHandle.stat({ bigint: true });
           assertSameFile(entry, currentStat);
 
           const readStream = fileHandle.createReadStream({ autoClose: true });

--- a/test/unit/lib/plugins/package/lib/zip-service.test.js
+++ b/test/unit/lib/plugins/package/lib/zip-service.test.js
@@ -1007,14 +1007,14 @@ describe('zipService', () => {
       const originalOpen = fs.promises.open.bind(fs.promises);
       const openStub = sinon.stub(fs.promises, 'open').callsFake(async (...args) => {
         const fileHandle = await originalOpen(...args);
-        const stat = await fileHandle.stat();
+        const stat = await fileHandle.stat({ bigint: true });
 
         return {
           stat: sinon.stub().resolves({
             dev: stat.dev,
             ino: stat.ino,
-            size: stat.size + 1,
-            mtimeMs: stat.mtimeMs,
+            size: stat.size + 1n,
+            mtimeNs: stat.mtimeNs,
           }),
           createReadStream: fileHandle.createReadStream.bind(fileHandle),
           close: fileHandle.close.bind(fileHandle),
@@ -1024,6 +1024,64 @@ describe('zipService', () => {
       try {
         await expect(
           packagePlugin.zipFiles(['handler.js'], getTestArtifactFileName('changed-file'))
+        ).to.be.rejectedWith('file changed between metadata collection and stream open');
+      } finally {
+        openStub.restore();
+      }
+    });
+
+    it('packages files when only stat.dev differs (Windows path-stat vs handle-stat, #280)', async () => {
+      const originalOpen = fs.promises.open.bind(fs.promises);
+      const openStub = sinon.stub(fs.promises, 'open').callsFake(async (...args) => {
+        const fileHandle = await originalOpen(...args);
+        const stat = await fileHandle.stat({ bigint: true });
+
+        return {
+          stat: sinon.stub().resolves({
+            dev: stat.dev === 0n ? 1n : 0n,
+            ino: stat.ino,
+            size: stat.size,
+            mtimeNs: stat.mtimeNs,
+          }),
+          createReadStream: fileHandle.createReadStream.bind(fileHandle),
+          close: fileHandle.close.bind(fileHandle),
+        };
+      });
+
+      try {
+        const artifact = await packagePlugin.zipFiles(
+          ['handler.js'],
+          getTestArtifactFileName('windows-dev-mismatch')
+        );
+        const unzipped = await new JsZip().loadAsync(fs.readFileSync(artifact));
+        const content = await unzipped.files['handler.js'].async('nodebuffer');
+        expect(content.toString()).to.equal('some content');
+      } finally {
+        openStub.restore();
+      }
+    });
+
+    it('still rejects when the inode changes between metadata collection and stream open', async () => {
+      const originalOpen = fs.promises.open.bind(fs.promises);
+      const openStub = sinon.stub(fs.promises, 'open').callsFake(async (...args) => {
+        const fileHandle = await originalOpen(...args);
+        const stat = await fileHandle.stat({ bigint: true });
+
+        return {
+          stat: sinon.stub().resolves({
+            dev: stat.dev,
+            ino: stat.ino + 1n,
+            size: stat.size,
+            mtimeNs: stat.mtimeNs,
+          }),
+          createReadStream: fileHandle.createReadStream.bind(fileHandle),
+          close: fileHandle.close.bind(fileHandle),
+        };
+      });
+
+      try {
+        await expect(
+          packagePlugin.zipFiles(['handler.js'], getTestArtifactFileName('changed-inode'))
         ).to.be.rejectedWith('file changed between metadata collection and stream open');
       } finally {
         openStub.restore();


### PR DESCRIPTION
On Windows, packaging could fail with "Cannot read file ... due to: file changed between metadata collection and stream open" even when the file had not changed. The streaming zip writer collects each file's metadata with a path-based `fs.stat()` and then re-checks it against a handle-based `fileHandle.stat()` immediately before streaming the entry, and on Windows these two stat sources report a different device id (`dev`) for the very same unchanged file because libuv's path fast-path does not read the volume serial number while the handle path does. The safety check interpreted that mismatch as a changed file and aborted the whole package.

This drops `dev` from the comparison, because it is unreliable across the two stat methods and contributes nothing useful here, while keeping the inode, size and modification-time checks that actually detect a file changing underneath us. Both stats are now collected with the `bigint` option so that the inode and modification time are compared as exact integers rather than a precision-losing Number and a floating-point millisecond value. The same code path is used for layer packaging, so that is covered as well.

Resolves #280.
