### PR TITLE
Retry Windows safe move rename locks

### DIFF
--- a/lib/utils/fs/safe-move-file.js
+++ b/lib/utils/fs/safe-move-file.js
@@ -4,18 +4,43 @@ const fsp = require('fs').promises;
 const crypto = require('crypto');
 const path = require('path');
 const { remove } = require('./remove');
+const sleep = require('../sleep');
+
+const RENAME_MAX_RETRIES = 3;
+const RENAME_RETRY_BASE_DELAY_MS = 100;
+
+// Windows can reject a valid rename with EPERM when the destination is briefly
+// locked by another process (a concurrent reader or an antivirus scan). Such
+// locks are transient, so retry with a short backoff before giving up.
+const shouldRetryRename = (error) => process.platform === 'win32' && error.code === 'EPERM';
+
+const renameWithRetry = async (oldPath, newPath) => {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await fsp.rename(oldPath, newPath);
+      return;
+    } catch (error) {
+      if (!shouldRetryRename(error) || attempt >= RENAME_MAX_RETRIES) {
+        throw error;
+      }
+
+      await sleep(RENAME_RETRY_BASE_DELAY_MS * 2 ** attempt);
+    }
+  }
+};
 
 /**
- * Given a path that designates a location of a file on another device,
- * will return a path to file in the same folder, but with a unique name
- * to avoid collisions.
+ * Given a path that designates a location of a file on another device, will
+ * return a path to file in the same folder, but with a unique name to avoid
+ * collisions.
  *
  * @param {*} destPath the path to the final location of the file being moved
  * @returns a unique path to a file on the same device as the file being moved
  */
 const generateTemporaryPathOnDestinationDevice = (destPath) => {
   const dirName = path.dirname(destPath);
-  // Generate a unique destination file name to get the file onto the destination filesystem
+  // Generate a unique destination file name to get the file onto the
+  // destination filesystem
   const tempName = path.basename(destPath) + crypto.randomBytes(8).toString('hex');
   return path.join(dirName, tempName);
 };
