### PR TITLE
Remove unused aws4 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "adm-zip": "^0.5.10",
-    "aws4": "^1.12.0",
     "chai": "^6.2.2",
     "chai-as-promised": "^8.0.2",
     "eslint": "^10.2.1",


### PR DESCRIPTION
This removes the unused aws4 development dependency from the 3.x branch because the package is no longer referenced by the codebase.