### PR TITLE
Avoid conflicting AWS credential sources during invoke local

### DIFF
--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -283,16 +283,25 @@ class AwsInvokeLocal {
     };
 
     const credentialEnvVars = await this.getCredentialEnvVars();
+    const hasResolvedCredentials = Boolean(credentialEnvVars.AWS_ACCESS_KEY_ID);
 
-    // profile override from config
+    // profile override from config, used only when there are no static credentials to inject
     const profileOverride = this.provider.getProfile();
-    if (profileOverride) {
+    if (profileOverride && !hasResolvedCredentials) {
       lambdaDefaultEnvVars.AWS_PROFILE = profileOverride;
     }
 
     const configuredEnvVars = await this.resolveConfiguredEnvVars(this.getConfiguredEnvVars());
 
     safeShallowAssign(process.env, lambdaDefaultEnvVars, credentialEnvVars, configuredEnvVars);
+
+    // A Lambda runtime exposes credentials as static keys, never a profile. Once those keys are
+    // injected, drop any inherited or overridden profile so the AWS SDK does not warn about
+    // multiple credential sources (#35); a profile set via the function environment is kept.
+    if (hasResolvedCredentials) {
+      if (!('AWS_PROFILE' in configuredEnvVars)) delete process.env.AWS_PROFILE;
+      if (!('AWS_DEFAULT_PROFILE' in configuredEnvVars)) delete process.env.AWS_DEFAULT_PROFILE;
+    }
   }
 
   async invokeLocal() {


### PR DESCRIPTION
During `serverless invoke local`, osls resolves the active AWS credentials and injects them into the invocation environment as `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` so that a local run mirrors a real Lambda runtime. It previously left any inherited or configured `AWS_PROFILE` in place alongside those keys, which led the AWS SDK to detect two credential sources and emit a warning that it would prefer the profile over the static credentials. This updates `loadEnvVars` so that, once static credentials have been injected, `AWS_PROFILE` and `AWS_DEFAULT_PROFILE` are removed from the invocation environment, leaving the single static-key source that a real Lambda runtime exposes. The configured profile override is now applied only when no static credentials are available to inject, and a profile that is set explicitly through the function environment is left untouched. Since the injected credentials are resolved from whichever profile is in effect, removing the profile name does not change which credentials the invoked function ultimately uses.