### PR TITLE
Restore provider IAM settings deprecated for removal in v5

### DIFF
--- a/docs/guides/deprecations.md
+++ b/docs/guides/deprecations.md
@@ -54,6 +54,26 @@ The `projectDir` option is no longer used and is ignored. Drop it to avoid futur
 
 Learn more about configuration validation here: ./configuration-validation.md
 
+<a name="PROVIDER_IAM_SETTINGS_V3"><div>&nbsp;</div></a>
+
+## Grouping IAM settings under `provider.iam`
+
+Deprecation code: `PROVIDER_IAM_SETTINGS_V3`
+
+Removal target: osls v5.0.0
+
+All IAM-related settings of _provider_ including `iamRoleStatements`, `iamManagedPolicies`, `role` and `cfnRole` are also now supported at `iam` property. Refer to the [IAM Guide](./iam.md).
+
+- `provider.role` -> `provider.iam.role`
+- `provider.rolePermissionsBoundary` -> `provider.iam.role.permissionsBoundary`
+- `provider.iamRoleStatements` -> `provider.iam.role.statements`
+- `provider.iamManagedPolicies` -> `provider.iam.role.managedPolicies`
+- `provider.cfnRole` -> `provider.iam.deploymentRole`
+
+In addition `iam.role.permissionBoundary` can also be set at `iam.role.permissionsBoundary` (which matches CloudFormation property name).
+
+Starting with osls v5.0.0, the old settings will no longer be supported.
+
 <a name="AWS_WEBSOCKET_API_USE_PROVIDER_TAGS"><div>&nbsp;</div></a>
 
 ## Property `provider.websocket.useProviderTags`

--- a/lib/plugins/aws/package/lib/merge-iam-templates.js
+++ b/lib/plugins/aws/package/lib/merge-iam-templates.js
@@ -51,6 +51,10 @@ module.exports = {
       return;
     }
 
+    if ('role' in this.serverless.service.provider) {
+      return;
+    }
+
     // resolve early if all functions contain a custom role
     const customRoleProvided = this.serverless.service.getAllFunctions().every((functionName) => {
       const functionObject = this.serverless.service.getFunction(functionName);
@@ -86,6 +90,11 @@ module.exports = {
     // set permission boundary
     if (iamRole.permissionsBoundary) {
       iamRoleLambdaExecutionTemplate.Properties.PermissionsBoundary = iamRole.permissionsBoundary;
+    } else if (iamRole.permissionBoundary) {
+      iamRoleLambdaExecutionTemplate.Properties.PermissionsBoundary = iamRole.permissionBoundary;
+    } else if (this.serverless.service.provider.rolePermissionsBoundary) {
+      iamRoleLambdaExecutionTemplate.Properties.PermissionsBoundary =
+        this.serverless.service.provider.rolePermissionsBoundary;
     }
 
     iamRoleLambdaExecutionTemplate.Properties.Policies[0].PolicyName =
@@ -174,11 +183,15 @@ module.exports = {
     // add custom iam role statements
     if (iamRole.statements) {
       this.mergeStatements(iamRole.statements);
+    } else if (this.serverless.service.provider.iamRoleStatements) {
+      this.mergeStatements(this.serverless.service.provider.iamRoleStatements);
     }
 
     // add iam managed policies
     if (iamRole.managedPolicies) {
       this.mergeManagedPolicies(iamRole.managedPolicies);
+    } else if (this.serverless.service.provider.iamManagedPolicies) {
+      this.mergeManagedPolicies(this.serverless.service.provider.iamManagedPolicies);
     }
 
     // check if one of the functions contains vpc configuration

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -30,6 +30,7 @@ const {
   getAwsSdkV3CredentialsProviderCacheKey,
 } = require('../../aws/credentials');
 const { cfValue } = require('../../utils/aws-schema-get-cf-value');
+const reportDeprecatedProperties = require('../../utils/report-deprecated-properties');
 const { toCacheKey } = require('../../utils/to-cache-key');
 const { getByPath } = require('../../utils/object-path');
 const { methodDescriptor } = require('../../utils/property-descriptors');
@@ -161,6 +162,18 @@ class AwsProvider {
             }
           }
         }
+        reportDeprecatedProperties(
+          'PROVIDER_IAM_SETTINGS_V3',
+          {
+            'provider.role': 'provider.iam.role',
+            'provider.rolePermissionsBoundary': 'provider.iam.role.permissionsBoundary',
+            'provider.iam.role.permissionBoundary': 'provider.iam.role.permissionsBoundary',
+            'provider.iamManagedPolicies': 'provider.iam.role.managedPolicies',
+            'provider.iamRoleStatements': 'provider.iam.role.statements',
+            'provider.cfnRole': 'provider.iam.deploymentRole',
+          },
+          { serviceConfig: this.serverless.service }
+        );
       },
     };
 