@@ -23,35 +48,26 @@ const generateTemporaryPathOnDestinationDevice = (destPath) => {
 /**
  * Allows a file to be moved (renamed) even across filesystem boundaries.
  *
- * If the rename fails because the file is getting renamed across file system boundaries,
- * the file is first copied to the destination file system under a temporary name,
- * and then renamed from there.
+ * If the rename fails because the file is getting renamed across file system
+ * boundaries, the file is first copied to the destination file system under a
+ * temporary name, and then renamed from there.
  *
- * This is done because rename is atomic but copy is not, and can leave partially copied files.
+ * This is done because rename is atomic but copy is not, and can leave
+ * partially copied files.
  *
  * @param {*} oldPath the original file that should be moved
  * @param {*} newPath the path to move the file to
  */
 async function safeMoveFile(oldPath, newPath) {
   try {
-    // Golden path, we simply rename the file in an atomic operation
-    await fsp.rename(oldPath, newPath);
+    await renameWithRetry(oldPath, newPath);
   } catch (err) {
-    // The EXDEV error indicates that the rename failed because the rename was across filesystem boundaries
-    // This might occur if a distro uses tmpfs for temporary directories
-    if (err.code === 'EXDEV') {
-      // Generate a unique destination file name to get the file onto the destination filesystem
-      const tempPath = generateTemporaryPathOnDestinationDevice(newPath);
+    if (err.code !== 'EXDEV') throw err;
 
-      // Copy onto the destination filesystem (not guaranteed to be atomic)
-      await fsp.copyFile(oldPath, tempPath);
-      // Atomically move the file onto the destination path, overwriting it
-      await fsp.rename(tempPath, newPath);
-      // Delete the old file once both the above operations succeed
-      await remove(oldPath);
-    } else {
-      throw err;
-    }
+    const tempPath = generateTemporaryPathOnDestinationDevice(newPath);
+    await fsp.copyFile(oldPath, tempPath);
+    await renameWithRetry(tempPath, newPath);
+    await remove(oldPath);
   }
 }
 

--- a/test/unit/lib/utils/fs/safe-move-file.test.js
+++ b/test/unit/lib/utils/fs/safe-move-file.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const sinon = require('sinon');
+const proxyquire = require('proxyquire');
 const provisionTempDir = require('../../../../lib/provision-tmp-dir');
 const { join } = require('path');
 const { expect } = require('chai');
@@ -29,6 +30,12 @@ const createFakeExDevError = () => {
   fakeCrossDeviceError.path = '/foo/bar';
   fakeCrossDeviceError.dest = '/bar/baz';
   return fakeCrossDeviceError;
+};
+
+const createFakeEpermError = () => {
+  const error = new Error('EPERM: operation not permitted, rename');
+  error.code = 'EPERM';
+  return error;
 };
 
 /**
@@ -138,6 +145,73 @@ describe('test/unit/lib/utils/fs/safeMoveFile.test.js', () => {
       const temporaryDestinationPath = renameStub.secondCall.args[0];
       expect(fs.existsSync(temporaryDestinationPath)).to.equal(false);
       expect(fs.existsSync(destinationFile)).to.equal(true);
+    });
+  });
+
+  describe('when rename fails with a transient Windows EPERM lock', () => {
+    let originalPlatformDescriptor;
+    let sleepStub;
+    let safeMoveFileWithStubbedSleep;
+
+    const setPlatform = (platform) => {
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: platform,
+      });
+    };
+
+    const loadSafeMoveFileWithStubbedSleep = () => {
+      safeMoveFileWithStubbedSleep = proxyquire('../../../../../lib/utils/fs/safe-move-file', {
+        '../sleep': sleepStub,
+      });
+    };
+
+    beforeEach(() => {
+      originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+      sleepStub = sinon.stub().resolves();
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+    });
+
+    it('retries on Windows and succeeds once the lock clears', async () => {
+      setPlatform('win32');
+      loadSafeMoveFileWithStubbedSleep();
+      renameStub.onFirstCall().rejects(createFakeEpermError());
+
+      await safeMoveFileWithStubbedSleep(sourceFile, destinationFile);
+
+      expect(renameStub).to.have.been.calledTwice;
+      expect(sleepStub).to.have.been.calledOnceWithExactly(100);
+      expect(fs.existsSync(sourceFile)).to.be.false;
+      expect(fs.existsSync(destinationFile)).to.be.true;
+    });
+
+    it('rethrows the EPERM once the retries are exhausted', async () => {
+      setPlatform('win32');
+      loadSafeMoveFileWithStubbedSleep();
+      renameStub.rejects(createFakeEpermError());
+
+      await expect(safeMoveFileWithStubbedSleep(sourceFile, destinationFile)).to.be.rejectedWith(
+        'EPERM'
+      );
+
+      expect(renameStub.callCount).to.equal(4);
+      expect(sleepStub.args.map(([ms]) => ms)).to.deep.equal([100, 200, 400]);
+    });
+
+    it('does not retry EPERM on non-Windows platforms', async () => {
+      setPlatform('linux');
+      loadSafeMoveFileWithStubbedSleep();
+      renameStub.rejects(createFakeEpermError());
+
+      await expect(safeMoveFileWithStubbedSleep(sourceFile, destinationFile)).to.be.rejectedWith(
+        'EPERM'
+      );
+
+      expect(renameStub).to.have.been.calledOnce;
+      expect(sleepStub).to.have.not.been.called;
     });
   });
 });


### PR DESCRIPTION
This change retries transient Windows EPERM failures when safeMoveFile renames files, which can happen when another process or antivirus scan briefly locks the destination. The retry logic is bounded and Windows-specific, and it is shared by both the direct rename path and the cross-device fallback so cached artifacts can still be moved safely without changing behavior on other platforms.