### PR TITLE
Clean up partial remote package artifact downloads on failure

### DIFF
--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -2,6 +2,7 @@
 
 const crypto = require('crypto');
 const fs = require('fs');
+const fsp = require('fs').promises;
 const path = require('path');
 const { isDeepStrictEqual } = require('node:util');
 const { pipeline } = require('node:stream/promises');
@@ -131,7 +132,12 @@ class AwsCompileFunctions {
     const s3 = await this.getS3Client(region);
     const response = await s3.send(new GetObjectCommand(s3Object));
 
-    await pipeline(response.Body, fs.createWriteStream(filePath));
+    try {
+      await pipeline(response.Body, fs.createWriteStream(filePath));
+    } catch (error) {
+      await fsp.unlink(filePath).catch(() => {});
+      throw error;
+    }
     if (functionObject.package && functionObject.package.artifact) {
       functionObject.package.artifact = filePath;
     } else {

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -90,6 +90,7 @@ describe('AwsCompileFunctions', () => {
     afterEach(() => {
       S3Client.prototype.send.restore();
       if (fs.createWriteStream.restore) fs.createWriteStream.restore();
+      if (fsp.unlink.restore) fsp.unlink.restore();
     });
 
     function createAwsCompileFunctionsWithS3ClientStub({ onSend } = {}) {
@@ -310,6 +311,58 @@ describe('AwsCompileFunctions', () => {
       expect(
         awsCompileFunctions.serverless.service.functions[functionName].package.artifact
       ).to.equal(originalArtifact);
+    });
+
+    it('should remove the partial temp file when a remote artifact download fails', async () => {
+      const streamError = new Error('stream failed');
+      sendStub.resolves({
+        Body: new Readable({
+          read() {
+            this.destroy(streamError);
+          },
+        }),
+      });
+      const unlinkSpy = sinon.spy(fsp, 'unlink');
+      setRemoteFunctionArtifact();
+
+      await expect(awsCompileFunctions.downloadPackageArtifacts()).to.be.rejectedWith(streamError);
+
+      expect(unlinkSpy).to.have.been.calledOnce;
+      const removedPath = unlinkSpy.firstCall.args[0];
+      expect(path.basename(removedPath)).to.equal(s3ArtifactName);
+      expect(fs.existsSync(removedPath)).to.equal(false);
+    });
+
+    it('should ignore a missing temp file during cleanup and reject with the original error', async () => {
+      const streamError = new Error('stream failed');
+      sendStub.resolves({
+        Body: new Readable({
+          read() {
+            this.destroy(streamError);
+          },
+        }),
+      });
+      const enoent = Object.assign(new Error('not found'), { code: 'ENOENT' });
+      sinon.stub(fsp, 'unlink').rejects(enoent);
+      setRemoteFunctionArtifact();
+
+      await expect(awsCompileFunctions.downloadPackageArtifacts()).to.be.rejectedWith(streamError);
+    });
+
+    it('should reject with the original error even when temp file cleanup fails', async () => {
+      const streamError = new Error('stream failed');
+      sendStub.resolves({
+        Body: new Readable({
+          read() {
+            this.destroy(streamError);
+          },
+        }),
+      });
+      const cleanupError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+      sinon.stub(fsp, 'unlink').rejects(cleanupError);
+      setRemoteFunctionArtifact();
+
+      await expect(awsCompileFunctions.downloadPackageArtifacts()).to.be.rejectedWith(streamError);
     });
   });
 


### PR DESCRIPTION
Remote S3 package artifact downloads could leave a partially written temp file behind when the download or the destination write stream failed, because the streamed write to disk was not wrapped in any cleanup. This wraps that write so that a failed download or write removes the partial temp file before re-throwing the original error, and it ignores any cleanup error so cleanup never masks the underlying download or write failure. It also adds unit tests covering removal of the partial temp file on failure, a missing temp file being ignored during cleanup, and a cleanup failure not masking the original error.

Fixes #220.