### PR TITLE
Refactor API Gateway low-level compiler tests

### DIFF
--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/index.test.js
@@ -3,8 +3,7 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const AwsProvider = require('../../../../../../../../../lib/plugins/aws/provider');
-const AwsCompileApigEvents = require('../../../../../../../../../lib/plugins/aws/package/compile/events/api-gateway/index');
-const Serverless = require('../../../../../../../../../lib/serverless');
+const { createApiGatewayCompilerContext } = require('./test-utils');
 const validate = require('../../../../../../../../../lib/plugins/aws/lib/validate');
 const getServiceState = require('../../../../../../../../../lib/plugins/aws/lib/get-service-state');
 const updateStage = require('../../../../../../../../../lib/plugins/aws/package/compile/events/api-gateway/lib/hack/update-stage');
@@ -14,26 +13,7 @@ describe('AwsCompileApigEvents', () => {
   let awsCompileApigEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.service.environment = {
-      vars: {},
-      stages: {
-        dev: {
-          vars: {},
-          regions: {
-            'us-east-1': {
-              vars: {},
-            },
-          },
-        },
-      },
-    };
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
+    ({ awsCompileApigEvents } = createApiGatewayCompilerContext());
   });
 
   describe('#constructor()', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/cors.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/cors.test.js
@@ -1,38 +1,29 @@
 'use strict';
 
 const expect = require('chai').expect;
-const AwsCompileApigEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/api-gateway/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
+const { createApiGatewayCompilerContext } = require('../test-utils');
 
 describe('#compileCors()', () => {
-  let serverless;
   let awsCompileApigEvents;
 
   beforeEach(() => {
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    serverless.service.service = 'first-service';
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-    serverless.service.environment = {
-      stages: {
-        dev: {
-          regions: {
-            'us-east-1': {
-              vars: {
-                IamRoleLambdaExecution:
-                  'arn:aws:iam::12345678:role/service-dev-IamRoleLambdaExecution-FOO12345678',
+    ({ awsCompileApigEvents } = createApiGatewayCompilerContext({
+      provider: { compiledCloudFormationTemplate: { Resources: {} } },
+      environment: {
+        stages: {
+          dev: {
+            regions: {
+              'us-east-1': {
+                vars: {
+                  IamRoleLambdaExecution:
+                    'arn:aws:iam::12345678:role/service-dev-IamRoleLambdaExecution-FOO12345678',
+                },
               },
             },
           },
         },
       },
-    };
-    awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
+    }));
     awsCompileApigEvents.apiGatewayMethodLogicalIds = [];
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
     awsCompileApigEvents.apiGatewayResources = {

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/deployment.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/deployment.test.js
@@ -1,31 +1,15 @@
 'use strict';
 
 const expect = require('chai').expect;
-const AwsCompileApigEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/api-gateway/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
+const { createApiGatewayCompilerContext } = require('../test-utils');
 
 describe('#compileDeployment()', () => {
-  let serverless;
-  let provider;
   let awsCompileApigEvents;
 
   beforeEach(() => {
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
-    serverless = new Serverless({ commands: [], options: {} });
-    provider = new AwsProvider(serverless, options);
-    serverless.setProvider('aws', provider);
-    serverless.service.provider.compiledCloudFormationTemplate = {
-      Resources: {},
-      Outputs: {},
-    };
-    awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
+    ({ awsCompileApigEvents } = createApiGatewayCompilerContext());
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
     awsCompileApigEvents.apiGatewayMethodLogicalIds = ['method-dependency1', 'method-dependency2'];
-    awsCompileApigEvents.provider = provider;
   });
 
   it('should create a deployment resource', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/permissions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/permissions.test.js
@@ -1,19 +1,15 @@
 'use strict';
 
 const expect = require('chai').expect;
-const AwsCompileApigEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/api-gateway/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
+const { createApiGatewayCompilerContext } = require('../test-utils');
 
 describe('#awsCompilePermissions()', () => {
   let awsCompileApigEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-
-    awsCompileApigEvents = new AwsCompileApigEvents(serverless);
+    ({ awsCompileApigEvents } = createApiGatewayCompilerContext({
+      provider: { compiledCloudFormationTemplate: { Resources: {} } },
+    }));
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
     awsCompileApigEvents.validated = {};
   });

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/resources.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/resources.test.js
@@ -1,19 +1,15 @@
 'use strict';
 
 const expect = require('chai').expect;
-const AwsCompileApigEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/api-gateway/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
+const { createApiGatewayCompilerContext } = require('../test-utils');
 
 describe('#compileResources()', () => {
-  let serverless;
   let awsCompileApigEvents;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-    awsCompileApigEvents = new AwsCompileApigEvents(serverless);
+    ({ awsCompileApigEvents } = createApiGatewayCompilerContext({
+      provider: { compiledCloudFormationTemplate: { Resources: {} } },
+    }));
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
     awsCompileApigEvents.validated = {};
   });

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/usage-plan-keys.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/usage-plan-keys.test.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
-const AwsCompileApigEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/api-gateway/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
+const { createApiGatewayCompilerContext } = require('../test-utils');
 
 const capitalize = (value) => {
   const text = String(value).toLowerCase();
@@ -11,22 +9,10 @@ const capitalize = (value) => {
 };
 
 describe('#compileUsagePlanKeys()', () => {
-  let serverless;
   let awsCompileApigEvents;
 
   beforeEach(() => {
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    serverless.service.service = 'first-service';
-    serverless.service.provider.compiledCloudFormationTemplate = {
-      Resources: {},
-      Outputs: {},
-    };
-    awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
+    ({ awsCompileApigEvents } = createApiGatewayCompilerContext());
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';
     awsCompileApigEvents.apiGatewayDeploymentLogicalId = 'ApiGatewayDeploymentTest';
   });

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/validate.test.js
@@ -3,9 +3,7 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const runServerless = require('../../../../../../../../../utils/run-serverless');
-const AwsCompileApigEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/api-gateway/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
+const { createApiGatewayCompilerContext } = require('../test-utils');
 const ServerlessError = require('../../../../../../../../../../lib/serverless-error');
 
 const expect = chai.expect;
@@ -25,13 +23,7 @@ describe('#validate()', () => {
   });
 
   beforeEach(() => {
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
-    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
+    ({ serverless, awsCompileApigEvents } = createApiGatewayCompilerContext());
   });
 
   it('should ignore non-http events', () => {
@@ -1519,8 +1511,9 @@ describe('#validate()', () => {
       stage: 'my@stage',
       region: 'us-east-1',
     };
-    serverless.setProvider('aws', new AwsProvider(serverless, invalidOptions));
-    awsCompileApigEvents = new AwsCompileApigEvents(serverless, invalidOptions);
+    ({ serverless, awsCompileApigEvents } = createApiGatewayCompilerContext({
+      options: invalidOptions,
+    }));
     awsCompileApigEvents.serverless.service.functions = {
       first: {
         events: [

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/test-utils.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/test-utils.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const AwsProvider = require('../../../../../../../../../lib/plugins/aws/provider');
+const AwsCompileApigEvents = require('../../../../../../../../../lib/plugins/aws/package/compile/events/api-gateway/index');
+
+function createApiGatewayCompilerContext(config = {}) {
+  const options = { stage: 'dev', region: 'us-east-1', ...config.options };
+  const providers = new Map();
+  const providerConfig = config.provider || {};
+  const functions = config.functions || {};
+
+  const serverless = {
+    config: {},
+    serviceDir: null,
+    cli: { log() {} },
+    init: () => Promise.resolve(),
+    setProvider(name, provider) {
+      providers.set(name, provider);
+    },
+    getProvider(name) {
+      return providers.get(name);
+    },
+    configSchemaHandler: {
+      defineProvider() {},
+      defineFunctionEvent() {},
+    },
+  };
+
+  serverless.service = {
+    service: 'first-service',
+    provider: {
+      name: 'aws',
+      compiledCloudFormationTemplate: { Resources: {}, Outputs: {} },
+      ...providerConfig,
+    },
+    functions,
+    environment: config.environment || {},
+    getFunction(functionName) {
+      return this.functions[functionName];
+    },
+  };
+
+  const provider = new AwsProvider(serverless, options);
+  const awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
+
+  return { serverless, provider, awsCompileApigEvents, options };
+}
+
+module.exports = { createApiGatewayCompilerContext };


### PR DESCRIPTION
This replaces direct Serverless construction in low-level API Gateway compiler tests with a shared fake compiler context. The helper keeps the real AWS provider and API Gateway compiler while limiting setup to the fields required by constructor, CORS, deployment, permissions, resources, usage-plan-key, and validation unit coverage.