### PR TITLE
Migrate API Gateway package compiler tests

### DIFF
--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/authorizers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/authorizers.test.js
@@ -221,6 +221,58 @@ describe('#compileAuthorizers()', () => {
 });
 
 describe('#compileAuthorizers() #2', () => {
+  it('should package a local Lambda authorizer with method references', async () => {
+    const { awsNaming, cfTemplate } = await runServerless({
+      fixture: 'api-gateway',
+      command: 'package',
+      configExt: {
+        functions: {
+          auth: {
+            handler: 'index.handler',
+          },
+          foo: {
+            events: [
+              {
+                http: {
+                  method: 'get',
+                  path: '/foo',
+                  authorizer: {
+                    name: 'auth',
+                    type: 'request',
+                    identitySource: 'method.request.header.Authorization',
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+    const authorizerLogicalId = awsNaming.getAuthorizerLogicalId('auth');
+    const authorizer = cfTemplate.Resources[authorizerLogicalId];
+    const authorizerPermission =
+      cfTemplate.Resources[awsNaming.getLambdaApiGatewayPermissionLogicalId('auth')];
+    const method = cfTemplate.Resources[awsNaming.getMethodLogicalId('Foo', 'GET')];
+
+    expect(authorizer.Type).to.equal('AWS::ApiGateway::Authorizer');
+    expect(authorizer.Properties.Name).to.equal('auth');
+    expect(authorizer.Properties.Type).to.equal('REQUEST');
+    expect(authorizer.Properties.IdentitySource).to.equal('method.request.header.Authorization');
+    expect(authorizer.Properties.RestApiId).to.deep.equal({ Ref: 'ApiGatewayRestApi' });
+    expect(authorizer.Properties.AuthorizerUri['Fn::Join'][1]).to.deep.include({
+      'Fn::GetAtt': ['AuthLambdaFunction', 'Arn'],
+    });
+    expect(authorizerPermission.Type).to.equal('AWS::Lambda::Permission');
+    expect(authorizerPermission.Properties.FunctionName).to.deep.equal({
+      'Fn::GetAtt': ['AuthLambdaFunction', 'Arn'],
+    });
+    expect(authorizerPermission.Properties.Action).to.equal('lambda:InvokeFunction');
+    expect(authorizerPermission.Properties.Principal).to.equal('apigateway.amazonaws.com');
+    expect(method.Properties.AuthorizationType).to.equal('CUSTOM');
+    expect(method.Properties.AuthorizerId).to.deep.equal({ Ref: authorizerLogicalId });
+    expect(method.DependsOn).to.include(authorizerLogicalId);
+  });
+
   it('Should reference provisioned alias when pointing local lambda authorizer', async () =>
     runServerless({
       fixture: 'function',

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/stage/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/stage/index.test.js
@@ -62,31 +62,6 @@ describe('#compileStage()', () => {
       };
     });
 
-    it.skip('should create a dedicated stage resource if tracing is configured', async () =>
-      awsCompileApigEvents.compileStage().then(() => {
-        const resources =
-          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
-
-        expect(resources[stageLogicalId]).to.deep.equal({
-          Type: 'AWS::ApiGateway::Stage',
-          Properties: {
-            RestApiId: {
-              Ref: awsCompileApigEvents.apiGatewayRestApiLogicalId,
-            },
-            DeploymentId: {
-              Ref: awsCompileApigEvents.apiGatewayDeploymentLogicalId,
-            },
-            StageName: 'dev',
-            Tags: [],
-            TracingEnabled: true,
-          },
-        });
-
-        expect(resources[awsCompileApigEvents.apiGatewayDeploymentLogicalId]).to.deep.equal({
-          Properties: {},
-        });
-      }));
-
     it('should NOT create a dedicated stage resource if tracing is not enabled', async () => {
       awsCompileApigEvents.serverless.service.provider.tracing = {};
 
@@ -105,101 +80,6 @@ describe('#compileStage()', () => {
     });
   });
 
-  describe('tags', () => {
-    it.skip('should create a dedicated stage resource if provider.stackTags is configured', async () => {
-      awsCompileApigEvents.serverless.service.provider.stackTags = {
-        foo: '1',
-      };
-
-      awsCompileApigEvents.compileStage().then(() => {
-        const resources =
-          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
-        expect(resources[awsCompileApigEvents.apiGatewayDeploymentLogicalId]).to.deep.equal({
-          Properties: {},
-        });
-
-        expect(resources[stageLogicalId]).to.deep.equal({
-          Type: 'AWS::ApiGateway::Stage',
-          Properties: {
-            RestApiId: {
-              Ref: awsCompileApigEvents.apiGatewayRestApiLogicalId,
-            },
-            DeploymentId: {
-              Ref: awsCompileApigEvents.apiGatewayDeploymentLogicalId,
-            },
-            StageName: stage,
-            TracingEnabled: false,
-            Tags: [{ Key: 'foo', Value: '1' }],
-          },
-        });
-      });
-    });
-
-    it.skip('should create a dedicated stage resource if provider.tags is configured', async () => {
-      awsCompileApigEvents.serverless.service.provider.tags = {
-        foo: '1',
-      };
-
-      awsCompileApigEvents.compileStage().then(() => {
-        const resources =
-          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
-        expect(resources[awsCompileApigEvents.apiGatewayDeploymentLogicalId]).to.deep.equal({
-          Properties: {},
-        });
-
-        expect(resources[stageLogicalId]).to.deep.equal({
-          Type: 'AWS::ApiGateway::Stage',
-          Properties: {
-            RestApiId: {
-              Ref: awsCompileApigEvents.apiGatewayRestApiLogicalId,
-            },
-            DeploymentId: {
-              Ref: awsCompileApigEvents.apiGatewayDeploymentLogicalId,
-            },
-            StageName: stage,
-            TracingEnabled: false,
-            Tags: [{ Key: 'foo', Value: '1' }],
-          },
-        });
-      });
-    });
-
-    it.skip('should override provider.stackTags by provider.tags', async () => {
-      awsCompileApigEvents.serverless.service.provider.stackTags = {
-        foo: 'from-stackTags',
-        bar: 'from-stackTags',
-      };
-      awsCompileApigEvents.serverless.service.provider.tags = {
-        foo: 'from-tags',
-        buz: 'from-tags',
-      };
-
-      awsCompileApigEvents.compileStage().then(() => {
-        const resources =
-          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
-
-        expect(resources[stageLogicalId]).to.deep.equal({
-          Type: 'AWS::ApiGateway::Stage',
-          Properties: {
-            RestApiId: {
-              Ref: awsCompileApigEvents.apiGatewayRestApiLogicalId,
-            },
-            DeploymentId: {
-              Ref: awsCompileApigEvents.apiGatewayDeploymentLogicalId,
-            },
-            StageName: stage,
-            TracingEnabled: false,
-            Tags: [
-              { Key: 'foo', Value: 'from-tags' },
-              { Key: 'bar', Value: 'from-stackTags' },
-              { Key: 'buz', Value: 'from-tags' },
-            ],
-          },
-        });
-      });
-    });
-  });
-
   describe('logs', () => {
     beforeEach(() => {
       sinon.stub(childProcess, 'execAsync');
@@ -208,46 +88,6 @@ describe('#compileStage()', () => {
         restApi: true,
       };
     });
-
-    it.skip('should create a dedicated stage resource if logs are configured', async () =>
-      awsCompileApigEvents.compileStage().then(() => {
-        const resources =
-          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
-
-        expect(resources[stageLogicalId]).to.deep.equal({
-          Type: 'AWS::ApiGateway::Stage',
-          Properties: {
-            RestApiId: {
-              Ref: awsCompileApigEvents.apiGatewayRestApiLogicalId,
-            },
-            DeploymentId: {
-              Ref: awsCompileApigEvents.apiGatewayDeploymentLogicalId,
-            },
-            StageName: 'dev',
-            Tags: [],
-            TracingEnabled: false,
-            MethodSettings: [
-              {
-                DataTraceEnabled: true,
-                HttpMethod: '*',
-                LoggingLevel: 'INFO',
-                ResourcePath: '/*',
-              },
-            ],
-            AccessLogSetting: {
-              DestinationArn: {
-                'Fn::GetAtt': [logGroupLogicalId, 'Arn'],
-              },
-              Format:
-                'requestId: $context.requestId, ip: $context.identity.sourceIp, caller: $context.identity.caller, user: $context.identity.user, requestTime: $context.requestTime, httpMethod: $context.httpMethod, resourcePath: $context.resourcePath, status: $context.status, protocol: $context.protocol, responseLength: $context.responseLength',
-            },
-          },
-        });
-
-        expect(resources[awsCompileApigEvents.apiGatewayDeploymentLogicalId]).to.deep.equal({
-          Properties: {},
-        });
-      }));
 
     it('should create a Log Group resource', async () => {
       return awsCompileApigEvents.compileStage().then(() => {
@@ -317,6 +157,108 @@ describe('#compileStage()', () => {
 });
 
 describe('test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js', () => {
+  const getApiGatewayDeploymentResource = (cfTemplate) => {
+    const deploymentLogicalId = Object.keys(cfTemplate.Resources).find((key) =>
+      key.startsWith('ApiGatewayDeployment')
+    );
+    expect(deploymentLogicalId).to.be.a('string');
+
+    const deployment = cfTemplate.Resources[deploymentLogicalId];
+    expect(deployment.Type).to.equal('AWS::ApiGateway::Deployment');
+
+    return deployment;
+  };
+
+  const expectDeploymentStageName = (cfTemplate, stageName) => {
+    expect(getApiGatewayDeploymentResource(cfTemplate).Properties).to.deep.include({
+      RestApiId: { Ref: 'ApiGatewayRestApi' },
+      StageName: stageName,
+    });
+  };
+
+  // Tracing, stage tags, and stage log settings are applied by the deploy-time
+  // update-stage hook; package only emits Deployment and log helper resources.
+  it('should not package tracing as a dedicated Stage resource', async () => {
+    const { cfTemplate, awsNaming } = await runServerless({
+      fixture: 'api-gateway',
+      command: 'package',
+      configExt: {
+        provider: {
+          tracing: {
+            apiGateway: true,
+          },
+        },
+      },
+    });
+
+    expect(cfTemplate.Resources[awsNaming.getStageLogicalId()]).to.be.undefined;
+    expectDeploymentStageName(cfTemplate, 'dev');
+  });
+
+  it('should not package provider.stackTags as API Gateway resource tags', async () => {
+    const { cfTemplate, awsNaming } = await runServerless({
+      fixture: 'api-gateway',
+      command: 'package',
+      configExt: {
+        provider: {
+          stackTags: {
+            foo: '1',
+          },
+        },
+      },
+    });
+
+    expect(cfTemplate.Resources[awsNaming.getStageLogicalId()]).to.be.undefined;
+    expectDeploymentStageName(cfTemplate, 'dev');
+    expect(cfTemplate.Resources.ApiGatewayRestApi.Properties.Tags).to.be.undefined;
+  });
+
+  it('should package provider.tags as API Gateway RestApi tags', async () => {
+    const { cfTemplate, awsNaming } = await runServerless({
+      fixture: 'api-gateway',
+      command: 'package',
+      configExt: {
+        provider: {
+          tags: {
+            foo: '1',
+          },
+        },
+      },
+    });
+
+    expect(cfTemplate.Resources[awsNaming.getStageLogicalId()]).to.be.undefined;
+    expectDeploymentStageName(cfTemplate, 'dev');
+    expect(cfTemplate.Resources.ApiGatewayRestApi.Properties.Tags).to.deep.equal([
+      { Key: 'foo', Value: '1' },
+    ]);
+  });
+
+  it('should only package provider.tags as API Gateway RestApi tags when stackTags are also configured', async () => {
+    const { cfTemplate, awsNaming } = await runServerless({
+      fixture: 'api-gateway',
+      command: 'package',
+      configExt: {
+        provider: {
+          stackTags: {
+            foo: 'from-stackTags',
+            bar: 'from-stackTags',
+          },
+          tags: {
+            foo: 'from-tags',
+            buz: 'from-tags',
+          },
+        },
+      },
+    });
+
+    expect(cfTemplate.Resources[awsNaming.getStageLogicalId()]).to.be.undefined;
+    expectDeploymentStageName(cfTemplate, 'dev');
+    expect(cfTemplate.Resources.ApiGatewayRestApi.Properties.Tags).to.deep.equal([
+      { Key: 'foo', Value: 'from-tags' },
+      { Key: 'buz', Value: 'from-tags' },
+    ]);
+  });
+
   it('should not create LogGroup if `accessLogging` set to false', async () => {
     const { cfTemplate, awsNaming } = await runServerless({
       fixture: 'api-gateway',
@@ -335,7 +277,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/
     expect(cfTemplate.Resources[awsNaming.getApiGatewayLogGroupLogicalId()]).to.be.undefined;
   });
 
-  it('should create LogGroup with `logs.restApi` set to `true`', async () => {
+  it('should package LogGroup and CloudWatch role with `logs.restApi` set to `true`', async () => {
     const { cfTemplate, awsNaming, serverless } = await runServerless({
       fixture: 'api-gateway',
       command: 'package',
@@ -348,11 +290,23 @@ describe('test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/
       },
     });
 
+    expect(cfTemplate.Resources[awsNaming.getStageLogicalId()]).to.be.undefined;
+    expectDeploymentStageName(cfTemplate, 'dev');
     expect(cfTemplate.Resources[awsNaming.getApiGatewayLogGroupLogicalId()]).to.deep.equal({
       Type: 'AWS::Logs::LogGroup',
       Properties: {
         LogGroupName: `/aws/api-gateway/${serverless.service.service}-dev`,
       },
+    });
+    expect(
+      cfTemplate.Resources[
+        awsNaming.getCustomResourceApiGatewayAccountCloudWatchRoleResourceLogicalId()
+      ].Properties.ServiceToken
+    ).to.deep.equal({
+      'Fn::GetAtt': [
+        awsNaming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionLogicalId(),
+        'Arn',
+      ],
     });
   });
 

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/usage-plan.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/usage-plan.test.js
@@ -296,9 +296,7 @@ describe('UsagePlan', () => {
       key.startsWith('ApiGatewayDeployment')
     );
     expect(deploymentLogicalId).to.be.a('string');
-    expect(cfTemplate.Resources[deploymentLogicalId].Type).to.equal(
-      'AWS::ApiGateway::Deployment'
-    );
+    expect(cfTemplate.Resources[deploymentLogicalId].Type).to.equal('AWS::ApiGateway::Deployment');
 
     return deploymentLogicalId;
   };
@@ -364,9 +362,7 @@ describe('UsagePlan', () => {
     expect(usagePlan.Properties.Description).to.equal(
       `Usage plan for ${serverless.service.service} dev stage`
     );
-    expect(usagePlan.Properties.UsagePlanName).to.equal(
-      `${serverless.service.service}-dev`
-    );
+    expect(usagePlan.Properties.UsagePlanName).to.equal(`${serverless.service.service}-dev`);
   });
 
   it('Should package named usage plan resources', async () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/usage-plan.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/usage-plan.test.js
@@ -291,6 +291,18 @@ describe('#compileUsagePlan()', () => {
 });
 
 describe('UsagePlan', () => {
+  const getApiGatewayDeploymentLogicalId = (cfTemplate) => {
+    const deploymentLogicalId = Object.keys(cfTemplate.Resources).find((key) =>
+      key.startsWith('ApiGatewayDeployment')
+    );
+    expect(deploymentLogicalId).to.be.a('string');
+    expect(cfTemplate.Resources[deploymentLogicalId].Type).to.equal(
+      'AWS::ApiGateway::Deployment'
+    );
+
+    return deploymentLogicalId;
+  };
+
   const burstLimit = 98;
   const rateLimit = 99;
 
@@ -326,6 +338,70 @@ describe('UsagePlan', () => {
       },
     },
   };
+
+  it('Should package a default usage plan resource', async () => {
+    const { awsNaming, cfTemplate, serverless } = await runServerless({
+      fixture: 'api-gateway',
+      command: 'package',
+      configExt: {
+        provider: {
+          apiGateway: {
+            apiKeys: ['1234567890'],
+          },
+        },
+      },
+    });
+    const usagePlan = cfTemplate.Resources[awsNaming.getUsagePlanLogicalId()];
+
+    expect(usagePlan.Type).to.equal('AWS::ApiGateway::UsagePlan');
+    expect(usagePlan.DependsOn).to.equal(getApiGatewayDeploymentLogicalId(cfTemplate));
+    expect(usagePlan.Properties.ApiStages).to.deep.equal([
+      {
+        ApiId: { Ref: 'ApiGatewayRestApi' },
+        Stage: 'dev',
+      },
+    ]);
+    expect(usagePlan.Properties.Description).to.equal(
+      `Usage plan for ${serverless.service.service} dev stage`
+    );
+    expect(usagePlan.Properties.UsagePlanName).to.equal(
+      `${serverless.service.service}-dev`
+    );
+  });
+
+  it('Should package named usage plan resources', async () => {
+    const { awsNaming, cfTemplate, serverless } = await runServerless({
+      fixture: 'api-gateway',
+      command: 'package',
+      configExt: {
+        provider: {
+          apiGateway: {
+            usagePlan: [{ free: {} }, { paid: {} }],
+          },
+        },
+      },
+    });
+    const deploymentLogicalId = getApiGatewayDeploymentLogicalId(cfTemplate);
+
+    for (const planName of ['free', 'paid']) {
+      const usagePlan = cfTemplate.Resources[awsNaming.getUsagePlanLogicalId(planName)];
+
+      expect(usagePlan.Type).to.equal('AWS::ApiGateway::UsagePlan');
+      expect(usagePlan.DependsOn).to.equal(deploymentLogicalId);
+      expect(usagePlan.Properties.ApiStages).to.deep.equal([
+        {
+          ApiId: { Ref: 'ApiGatewayRestApi' },
+          Stage: 'dev',
+        },
+      ]);
+      expect(usagePlan.Properties.Description).to.equal(
+        `Usage plan "${planName}" for ${serverless.service.service} dev stage`
+      );
+      expect(usagePlan.Properties.UsagePlanName).to.equal(
+        `${serverless.service.service}-${planName}-dev`
+      );
+    }
+  });
 
   it('Should have values for throttle', async () => {
     serverlessConfigurationExtension.provider.apiGateway = { usagePlan: { throttle } };
@@ -371,7 +447,7 @@ describe('UsagePlan', () => {
       rateLimit
     );
 
-    expect(cfTemplate.Resources.ApiGatewayUsagePlan.Properties).to.not.have.property('quota');
+    expect(cfTemplate.Resources.ApiGatewayUsagePlan.Properties).to.not.have.property('Quota');
   });
 
   it('Should have values for quota and throttle', async () => {


### PR DESCRIPTION
This migrates API Gateway package-time compiler coverage to fixture-backed runServerless tests. It adds final-template assertions for local authorizers, usage plans, deployment stage wiring, API Gateway resource tags, log helper resources, and the current package-time stage behavior while preserving lower-level compiler unit coverage.