### PR TITLE
Update main branch references to 3.x

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,11 +21,11 @@ jobs:
         with:
           fetch-depth: 30
 
-      - name: Retrieve last main commit (for `git diff` purposes)
+      - name: Retrieve last 3.x commit (for `git diff` purposes)
         run: |
           git checkout -b pr
-          git fetch --prune --depth=30 origin +refs/heads/main:refs/remotes/origin/main
-          git checkout main
+          git fetch --prune --depth=30 origin +refs/heads/3.x:refs/remotes/origin/3.x
+          git checkout 3.x
           git checkout pr
 
       - name: Restore npm cache

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,4 +1,4 @@
 # Release process
 
-1. Push to `main`
+1. Push to `3.x`
 2. Tag a release in GitHub

--- a/lib/aws/credentials-help-url.js
+++ b/lib/aws/credentials-help-url.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = 'https://github.com/oss-serverless/osls/blob/main/docs/guides/credentials.md';
+module.exports = 'https://github.com/oss-serverless/osls/blob/3.x/docs/guides/credentials.md';

--- a/lib/classes/config-schema-handler/index.js
+++ b/lib/classes/config-schema-handler/index.js
@@ -120,7 +120,7 @@ class ConfigSchemaHandler {
             messages.length > 1
               ? `${ERROR_PREFIX}: \n     ${messages.join('\n     ')}`
               : `${ERROR_PREFIX} ${messages[0]}`
-          }\n\nLearn more about configuration validation here: https://github.com/oss-serverless/osls/blob/main/docs/guides/configuration-validation.md`,
+          }\n\nLearn more about configuration validation here: https://github.com/oss-serverless/osls/blob/3.x/docs/guides/configuration-validation.md`,
           'INVALID_NON_SCHEMA_COMPLIANT_CONFIGURATION'
         );
       } else {
@@ -131,7 +131,7 @@ class ConfigSchemaHandler {
             ...messages.map((message) => `  ${message}`),
             '',
             `Learn more about configuration validation here: ${style.link(
-              'https://github.com/oss-serverless/osls/blob/main/docs/guides/configuration-validation.md'
+              'https://github.com/oss-serverless/osls/blob/3.x/docs/guides/configuration-validation.md'
             )}`,
           ].join('\n')
         );

