### PR TITLE
Update 3.x branch references to 4.x

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,11 +21,11 @@ jobs:
         with:
           fetch-depth: 30
 
-      - name: Retrieve last 3.x commit (for `git diff` purposes)
+      - name: Retrieve last 4.x commit (for `git diff` purposes)
         run: |
           git checkout -b pr
-          git fetch --prune --depth=30 origin +refs/heads/3.x:refs/remotes/origin/3.x
-          git checkout 3.x
+          git fetch --prune --depth=30 origin +refs/heads/4.x:refs/remotes/origin/4.x
+          git checkout 4.x
           git checkout pr
 
       - name: Restore npm cache

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,4 +1,4 @@
 # Release process
 
-1. Push to `3.x`
+1. Push to `4.x`
 2. Tag a release in GitHub

--- a/lib/aws/credentials-help-url.js
+++ b/lib/aws/credentials-help-url.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = 'https://github.com/oss-serverless/osls/blob/3.x/docs/guides/credentials.md';
+module.exports = 'https://github.com/oss-serverless/osls/blob/4.x/docs/guides/credentials.md';

--- a/lib/classes/config-schema-handler/index.js
+++ b/lib/classes/config-schema-handler/index.js
@@ -120,7 +120,7 @@ class ConfigSchemaHandler {
             messages.length > 1
               ? `${ERROR_PREFIX}: \n     ${messages.join('\n     ')}`
               : `${ERROR_PREFIX} ${messages[0]}`
-          }\n\nLearn more about configuration validation here: https://github.com/oss-serverless/osls/blob/3.x/docs/guides/configuration-validation.md`,
+          }\n\nLearn more about configuration validation here: https://github.com/oss-serverless/osls/blob/4.x/docs/guides/configuration-validation.md`,
           'INVALID_NON_SCHEMA_COMPLIANT_CONFIGURATION'
         );
       } else {
@@ -131,7 +131,7 @@ class ConfigSchemaHandler {
             ...messages.map((message) => `  ${message}`),
             '',
             `Learn more about configuration validation here: ${style.link(
-              'https://github.com/oss-serverless/osls/blob/3.x/docs/guides/configuration-validation.md'
+              'https://github.com/oss-serverless/osls/blob/4.x/docs/guides/configuration-validation.md'
             )}`,
           ].join('\n')
         );

