### PR TITLE
Migrate WebSocket compiler tests

### DIFF
--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/index.test.js
@@ -3,34 +3,28 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const AwsProvider = require('../../../../../../../../../lib/plugins/aws/provider');
-const AwsCompileWebsocketsEvents = require('../../../../../../../../../lib/plugins/aws/package/compile/events/websockets/index');
-const Serverless = require('../../../../../../../../../lib/serverless');
 const runServerless = require('../../../../../../../../utils/run-serverless');
+const { createWebsocketsCompilerContext } = require('./test-utils');
 
 describe('AwsCompileWebsocketsEvents', () => {
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.service.environment = {
-      vars: {},
-      stages: {
-        dev: {
-          vars: {},
-          regions: {
-            'us-east-1': {
-              vars: {},
+    ({ awsCompileWebsocketsEvents } = createWebsocketsCompilerContext({
+      environment: {
+        vars: {},
+        stages: {
+          dev: {
+            vars: {},
+            regions: {
+              'us-east-1': {
+                vars: {},
+              },
             },
           },
         },
       },
-    };
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless, options);
+    }));
   });
 
   describe('#constructor()', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.test.js
@@ -1,26 +1,17 @@
 'use strict';
 
 const expect = require('chai').expect;
-const AwsCompileWebsocketsEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/websockets/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
 const runServerless = require('../../../../../../../../../utils/run-serverless');
+const { createWebsocketsCompilerContext } = require('../test-utils');
 
 describe('#compileAuthorizers()', () => {
   let awsCompileWebsocketsEvents;
 
   describe('for routes with authorizer definition', () => {
     beforeEach(() => {
-      const serverless = new Serverless({ commands: [], options: {} });
-      serverless.setProvider('aws', new AwsProvider(serverless));
-      serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-      serverless.service.functions = {
-        auth: {},
-      };
-      awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless);
-
-      awsCompileWebsocketsEvents.websocketsApiLogicalId =
-        awsCompileWebsocketsEvents.provider.naming.getWebsocketsApiLogicalId();
+      ({ awsCompileWebsocketsEvents } = createWebsocketsCompilerContext({
+        functions: { auth: {} },
+      }));
 
       awsCompileWebsocketsEvents.validated = {
         events: [
@@ -110,14 +101,7 @@ describe('#compileAuthorizers()', () => {
 
   describe('for routes without authorizer definition', () => {
     beforeEach(() => {
-      const serverless = new Serverless({ commands: [], options: {} });
-      serverless.setProvider('aws', new AwsProvider(serverless));
-      serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-
-      awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless);
-
-      awsCompileWebsocketsEvents.websocketsApiLogicalId =
-        awsCompileWebsocketsEvents.provider.naming.getWebsocketsApiLogicalId();
+      ({ awsCompileWebsocketsEvents } = createWebsocketsCompilerContext());
 
       awsCompileWebsocketsEvents.validated = {
         events: [

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/deployment.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/deployment.test.js
@@ -1,29 +1,13 @@
 'use strict';
 
 const expect = require('chai').expect;
-const AwsCompileWebsocketsEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/websockets/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
+const { createWebsocketsCompilerContext } = require('../test-utils');
 
 describe('#compileDeployment()', () => {
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.provider.compiledCloudFormationTemplate = {
-      Resources: {},
-      Outputs: {},
-    };
-
-    awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless, options);
-
-    awsCompileWebsocketsEvents.websocketsApiLogicalId =
-      awsCompileWebsocketsEvents.provider.naming.getWebsocketsApiLogicalId();
+    ({ awsCompileWebsocketsEvents } = createWebsocketsCompilerContext());
   });
 
   it('should create a deployment resource and output', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/integrations.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/integrations.test.js
@@ -1,25 +1,18 @@
 'use strict';
 
 const expect = require('chai').expect;
-const AwsCompileWebsocketsEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/websockets/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
+const { createWebsocketsCompilerContext } = require('../test-utils');
 
 describe('#compileIntegrations()', () => {
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-    serverless.service.functions = {
-      First: {},
-      Second: {},
-    };
-    awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless);
-
-    awsCompileWebsocketsEvents.websocketsApiLogicalId =
-      awsCompileWebsocketsEvents.provider.naming.getWebsocketsApiLogicalId();
+    ({ awsCompileWebsocketsEvents } = createWebsocketsCompilerContext({
+      functions: {
+        First: {},
+        Second: {},
+      },
+    }));
   });
 
   it('should create an integration resource for every event', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/permissions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/permissions.test.js
@@ -1,27 +1,19 @@
 'use strict';
 
 const expect = require('chai').expect;
-const AwsCompileWebsocketsEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/websockets/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
+const { createWebsocketsCompilerContext } = require('../test-utils');
 
 describe('#compilePermissions()', () => {
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-    serverless.service.functions = {
-      First: {},
-      Second: {},
-      auth: {},
-    };
-
-    awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless);
-
-    awsCompileWebsocketsEvents.websocketsApiLogicalId =
-      awsCompileWebsocketsEvents.provider.naming.getWebsocketsApiLogicalId();
+    ({ awsCompileWebsocketsEvents } = createWebsocketsCompilerContext({
+      functions: {
+        First: {},
+        Second: {},
+        auth: {},
+      },
+    }));
   });
 
   it('should create a permission resource for every event', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/route-responses.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/route-responses.test.js
@@ -1,22 +1,13 @@
 'use strict';
 
 const expect = require('chai').expect;
-const AwsCompileWebsocketsEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/websockets/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
+const { createWebsocketsCompilerContext } = require('../test-utils');
 
 describe('#compileRouteResponses()', () => {
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-
-    awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless);
-
-    awsCompileWebsocketsEvents.websocketsApiLogicalId =
-      awsCompileWebsocketsEvents.provider.naming.getWebsocketsApiLogicalId();
+    ({ awsCompileWebsocketsEvents } = createWebsocketsCompilerContext());
   });
 
   it('should create a RouteResponse resource for events with selection expression', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/routes.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/routes.test.js
@@ -1,22 +1,13 @@
 'use strict';
 
 const expect = require('chai').expect;
-const AwsCompileWebsocketsEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/websockets/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
+const { createWebsocketsCompilerContext } = require('../test-utils');
 
 describe('#compileRoutes()', () => {
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-
-    awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless);
-
-    awsCompileWebsocketsEvents.websocketsApiLogicalId =
-      awsCompileWebsocketsEvents.provider.naming.getWebsocketsApiLogicalId();
+    ({ awsCompileWebsocketsEvents } = createWebsocketsCompilerContext());
   });
 
   it('should create a route resource for every event', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
@@ -3,17 +3,9 @@
 const chai = require('chai');
 
 const expect = chai.expect;
-const sinon = require('sinon');
-const childProcess = require('child_process');
-const { promisify } = require('util');
 const isObject = require('type/object/is');
-const AwsCompileWebsocketsEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/websockets/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
-const { createTmpDir } = require('../../../../../../../../../utils/fs');
 const runServerless = require('../../../../../../../../../utils/run-serverless');
-
-if (!childProcess.execAsync) childProcess.execAsync = promisify(childProcess.exec);
+const { createWebsocketsCompilerContext } = require('../test-utils');
 
 describe('#compileStage()', () => {
   let awsCompileWebsocketsEvents;
@@ -21,22 +13,9 @@ describe('#compileStage()', () => {
   let logGroupLogicalId;
 
   beforeEach(() => {
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.service = 'my-service';
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-    serverless.serviceDir = createTmpDir();
-    serverless.cli = { log: () => {} };
-
-    awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless, options);
+    ({ awsCompileWebsocketsEvents } = createWebsocketsCompilerContext());
     stageLogicalId = awsCompileWebsocketsEvents.provider.naming.getWebsocketsStageLogicalId();
     logGroupLogicalId = awsCompileWebsocketsEvents.provider.naming.getWebsocketsLogGroupLogicalId();
-    awsCompileWebsocketsEvents.websocketsApiLogicalId =
-      awsCompileWebsocketsEvents.provider.naming.getWebsocketsApiLogicalId();
   });
 
   it('should create a stage resource if no websocketApiId specified', async () =>
@@ -73,7 +52,6 @@ describe('#compileStage()', () => {
 
   describe('logs', () => {
     beforeEach(() => {
-      sinon.stub(childProcess, 'execAsync');
       // setting up Websocket logs
       awsCompileWebsocketsEvents.serverless.service.provider.logs = {
         websocket: true,

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/validate.test.js
@@ -1,23 +1,14 @@
 'use strict';
 
 const expect = require('chai').expect;
-const AwsCompileWebsocketsEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/websockets/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
 const runServerless = require('../../../../../../../../../utils/run-serverless');
+const { createWebsocketsCompilerContext } = require('../test-utils');
 
 describe('#validate()', () => {
-  let serverless;
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless, options);
+    ({ awsCompileWebsocketsEvents } = createWebsocketsCompilerContext());
   });
 
   it('should support the simplified string syntax', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/test-utils.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/test-utils.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const AwsProvider = require('../../../../../../../../../lib/plugins/aws/provider');
+const AwsCompileWebsocketsEvents = require('../../../../../../../../../lib/plugins/aws/package/compile/events/websockets/index');
+const { createTmpDir } = require('../../../../../../../../utils/fs');
+
+function createWebsocketsCompilerContext(config = {}) {
+  const options = { stage: 'dev', region: 'us-east-1', ...config.options };
+  const providers = new Map();
+  const providerConfig = config.provider || {};
+  const functions = config.functions || {};
+
+  const serverless = {
+    config: {},
+    serviceDir: config.serviceDir || createTmpDir(),
+    cli: { log() {} },
+    _logDeprecation() {},
+    setProvider(name, provider) {
+      providers.set(name, provider);
+    },
+    getProvider(name) {
+      return providers.get(name);
+    },
+    configSchemaHandler: {
+      defineProvider() {},
+      defineFunctionEvent() {},
+    },
+  };
+
+  serverless.service = {
+    service: config.service || 'my-service',
+    provider: {
+      name: 'aws',
+      compiledCloudFormationTemplate: { Resources: {}, Outputs: {} },
+      ...providerConfig,
+    },
+    package: {
+      artifactDirectoryName: 'serverless',
+      ...config.package,
+    },
+    functions,
+    environment: config.environment || {},
+    getFunction(functionName) {
+      return this.functions[functionName];
+    },
+    getAllFunctions() {
+      return Object.keys(this.functions);
+    },
+  };
+
+  const provider = new AwsProvider(serverless, options);
+  const awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless, options);
+  awsCompileWebsocketsEvents.websocketsApiLogicalId = provider.naming.getWebsocketsApiLogicalId();
+
+  return { serverless, provider, awsCompileWebsocketsEvents, options };
+}
+
+module.exports = { createWebsocketsCompilerContext };


### PR DESCRIPTION
This refactors the WebSocket compiler tests to use a focused compiler context helper instead of direct full Serverless construction. It preserves the existing fixture-backed package coverage while keeping the route, integration, permission, deployment, stage, authorizer, and validation builder checks unit-sized.