### PR TITLE
Migrate S3 and Cognito event coverage

### DIFF
--- a/lib/plugins/aws/package/compile/events/cognito-user-pool.js
+++ b/lib/plugins/aws/package/compile/events/cognito-user-pool.js
@@ -450,11 +450,12 @@ class AwsCompileCognitoUserPoolEvents {
       const userPoolLogicalId = this.provider.naming.getCognitoUserPoolLogicalId(poolName);
 
       // If overrides exist in `Resources`, merge them in
-      if (
+      const customResources =
         this.serverless.service.resources &&
-        this.serverless.service.resources[userPoolLogicalId]
-      ) {
-        const customUserPool = this.serverless.service.resources[userPoolLogicalId];
+        (this.serverless.service.resources.Resources || this.serverless.service.resources);
+
+      if (customResources && customResources[userPoolLogicalId]) {
+        const customUserPool = customResources[userPoolLogicalId];
         const generatedUserPool = this.generateTemplateForPool(
           poolName,
           currentPoolTriggerFunctions

--- a/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
@@ -201,6 +201,8 @@ const preTokenGenerationConfigurationExtension = {
   },
 };
 
+const customUserPoolDependency = 'CustomCognitoUserPoolDependency';
+
 describe('AwsCompileCognitoUserPoolEvents', () => {
   let serverless;
   let awsCompileCognitoUserPoolEvents;
@@ -1018,15 +1020,132 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
 
 describe('lib/plugins/aws/package/compile/events/cognito-user-pool.test.js', () => {
   let cfResources;
+  let naming;
+  let serverlessInstance;
 
   before(async () => {
-    const { cfTemplate } = await runServerless({
-      fixture: 'function',
-      configExt: serverlessConfigurationExtension,
+    const { awsNaming, cfTemplate, serverless } = await runServerless({
+      fixture: 'cognito-user-pool',
+      configExt: {
+        ...serverlessConfigurationExtension,
+        resources: {
+          Resources: {
+            CognitoUserPoolCUPCustomEmailSender: {
+              DependsOn: [customUserPoolDependency],
+            },
+          },
+        },
+      },
       command: 'package',
     });
 
     ({ Resources: cfResources } = cfTemplate);
+    naming = awsNaming;
+    serverlessInstance = serverless;
+  });
+
+  describe('Fixture final templates', () => {
+    it('should generate expected resources for new Cognito user pools', () => {
+      const serviceName = serverlessInstance.service.service;
+      const poolName = `${serviceName} CUP Basic`;
+      const poolResource = cfResources[naming.getCognitoUserPoolLogicalId(poolName)];
+      const permissionResource =
+        cfResources[
+          naming.getLambdaCognitoUserPoolPermissionLogicalId('basic', poolName, 'PreSignUp')
+        ];
+
+      expect(poolResource).to.deep.equal({
+        Type: 'AWS::Cognito::UserPool',
+        Properties: {
+          UserPoolName: poolName,
+          LambdaConfig: {
+            PreSignUp: { 'Fn::GetAtt': [naming.getLambdaLogicalId('basic'), 'Arn'] },
+          },
+        },
+        DependsOn: [naming.getLambdaLogicalId('basic')],
+      });
+      expect(permissionResource).to.deep.equal({
+        Type: 'AWS::Lambda::Permission',
+        DependsOn: undefined,
+        Properties: {
+          FunctionName: { 'Fn::GetAtt': [naming.getLambdaLogicalId('basic'), 'Arn'] },
+          Action: 'lambda:InvokeFunction',
+          Principal: 'cognito-idp.amazonaws.com',
+          SourceArn: { 'Fn::GetAtt': [naming.getCognitoUserPoolLogicalId(poolName), 'Arn'] },
+        },
+      });
+    });
+
+    it('should merge generated Cognito user pool resources with custom resources', () => {
+      const serviceName = serverlessInstance.service.service;
+      const poolResource = cfResources[naming.getCognitoUserPoolLogicalId('CUP CustomEmailSender')];
+
+      expect(poolResource.Type).to.equal('AWS::Cognito::UserPool');
+      expect(poolResource.Properties).to.deep.include({
+        UserPoolName: `${serviceName} CUP CustomEmailSender`,
+        UsernameAttributes: ['email'],
+        AutoVerifiedAttributes: ['email'],
+        EmailVerificationMessage: 'email message: {####}',
+        EmailVerificationSubject: 'email subject: {####}',
+      });
+      expect(poolResource.Properties.LambdaConfig).to.deep.equal({
+        KMSKeyID: { 'Fn::GetAtt': ['kmsKey', 'Arn'] },
+        CustomEmailSender: {
+          LambdaArn: { 'Fn::GetAtt': [naming.getLambdaLogicalId('customEmailSender'), 'Arn'] },
+          LambdaVersion: 'V1_0',
+        },
+      });
+      expect(poolResource.DependsOn).to.deep.equal([
+        naming.getLambdaLogicalId('customEmailSender'),
+        customUserPoolDependency,
+      ]);
+    });
+
+    it('should generate expected custom resources for existing Cognito user pools', () => {
+      const serviceName = serverlessInstance.service.service;
+      const simpleResource =
+        cfResources[naming.getCustomResourceCognitoUserPoolResourceLogicalId('existingSimple')];
+      const multiResource =
+        cfResources[naming.getCustomResourceCognitoUserPoolResourceLogicalId('existingMulti')];
+      const customSenderResource =
+        cfResources[
+          naming.getCustomResourceCognitoUserPoolResourceLogicalId('existingCustomEmailSender')
+        ];
+
+      expect(simpleResource).to.deep.equal({
+        Type: 'Custom::CognitoUserPool',
+        Version: 1,
+        DependsOn: [
+          naming.getLambdaLogicalId('existingSimple'),
+          naming.getCustomResourceCognitoUserPoolHandlerFunctionLogicalId(),
+        ],
+        Properties: {
+          ServiceToken: {
+            'Fn::GetAtt': [
+              naming.getCustomResourceCognitoUserPoolHandlerFunctionLogicalId(),
+              'Arn',
+            ],
+          },
+          FunctionName: serverlessInstance.service.getFunction('existingSimple').name,
+          UserPoolName: `${serviceName} CUP Existing Simple`,
+          UserPoolConfigs: [{ Trigger: 'PreSignUp' }],
+          ForceDeploy: undefined,
+        },
+      });
+      expect(multiResource.Properties).to.deep.include({
+        FunctionName: serverlessInstance.service.getFunction('existingMulti').name,
+        UserPoolName: `${serviceName} CUP Existing Multi`,
+        UserPoolConfigs: [{ Trigger: 'PreSignUp' }, { Trigger: 'PreAuthentication' }],
+        ForceDeploy: undefined,
+      });
+      expect(customSenderResource.Properties.UserPoolConfigs).to.deep.equal([
+        {
+          Trigger: 'CustomEmailSender',
+          KMSKeyID: { 'Fn::GetAtt': ['kmsKey', 'Arn'] },
+          LambdaVersion: 'V1_0',
+        },
+      ]);
+    });
   });
 
   describe('Custom Sender Sources', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -617,10 +617,11 @@ describe('AwsCompileS3Events', () => {
 
     it('should support `forceDeploy` setting', async () => {
       const result = await runServerless({
-        fixture: 'function',
+        fixture: 's3',
         configExt: {
           functions: {
             basic: {
+              handler: 'core.existing',
               events: [
                 {
                   s3: {
@@ -956,10 +957,11 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
 
   before(async () => {
     const { cfTemplate, awsNaming, serverless } = await runServerless({
-      fixture: 'function',
+      fixture: 's3',
       configExt: {
         functions: {
           basic: {
+            handler: 'core.existing',
             events: [
               {
                 s3: {
@@ -971,6 +973,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
             ],
           },
           other: {
+            handler: 'core.existingCreated',
             events: [
               {
                 s3: {
@@ -982,7 +985,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
             ],
           },
           withIf: {
-            handler: 'basic.handler',
+            handler: 'core.existingRemoved',
             events: [
               {
                 s3: {
@@ -1000,7 +1003,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
             ],
           },
           prefixSuffixWithCfFunction: {
-            handler: 'basic.handler',
+            handler: 'core.custom',
             events: [
               {
                 s3: {
@@ -1030,6 +1033,114 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
     cfResources = cfTemplate.Resources;
     naming = awsNaming;
     serverlessInstance = serverless;
+  });
+
+  it('should generate expected resources for new S3 buckets', () => {
+    const serviceName = serverlessInstance.service.service;
+    const minimalBucketName = `${serviceName}-s3-minimal`;
+    const extendedBucketName = `${serviceName}-s3-extended`;
+    const minimalBucket = cfResources[naming.getBucketLogicalId(minimalBucketName)];
+    const extendedBucket = cfResources[naming.getBucketLogicalId(extendedBucketName)];
+    const customBucket = cfResources[naming.getBucketLogicalId('customBucket')];
+
+    expect(minimalBucket).to.deep.equal({
+      Type: 'AWS::S3::Bucket',
+      Properties: {
+        BucketName: minimalBucketName,
+        NotificationConfiguration: {
+          LambdaConfigurations: [
+            {
+              Event: 's3:ObjectCreated:*',
+              Function: { 'Fn::GetAtt': [naming.getLambdaLogicalId('minimal'), 'Arn'] },
+            },
+          ],
+        },
+      },
+      DependsOn: [naming.getLambdaS3PermissionLogicalId('minimal', minimalBucketName)],
+    });
+    expect(extendedBucket.Properties.NotificationConfiguration.LambdaConfigurations).to.deep.equal([
+      {
+        Event: 's3:ObjectRemoved:*',
+        Function: { 'Fn::GetAtt': [naming.getLambdaLogicalId('extended'), 'Arn'] },
+        Filter: {
+          S3Key: {
+            Rules: [
+              { Name: 'prefix', Value: 'photos/' },
+              { Name: 'suffix', Value: '.jpg' },
+            ],
+          },
+        },
+      },
+    ]);
+    expect(extendedBucket.DependsOn).to.deep.equal([
+      naming.getLambdaS3PermissionLogicalId('extended', extendedBucketName),
+    ]);
+    expect(customBucket.Properties).to.deep.include({
+      BucketName: `${serviceName}-custom-bucket-dev`,
+      PublicAccessBlockConfiguration: {
+        BlockPublicAcls: true,
+        BlockPublicPolicy: true,
+        IgnorePublicAcls: true,
+        RestrictPublicBuckets: true,
+      },
+    });
+  });
+
+  it('should generate expected custom resources for existing S3 buckets', () => {
+    const serviceName = serverlessInstance.service.service;
+    const existingResource = cfResources[naming.getCustomResourceS3ResourceLogicalId('existing')];
+    const createdResource =
+      cfResources[naming.getCustomResourceS3ResourceLogicalId('existingCreated')];
+    const removedResource =
+      cfResources[naming.getCustomResourceS3ResourceLogicalId('existingRemoved')];
+
+    expect(existingResource).to.deep.equal({
+      Type: 'Custom::S3',
+      Version: 1,
+      DependsOn: [
+        naming.getLambdaLogicalId('existing'),
+        naming.getCustomResourceS3HandlerFunctionLogicalId(),
+      ],
+      Properties: {
+        ServiceToken: {
+          'Fn::GetAtt': [naming.getCustomResourceS3HandlerFunctionLogicalId(), 'Arn'],
+        },
+        FunctionName: serverlessInstance.service.getFunction('existing').name,
+        BucketName: `${serviceName}-s3-existing-simple`,
+        BucketConfigs: [
+          {
+            Event: 's3:ObjectCreated:*',
+            Rules: [{ Prefix: 'Files/' }, { Suffix: '.TXT' }],
+          },
+        ],
+      },
+    });
+    expect(createdResource.Properties.BucketName).to.equal(`${serviceName}-s3-existing-complex`);
+    expect(createdResource.Properties.BucketConfigs).to.deep.equal([
+      {
+        Event: 's3:ObjectCreated:*',
+        Rules: [{ Prefix: 'photos' }, { Suffix: '.jpg' }],
+      },
+      {
+        Event: 's3:ObjectCreated:*',
+        Rules: [{ Prefix: 'photos' }, { Suffix: '.png' }],
+      },
+    ]);
+    expect(removedResource.DependsOn).to.deep.equal([
+      naming.getLambdaLogicalId('existingRemoved'),
+      naming.getCustomResourceS3HandlerFunctionLogicalId(),
+      naming.getCustomResourceS3ResourceLogicalId('existingCreated'),
+    ]);
+    expect(removedResource.Properties.BucketConfigs).to.deep.equal([
+      {
+        Event: 's3:ObjectRemoved:*',
+        Rules: [{ Prefix: 'photos' }, { Suffix: '.jpg' }],
+      },
+      {
+        Event: 's3:ObjectRemoved:*',
+        Rules: [{ Prefix: 'photos' }, { Suffix: '.png' }],
+      },
+    ]);
   });
 
   it('should create lambda permissions policy with wild card', async () => {


### PR DESCRIPTION
This adds fixture-backed package assertions for S3 and Cognito user pool event custom resources while keeping existing helper seam coverage intact. It also preserves generated Cognito user pool dependencies when custom resources are defined under the standard resources.Resources shape.