--- a/lib/utils/log-deprecation.js
+++ b/lib/utils/log-deprecation.js
@@ -75,7 +75,7 @@ module.exports = (code, message, { serviceConfig } = {}) => {
     switch (resolveMode(serviceConfig)) {
       case 'error':
         throw new ServerlessError(
-          `${message}\n  More Info: https://github.com/oss-serverless/osls/blob/3.x/docs/guides/deprecations.md#${code}`,
+          `${message}\n  More Info: https://github.com/oss-serverless/osls/blob/4.x/docs/guides/deprecations.md#${code}`,
           `REJECTED_DEPRECATION_${code}`
         );
       case 'warn':
@@ -128,7 +128,7 @@ module.exports.printSummary = async () => {
       if (!code.startsWith('EXT_')) {
         healthStatus.push(
           style.aside(
-            `More info: https://github.com/oss-serverless/osls/blob/3.x/docs/guides/deprecations.md#${code}`
+            `More info: https://github.com/oss-serverless/osls/blob/4.x/docs/guides/deprecations.md#${code}`
           )
         );
       }

--- a/package.json
+++ b/package.json
@@ -100,11 +100,11 @@
   "scripts": {
     "integration-test-run-package": "mocha --config test/mocha/package.cjs \"test/integration-package/**/*.tests.js\"",
     "lint": "eslint .",
-    "lint:updated": "pipe-git-updated --ext=cjs --ext=js --ext=mjs --base=3.x -- eslint",
+    "lint:updated": "pipe-git-updated --ext=cjs --ext=js --ext=mjs --base=4.x -- eslint",
     "prettier-check": "prettier -c \"**/*.{cjs,css,html,js,json,md,mjs,yaml,yml}\"",
-    "prettier-check:updated": "pipe-git-updated --ext=cjs --ext=css --ext=html --ext=js --ext=json --ext=md --ext=mjs --ext=yaml --ext=yml --base=3.x -- prettier -c",
+    "prettier-check:updated": "pipe-git-updated --ext=cjs --ext=css --ext=html --ext=js --ext=json --ext=md --ext=mjs --ext=yaml --ext=yml --base=4.x -- prettier -c",
     "prettify": "prettier --write \"**/*.{cjs,css,html,js,json,md,mjs,yaml,yml}\"",
-    "prettify:updated": "pipe-git-updated --ext=cjs --ext=css --ext=html --ext=js --ext=json --ext=md --ext=mjs --ext=yaml --ext=yml --base=3.x -- prettier --write",
+    "prettify:updated": "pipe-git-updated --ext=cjs --ext=css --ext=html --ext=js --ext=json --ext=md --ext=mjs --ext=yaml --ext=yml --base=4.x -- prettier --write",
     "test": "mocha --config test/mocha/unit.cjs --parallel \"test/unit/**/*.test.js\"",
     "test:ci": "npm run prettier-check:updated && npm run lint:updated && npm run test:isolated",
     "test:isolated": "mocha --config test/mocha/unit.cjs --parallel \"test/unit/**/*.test.js\""

--- a/test/unit/commands/doctor.test.js
+++ b/test/unit/commands/doctor.test.js
@@ -30,7 +30,7 @@ describe('test/unit/commands/doctor.test.js', async () => {
 
     expect(output).to.include('deprecation triggered in the last command');
     expect(output).to.include(
-      'More info: https://github.com/oss-serverless/osls/blob/3.x/docs/guides/deprecations.md#AWS_HTTP_API_USE_PROVIDER_TAGS_PROPERTY'
+      'More info: https://github.com/oss-serverless/osls/blob/4.x/docs/guides/deprecations.md#AWS_HTTP_API_USE_PROVIDER_TAGS_PROPERTY'
     );
   });
 

--- a/test/unit/lib/utils/log-deprecation.test.js
+++ b/test/unit/lib/utils/log-deprecation.test.js
@@ -42,7 +42,7 @@ describe('test/unit/lib/utils/logDeprecation.test.js', () => {
     expect(error).to.have.property('code', 'REJECTED_DEPRECATION_CODE1');
     expect(error.message).to.include('Start using deprecation log');
     expect(error.message).to.include(
-      'More Info: https://github.com/oss-serverless/osls/blob/3.x/docs/guides/deprecations.md#CODE1'
+      'More Info: https://github.com/oss-serverless/osls/blob/4.x/docs/guides/deprecations.md#CODE1'
     );
   });
 
@@ -57,7 +57,7 @@ describe('test/unit/lib/utils/logDeprecation.test.js', () => {
 
     expect(summary).to.include('Start using deprecation log');
     expect(summary).to.include(
-      'More info: https://github.com/oss-serverless/osls/blob/3.x/docs/guides/deprecations.md#CODE1'
+      'More info: https://github.com/oss-serverless/osls/blob/4.x/docs/guides/deprecations.md#CODE1'
     );
   });
 


### PR DESCRIPTION
The recent merge from 3.x carried that branch's references to the 3.x branch name onto 4.x, where they should instead refer to 4.x. This points the continuous integration step that retrieves the base commit for git diff at 4.x, sets the package.json lint and prettier scripts that operate on changed files to diff against 4.x, updates the release process note to push to 4.x, and switches the documentation links embedded in the credentials help URL, the configuration validation messages, and the deprecation log output to the blob/4.x path, with the matching unit test expectations updated to agree. The referenced documentation pages all exist on 4.x, so the links resolve, and the test/README.md examples already use relative links and need no change.