@@ -811,6 +824,7 @@ class AwsProvider {
             },
             apiName: { type: 'string' },
             architecture: { $ref: '#/definitions/awsLambdaArchitecture' },
+            cfnRole: { $ref: '#/definitions/awsArn' },
             cloudFront: {
               type: 'object',
               properties: {
@@ -1015,6 +1029,7 @@ class AwsProvider {
                           items: { $ref: '#/definitions/awsArn' },
                         },
                         statements: { $ref: '#/definitions/awsIamPolicyStatements' },
+                        permissionBoundary: { $ref: '#/definitions/awsArn' },
                         permissionsBoundary: { $ref: '#/definitions/awsArn' },
                         tags: { $ref: '#/definitions/awsResourceTags' },
                       },
@@ -1026,6 +1041,8 @@ class AwsProvider {
               },
               additionalProperties: false,
             },
+            iamManagedPolicies: { type: 'array', items: { $ref: '#/definitions/awsArn' } },
+            iamRoleStatements: { $ref: '#/definitions/awsIamPolicyStatements' },
             ecr: {
               type: 'object',
               properties: {
@@ -1182,6 +1199,8 @@ class AwsProvider {
                 'sa-east-1',
               ],
             },
+            role: { $ref: '#/definitions/awsLambdaRole' },
+            rolePermissionsBoundary: { $ref: '#/definitions/awsArnString' },
             rollbackConfiguration: {
               type: 'object',
               properties: {
@@ -1782,7 +1801,7 @@ class AwsProvider {
 
     return provider.iam && provider.iam.deploymentRole !== undefined
       ? provider.iam.deploymentRole
-      : undefined;
+      : provider.cfnRole;
   }
 
   // Check if role is provided as a string or a CF function reference to existing role
@@ -1805,7 +1824,7 @@ class AwsProvider {
 
     if (this.isExistingRoleProvided(role)) return role;
 
-    return undefined;
+    return hasOwn(provider, 'role') ? provider.role : undefined;
   }
 
   resolveFunctionArn(functionAddress) {

--- a/lib/utils/report-deprecated-properties.js
+++ b/lib/utils/report-deprecated-properties.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const logDeprecation = require('./log-deprecation');
+const { getByPath } = require('./object-path');
+
+const getMessage = (props, serviceConfig) => {
+  const warnings = [];
+
+  for (const [oldProp, newProp] of Object.entries(props)) {
+    if (getByPath(serviceConfig, oldProp) != null) {
+      warnings.push([oldProp, newProp]);
+    }
+  }
+
+  if (warnings.length) {
+    const what = warnings.length > 1 ? 'properties' : 'property';
+    const details = warnings
+      .map(([oldProp, newProp]) => `  "${oldProp}" -> "${newProp}"`)
+      .join('\n');
+    return `Starting with osls 5.0.0, following ${what} will no longer be supported:\n${details}`;
+  }
+  return null;
+};
+
+module.exports = (code, props, { serviceConfig } = {}) => {
+  const msg = getMessage(props, serviceConfig);
+  if (msg) {
+    logDeprecation(code, msg, { serviceConfig });
+  }
+};

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -360,7 +360,9 @@ describe('AwsCompileFunctions', () => {
       const { cfTemplate } = await runServerless({
         fixture: 'function',
         configExt: {
+          disabledDeprecations: ['PROVIDER_IAM_SETTINGS_V3'],
           provider: {
+            role: 'role-a',
             iam: { role: 'role-b' },
           },
         },

--- a/test/unit/lib/plugins/aws/package/lib/merge-iam-templates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/merge-iam-templates.test.js
@@ -16,22 +16,22 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
       expect(cfTemplate.Resources).to.not.have.property(iamRoleLambdaExecution);
     });
 
-    it('should reject removed `provider.role`', () =>
-      expect(
-        runServerless({
-          fixture: 'function',
-          command: 'package',
-          configExt: {
-            provider: {
-              name: 'aws',
-              role: 'arn:aws:iam::YourAccountNumber:role/YourIamRole',
-            },
+    it('should not create role resource with deprecated `provider.role`', async () => {
+      const { cfTemplate, awsNaming } = await runServerless({
+        fixture: 'function',
+        command: 'package',
+        configExt: {
+          disabledDeprecations: ['PROVIDER_IAM_SETTINGS_V3'],
+          provider: {
+            name: 'aws',
+            role: 'arn:aws:iam::YourAccountNumber:role/YourIamRole',
           },
-        })
-      ).to.eventually.be.rejected.and.have.property(
-        'code',
-        'INVALID_NON_SCHEMA_COMPLIANT_CONFIGURATION'
-      ));
+        },
+      });
+
+      const IamRoleLambdaExecution = awsNaming.getRoleLogicalId();
+      expect(cfTemplate.Resources).to.not.have.property(IamRoleLambdaExecution);
+    });
 
     it('should not create role resource with `provider.iam.role`', async () => {
       const { cfTemplate, awsNaming } = await runServerless({
@@ -171,7 +171,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
       });
     });
 
-    describe('Provider IAM properties', () => {
+    describe('Provider properties - deprecated properties', () => {
       let cfResources;
       let naming;
 
@@ -180,29 +180,26 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
           fixture: 'function',
           command: 'package',
           configExt: {
+            disabledDeprecations: ['PROVIDER_IAM_SETTINGS_V3'],
             provider: {
-              iam: {
-                role: {
-                  statements: [
-                    {
-                      Effect: 'Allow',
-                      Resource: '*',
-                      NotAction: 'iam:DeleteUser',
-                    },
-                  ],
-                  managedPolicies: [
-                    'arn:aws:iam::123456789012:user/*',
-                    'arn:aws:s3:::my_corporate_bucket/Development/*',
-                    'arn:aws:iam::123456789012:u*',
-                  ],
-                  permissionsBoundary: ['arn:aws:iam::123456789012:policy/XCompanyBoundaries'],
+              iamRoleStatements: [
+                {
+                  Effect: 'Allow',
+                  Resource: '*',
+                  NotAction: 'iam:DeleteUser',
                 },
-              },
+              ],
               vpc: {
                 securityGroupIds: ['xxx'],
                 subnetIds: ['xxx'],
               },
               logRetentionInDays: 5,
+              iamManagedPolicies: [
+                'arn:aws:iam::123456789012:user/*',
+                'arn:aws:s3:::my_corporate_bucket/Development/*',
+                'arn:aws:iam::123456789012:u*',
+              ],
+              rolePermissionsBoundary: ['arn:aws:iam::123456789012:policy/XCompanyBoundaries'],
             },
           },
         });
@@ -211,7 +208,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
         naming = awsNaming;
       });
 
-      it('should support `provider.iam.role.statements`', async () => {
+      it('should support `provider.iamRoleStatements`', async () => {
         const IamRoleLambdaExecution = naming.getRoleLogicalId();
         const iamResource = cfResources[IamRoleLambdaExecution];
         const { Statement } = iamResource.Properties.Policies[0].PolicyDocument;
@@ -222,7 +219,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
           NotAction: ['iam:DeleteUser'],
         });
       });
-      it('should support `provider.iam.role.managedPolicies`', () => {
+      it('should support `provider.iamManagedPolicies`', () => {
         const IamRoleLambdaExecution = naming.getRoleLogicalId();
         const {
           Properties: { ManagedPolicyArns },
@@ -235,7 +232,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
         expect(ManagedPolicyArns).to.deep.includes('arn:aws:iam::123456789012:u*');
       });
 
-      it('should support `provider.iam.role.permissionsBoundary`', () => {
+      it('should support `provider.rolePermissionsBoundary`', () => {
         const IamRoleLambdaExecution = naming.getRoleLogicalId();
         const {
           Properties: { PermissionsBoundary },
@@ -245,15 +242,16 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
         );
       });
 
-      it('should support `provider.iam.role.permissionsBoundary`', async () => {
+      it('should support `provider.iam.role.permissionBoundary`', async () => {
         const { cfTemplate, awsNaming } = await runServerless({
           fixture: 'function',
           command: 'package',
           configExt: {
+            disabledDeprecations: ['PROVIDER_IAM_SETTINGS_V3'],
             provider: {
               iam: {
                 role: {
-                  permissionsBoundary: ['arn:aws:iam::123456789012:policy/XCompanyBoundaries'],
+                  permissionBoundary: ['arn:aws:iam::123456789012:policy/XCompanyBoundaries'],
                 },
               },
             },

--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -78,7 +78,8 @@ describe('AwsProvider', () => {
   });
 
   describe('#getCustomDeploymentRole()', () => {
-    it('should use provider.iam.deploymentRole', () => {
+    it('should prefer provider.iam.deploymentRole over cfnRole', () => {
+      serverless.service.provider.cfnRole = 'arn:aws:iam::123:role/cfn';
       serverless.service.provider.iam = {
         deploymentRole: 'arn:aws:iam::123:role/deploy',
       };
@@ -86,13 +87,15 @@ describe('AwsProvider', () => {
       expect(awsProvider.getCustomDeploymentRole()).to.equal('arn:aws:iam::123:role/deploy');
     });
 
-    it('should not fall back to removed cfnRole', () => {
+    it('should fall back to cfnRole when iam.deploymentRole is undefined', () => {
+      serverless.service.provider.cfnRole = 'arn:aws:iam::123:role/cfn';
       serverless.service.provider.iam = {};
 
-      expect(awsProvider.getCustomDeploymentRole()).to.equal(undefined);
+      expect(awsProvider.getCustomDeploymentRole()).to.equal('arn:aws:iam::123:role/cfn');
     });
 
     it('should preserve an explicit null deployment role', () => {
+      serverless.service.provider.cfnRole = 'arn:aws:iam::123:role/cfn';
       serverless.service.provider.iam = {
         deploymentRole: null,
       };
@@ -103,15 +106,17 @@ describe('AwsProvider', () => {
 
   describe('#getCustomExecutionRole()', () => {
     it('ignores inherited function roles', () => {
+      serverless.service.provider.role = 'OwnProviderRole';
       const functionObj = Object.create({ role: 'InheritedFunctionRole' });
 
-      expect(awsProvider.getCustomExecutionRole(functionObj)).to.equal(undefined);
+      expect(awsProvider.getCustomExecutionRole(functionObj)).to.equal('OwnProviderRole');
     });
 
     it('ignores inherited provider iam roles', () => {
       serverless.service.provider.iam = Object.create({ role: 'InheritedIamRole' });
+      serverless.service.provider.role = 'OwnProviderRole';
 
-      expect(awsProvider.getCustomExecutionRole({})).to.equal(undefined);
+      expect(awsProvider.getCustomExecutionRole({})).to.equal('OwnProviderRole');
     });
   });
 

--- a/test/unit/lib/plugins/aws/remove/lib/stack.test.js
+++ b/test/unit/lib/plugins/aws/remove/lib/stack.test.js
@@ -62,9 +62,7 @@ describe('removeStack', () => {
     });
 
     it('should use CloudFormation service role if it is specified', async () => {
-      awsRemove.serverless.service.provider.iam = {
-        deploymentRole: 'arn:aws:iam::123456789012:role/myrole',
-      };
+      awsRemove.serverless.service.provider.cfnRole = 'arn:aws:iam::123456789012:role/myrole';
 
       return awsRemove.remove().then(() => {
         expect(removeStackStub.firstCall.args[0]).to.be.instanceOf(DeleteStackCommand);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -873,6 +873,7 @@ export interface AWS {
     };
     apiName?: string;
     architecture?: AwsLambdaArchitecture;
+    cfnRole?: AwsArn;
     cloudFront?: {
       cachePolicies?: {
         [k: string]: {
@@ -967,11 +968,14 @@ export interface AWS {
             path?: string;
             managedPolicies?: AwsArn[];
             statements?: AwsIamPolicyStatements;
+            permissionBoundary?: AwsArn;
             permissionsBoundary?: AwsArn;
             tags?: AwsResourceTags;
           };
       deploymentRole?: AwsArn;
     };
+    iamManagedPolicies?: AwsArn[];
+    iamRoleStatements?: AwsIamPolicyStatements;
     ecr?: {
       scanOnPush?: boolean;
       images: {
@@ -1071,6 +1075,8 @@ export interface AWS {
       | 'me-south-1'
       | 'mx-central-1'
       | 'sa-east-1';
+    role?: AwsLambdaRole;
+    rolePermissionsBoundary?: AwsArnString;
     rollbackConfiguration?: {
       RollbackTriggers?: {
         Arn: AwsArnString;


### PR DESCRIPTION
Version 4 removed the IAM settings grouped directly under `provider` (`role`, `rolePermissionsBoundary`, `iamManagedPolicies`, `iamRoleStatements` and `cfnRole`), but that removal has since been rescheduled from osls 4.0.0 to osls 5.0.0. This restores support for them on the 4.x line by reinstating their schema definitions, the deployment and execution role fallbacks, the IAM template merging and the TypeScript types, and it again emits the `PROVIDER_IAM_SETTINGS_V3` deprecation warning that now points at the 5.0.0 removal. The deprecations guide regains the corresponding entry.