--- a/lib/plugins/standalone.js
+++ b/lib/plugins/standalone.js
@@ -18,7 +18,7 @@ const upgradeCommandDeprecationMessage = [
   '',
   '  npm install -g osls@latest',
   '',
-  'More info: https://github.com/oss-serverless/osls/blob/main/docs/guides/deprecations.md#STANDALONE_UPGRADE_COMMAND_DEPRECATED',
+  'More info: https://github.com/oss-serverless/osls/blob/3.x/docs/guides/deprecations.md#STANDALONE_UPGRADE_COMMAND_DEPRECATED',
 ].join('\n');
 const uninstallCommandDeprecationMessage = [
   'The top-level standalone `sls uninstall` command is deprecated and scheduled for removal in osls v4.0.0.',

--- a/lib/utils/log-deprecation.js
+++ b/lib/utils/log-deprecation.js
@@ -75,7 +75,7 @@ module.exports = (code, message, { serviceConfig } = {}) => {
     switch (resolveMode(serviceConfig)) {
       case 'error':
         throw new ServerlessError(
-          `${message}\n  More Info: https://github.com/oss-serverless/osls/blob/main/docs/guides/deprecations.md#${code}`,
+          `${message}\n  More Info: https://github.com/oss-serverless/osls/blob/3.x/docs/guides/deprecations.md#${code}`,
           `REJECTED_DEPRECATION_${code}`
         );
       case 'warn':
@@ -128,7 +128,7 @@ module.exports.printSummary = async () => {
       if (!code.startsWith('EXT_')) {
         healthStatus.push(
           style.aside(
-            `More info: https://github.com/oss-serverless/osls/blob/main/docs/guides/deprecations.md#${code}`
+            `More info: https://github.com/oss-serverless/osls/blob/3.x/docs/guides/deprecations.md#${code}`
           )
         );
       }

--- a/package.json
+++ b/package.json
@@ -93,11 +93,11 @@
   "scripts": {
     "integration-test-run-package": "mocha --config test/mocha/package.cjs \"test/integration-package/**/*.tests.js\"",
     "lint": "eslint .",
-    "lint:updated": "pipe-git-updated --ext=cjs --ext=js --ext=mjs --base=main -- eslint",
+    "lint:updated": "pipe-git-updated --ext=cjs --ext=js --ext=mjs --base=3.x -- eslint",
     "prettier-check": "prettier -c \"**/*.{cjs,css,html,js,json,md,mjs,yaml,yml}\"",
-    "prettier-check:updated": "pipe-git-updated --ext=cjs --ext=css --ext=html --ext=js --ext=json --ext=md --ext=mjs --ext=yaml --ext=yml --base=main -- prettier -c",
+    "prettier-check:updated": "pipe-git-updated --ext=cjs --ext=css --ext=html --ext=js --ext=json --ext=md --ext=mjs --ext=yaml --ext=yml --base=3.x -- prettier -c",
     "prettify": "prettier --write \"**/*.{cjs,css,html,js,json,md,mjs,yaml,yml}\"",
-    "prettify:updated": "pipe-git-updated --ext=cjs --ext=css --ext=html --ext=js --ext=json --ext=md --ext=mjs --ext=yaml --ext=yml --base=main -- prettier --write",
+    "prettify:updated": "pipe-git-updated --ext=cjs --ext=css --ext=html --ext=js --ext=json --ext=md --ext=mjs --ext=yaml --ext=yml --base=3.x -- prettier --write",
     "test": "mocha --config test/mocha/unit.cjs --parallel \"test/unit/**/*.test.js\"",
     "test:ci": "npm run prettier-check:updated && npm run lint:updated && npm run test:isolated",
     "test:isolated": "mocha --config test/mocha/unit.cjs --parallel \"test/unit/**/*.test.js\""

--- a/test/README.md
+++ b/test/README.md
@@ -17,22 +17,22 @@ All new tests should be configured with help of [runServerless](./utils/run-serv
 
 The `runServerless` util (inlined from @serverless/test) is configured at `./utils/run-serverless.js` and supports two additional options (`fixture` and `configExt`), which provides out of a box setup to run _Serverless_ instance against prepared fixture with eventually extended service configuration
 
-As `runServerless` tests are expensive, it's good to ensure a _minimal_ count of `runServerless` runs to test given scope of problems. Ideally with one service example we should cover most of the test cases we can (good example of such approach is [ALB health check tests](https://github.com/serverless/serverless/blob/80e70e7affd54418361c4d54bdef1561af6b8826/lib/plugins/aws/package/compile/events/alb/lib/healthCheck.test.js#L18-L127))
+As `runServerless` tests are expensive, it's good to ensure a _minimal_ count of `runServerless` runs to test given scope of problems. Ideally with one service example we should cover most of the test cases we can (good example of such approach is [ALB health check tests](./unit/lib/plugins/aws/package/compile/events/alb/lib/health-check.test.js))
 
-When creating a new test, it is an established practice to name the top-level describe after the path to the file, as shown in [AWS Kafka tests](https://github.com/serverless/serverless/blob/b36cdf2db6ee25f7defe6f2c02dd40e1d5cb65c4/test/unit/lib/plugins/aws/package/compile/events/kafka.test.js#L10).
+When creating a new test, it is an established practice to name the top-level describe after the path to the file, as shown in [AWS Kafka tests](./unit/lib/plugins/aws/package/compile/events/kafka.test.js).
 
 ### Existing test examples:
 
-- [Run against config passed inline](https://github.com/serverless/serverless/blob/73107822945a878abbdebe2309e8e9d87cc2858a/lib/plugins/aws/package/lib/generateCoreTemplate.test.js#L11-L14)
-- [Run against pre-prepared fixture](https://github.com/serverless/serverless/blob/74634c3317a116077a008375e20d6a5b99b1256e/lib/plugins/aws/package/compile/functions/index.test.js#L2605-L2608)
-  - Fixtures can be [extended](https://github.com/serverless/serverless/blob/74634c3317a116077a008375e20d6a5b99b1256e/lib/plugins/aws/package/compile/events/httpApi/index.test.js#L95-L99) on spot. Whenever possible it's better to extend existing fixture (e.g. basic `function`) instead of creating new one (check [ALB health check tests](https://github.com/serverless/serverless/blob/80e70e7affd54418361c4d54bdef1561af6b8826/lib/plugins/aws/package/compile/events/alb/lib/healthCheck.test.js) for good example on such approach)
+- [Run against config passed inline](./unit/lib/plugins/aws/package/lib/generate-core-template.test.js)
+- [Run against pre-prepared fixture](./unit/lib/plugins/aws/package/compile/functions.test.js)
+  - Fixtures can be [extended](./unit/lib/plugins/aws/package/compile/events/http-api.test.js) on spot. Whenever possible it's better to extend existing fixture (e.g. basic `function`) instead of creating new one (check [ALB health check tests](./unit/lib/plugins/aws/package/compile/events/alb/lib/health-check.test.js) for good example on such approach)
   - If needed introduce new test fixtures at [test/fixtures](./fixtures)
 
 Example of test files fully backed by `runServerless`:
 
-- [lib/plugins/aws/package/compile/events/httpApi.js](https://github.com/serverless/serverless/blob/main/lib/plugins/aws/package/compile/events/httpApi.js)
+- [test/unit/lib/plugins/aws/package/compile/events/http-api.test.js](./unit/lib/plugins/aws/package/compile/events/http-api.test.js)
 
-If we're about to add new tests to an existing test file with tests written old way, then best is to create another `describe` block for new tests at the bottom (as it's done [here](https://github.com/serverless/serverless/blob/main/test/unit/lib/plugins/aws/package/compile/functions.test.js#L1049))
+If we're about to add new tests to an existing test file with tests written old way, then best is to create another `describe` block for new tests at the bottom (as it's done [here](./unit/lib/plugins/aws/package/compile/functions.test.js))
 
 _Note: PR's which rewrite existing tests into new method are very welcome! (but, ideally each PR should cover single test file rewrite)_
 

--- a/test/unit/commands/doctor.test.js
+++ b/test/unit/commands/doctor.test.js
@@ -30,7 +30,7 @@ describe('test/unit/commands/doctor.test.js', async () => {
 
     expect(output).to.include('deprecation triggered in the last command');
     expect(output).to.include(
-      'More info: https://github.com/oss-serverless/osls/blob/main/docs/guides/deprecations.md#AWS_HTTP_API_USE_PROVIDER_TAGS_PROPERTY'
+      'More info: https://github.com/oss-serverless/osls/blob/3.x/docs/guides/deprecations.md#AWS_HTTP_API_USE_PROVIDER_TAGS_PROPERTY'
     );
   });
 

--- a/test/unit/lib/utils/log-deprecation.test.js
+++ b/test/unit/lib/utils/log-deprecation.test.js
@@ -42,7 +42,7 @@ describe('test/unit/lib/utils/logDeprecation.test.js', () => {
     expect(error).to.have.property('code', 'REJECTED_DEPRECATION_CODE1');
     expect(error.message).to.include('Start using deprecation log');
     expect(error.message).to.include(
-      'More Info: https://github.com/oss-serverless/osls/blob/main/docs/guides/deprecations.md#CODE1'
+      'More Info: https://github.com/oss-serverless/osls/blob/3.x/docs/guides/deprecations.md#CODE1'
     );
   });
 
@@ -57,7 +57,7 @@ describe('test/unit/lib/utils/logDeprecation.test.js', () => {
 
     expect(summary).to.include('Start using deprecation log');
     expect(summary).to.include(
-      'More info: https://github.com/oss-serverless/osls/blob/main/docs/guides/deprecations.md#CODE1'
+      'More info: https://github.com/oss-serverless/osls/blob/3.x/docs/guides/deprecations.md#CODE1'
     );
   });
 


### PR DESCRIPTION
Now that the default branch has been renamed from main to 3.x, this updates the remaining references to the old branch name so they point at 3.x. The documentation links embedded in the credentials help URL, the configuration validation error and warning messages, the standalone command deprecation notice, and the deprecation log summary now use the blob/3.x path, and the matching unit test expectations are updated to agree. The package.json scripts that lint and format only the changed files now diff against 3.x, the continuous integration step that retrieves the base commit for git diff now fetches and checks out 3.x, and the release process note now says to push to 3.x.

It also removes the test documentation's reliance on the upstream serverless/serverless repository. The examples in test/README.md now use relative links to the equivalent files in this repository, so they no longer depend on an external project or a pinned commit, and the entry that illustrates a test fully backed by runServerless now points at the actual http-api test file rather than a source module.

Unrelated uses of the word main, such as the package entry point, the AWS console URL in the HTTP API documentation, and the external bitbucket URLs in a download test fixture, are intentionally left unchanged.