### PR TITLE
Refactor leaf event compiler tests

### DIFF
--- a/test/unit/lib/plugins/aws/package/compile/events/alb/lib/listener-rules.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/lib/listener-rules.test.js
@@ -2,19 +2,16 @@
 
 const expect = require('chai').expect;
 const AwsCompileAlbEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/alb/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
+const { createAwsEventCompilerContext } = require('../../test-utils');
 
 describe('#compileListenerRules()', () => {
   let awsCompileAlbEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.service = 'some-service';
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-
-    awsCompileAlbEvents = new AwsCompileAlbEvents(serverless);
+    ({ awsCompileEvents: awsCompileAlbEvents } = createAwsEventCompilerContext(
+      AwsCompileAlbEvents,
+      { service: 'some-service' }
+    ));
   });
 
   it('should create ELB listener rule resources', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/lib/permissions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/lib/permissions.test.js
@@ -2,21 +2,16 @@
 
 const expect = require('chai').expect;
 const AwsCompileAlbEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/alb/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
+const { createAwsEventCompilerContext } = require('../../test-utils');
 
 describe('#compilePermissions()', () => {
   let awsCompileAlbEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.service = 'some-service';
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-    serverless.service.functions.first = {};
-    serverless.service.functions.second = {};
-
-    awsCompileAlbEvents = new AwsCompileAlbEvents(serverless);
+    ({ awsCompileEvents: awsCompileAlbEvents } = createAwsEventCompilerContext(
+      AwsCompileAlbEvents,
+      { service: 'some-service', functions: { first: {}, second: {} } }
+    ));
   });
 
   it('should create Lambda permission resources', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/lib/target-groups.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/lib/target-groups.test.js
@@ -2,21 +2,16 @@
 
 const expect = require('chai').expect;
 const AwsCompileAlbEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/alb/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
+const { createAwsEventCompilerContext } = require('../../test-utils');
 
 describe('#compileTargetGroups()', () => {
   let awsCompileAlbEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.service = 'some-service';
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-    serverless.service.functions.first = {};
-    serverless.service.functions.second = {};
-
-    awsCompileAlbEvents = new AwsCompileAlbEvents(serverless);
+    ({ awsCompileEvents: awsCompileAlbEvents } = createAwsEventCompilerContext(
+      AwsCompileAlbEvents,
+      { service: 'some-service', functions: { first: {}, second: {} } }
+    ));
   });
 
   it('should create ELB target group resources', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
@@ -2,19 +2,16 @@
 
 const expect = require('chai').expect;
 const AwsCompileAlbEvents = require('../../../../../../../../../../lib/plugins/aws/package/compile/events/alb/index');
-const Serverless = require('../../../../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
+const { createAwsEventCompilerContext } = require('../../test-utils');
 
 describe('#validate()', () => {
   let awsCompileAlbEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    serverless.service.service = 'some-service';
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-
-    awsCompileAlbEvents = new AwsCompileAlbEvents(serverless);
+    ({ awsCompileEvents: awsCompileAlbEvents } = createAwsEventCompilerContext(
+      AwsCompileAlbEvents,
+      { service: 'some-service' }
+    ));
   });
 
   it('should detect alb event definitions', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/alexa-skill.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alexa-skill.test.js
@@ -3,17 +3,15 @@
 const expect = require('chai').expect;
 const AwsProvider = require('../../../../../../../../lib/plugins/aws/provider');
 const AwsCompileAlexaSkillEvents = require('../../../../../../../../lib/plugins/aws/package/compile/events/alexa-skill');
-const Serverless = require('../../../../../../../../lib/serverless');
+const { createAwsEventCompilerContext } = require('./test-utils');
 
 describe('AwsCompileAlexaSkillEvents', () => {
-  let serverless;
   let awsCompileAlexaSkillEvents;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    awsCompileAlexaSkillEvents = new AwsCompileAlexaSkillEvents(serverless);
+    ({ awsCompileEvents: awsCompileAlexaSkillEvents } = createAwsEventCompilerContext(
+      AwsCompileAlexaSkillEvents
+    ));
   });
 
   describe('#constructor()', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/alexa-smart-home.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alexa-smart-home.test.js
@@ -3,18 +3,15 @@
 const expect = require('chai').expect;
 const AwsProvider = require('../../../../../../../../lib/plugins/aws/provider');
 const AwsCompileAlexaSmartHomeEvents = require('../../../../../../../../lib/plugins/aws/package/compile/events/alexa-smart-home');
-const Serverless = require('../../../../../../../../lib/serverless');
+const { createAwsEventCompilerContext } = require('./test-utils');
 
 describe('AwsCompileAlexaSmartHomeEvents', () => {
-  let serverless;
   let awsCompileAlexaSmartHomeEvents;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    awsCompileAlexaSmartHomeEvents = new AwsCompileAlexaSmartHomeEvents(serverless);
-    awsCompileAlexaSmartHomeEvents.serverless.service.service = 'new-service';
+    ({ awsCompileEvents: awsCompileAlexaSmartHomeEvents } = createAwsEventCompilerContext(
+      AwsCompileAlexaSmartHomeEvents
+    ));
   });
 
   describe('#constructor()', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/cloud-watch-event.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cloud-watch-event.test.js
@@ -3,18 +3,15 @@
 const expect = require('chai').expect;
 const AwsProvider = require('../../../../../../../../lib/plugins/aws/provider');
 const AwsCompileCloudWatchEventEvents = require('../../../../../../../../lib/plugins/aws/package/compile/events/cloud-watch-event');
-const Serverless = require('../../../../../../../../lib/serverless');
+const { createAwsEventCompilerContext } = require('./test-utils');
 
 describe('awsCompileCloudWatchEventEvents', () => {
-  let serverless;
   let awsCompileCloudWatchEventEvents;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    awsCompileCloudWatchEventEvents = new AwsCompileCloudWatchEventEvents(serverless);
-    awsCompileCloudWatchEventEvents.serverless.service.service = 'new-service';
+    ({ awsCompileEvents: awsCompileCloudWatchEventEvents } = createAwsEventCompilerContext(
+      AwsCompileCloudWatchEventEvents
+    ));
   });
 
   describe('#constructor()', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/iot.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/iot.test.js
@@ -3,18 +3,14 @@
 const expect = require('chai').expect;
 const AwsProvider = require('../../../../../../../../lib/plugins/aws/provider');
 const AwsCompileIoTEvents = require('../../../../../../../../lib/plugins/aws/package/compile/events/iot');
-const Serverless = require('../../../../../../../../lib/serverless');
+const { createAwsEventCompilerContext } = require('./test-utils');
 
 describe('AwsCompileIoTEvents', () => {
-  let serverless;
   let awsCompileIoTEvents;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    awsCompileIoTEvents = new AwsCompileIoTEvents(serverless);
-    awsCompileIoTEvents.serverless.service.service = 'new-service';
+    ({ awsCompileEvents: awsCompileIoTEvents } =
+      createAwsEventCompilerContext(AwsCompileIoTEvents));
   });
 
   describe('#constructor()', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/sns.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/sns.test.js
@@ -3,20 +3,16 @@
 const expect = require('chai').expect;
 const AwsProvider = require('../../../../../../../../lib/plugins/aws/provider');
 const AwsCompileSNSEvents = require('../../../../../../../../lib/plugins/aws/package/compile/events/sns');
-const Serverless = require('../../../../../../../../lib/serverless');
+const { createAwsEventCompilerContext } = require('./test-utils');
 
 describe('AwsCompileSNSEvents', () => {
-  let serverless;
   let awsCompileSNSEvents;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    const options = {
-      region: 'some-region',
-    };
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    awsCompileSNSEvents = new AwsCompileSNSEvents(serverless, options);
+    ({ awsCompileEvents: awsCompileSNSEvents } = createAwsEventCompilerContext(
+      AwsCompileSNSEvents,
+      { options: { region: 'some-region' } }
+    ));
   });
 
   describe('#constructor()', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/test-utils.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/test-utils.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const AwsProvider = require('../../../../../../../../lib/plugins/aws/provider');
+
+function createAwsEventCompilerContext(EventCompiler, config = {}) {
+  const options = { stage: 'dev', region: 'us-east-1', ...config.options };
+  const providers = new Map();
+  const providerConfig = config.provider || {};
+  const functions = config.functions || {};
+
+  const serverless = {
+    config: {},
+    serviceDir: null,
+    cli: { log() {} },
+    _logDeprecation() {},
+    setProvider(name, provider) {
+      providers.set(name, provider);
+    },
+    getProvider(name) {
+      return providers.get(name);
+    },
+    configSchemaHandler: {
+      defineProvider() {},
+      defineFunctionEvent() {},
+    },
+  };
+
+  serverless.service = {
+    service: config.service || 'new-service',
+    provider: {
+      name: 'aws',
+      compiledCloudFormationTemplate: { Resources: {}, Outputs: {} },
+      ...providerConfig,
+    },
+    functions,
+    environment: config.environment || {},
+    getFunction(functionName) {
+      return this.functions[functionName];
+    },
+    getAllFunctions() {
+      return Object.keys(this.functions);
+    },
+  };
+
+  const provider = new AwsProvider(serverless, options);
+  const awsCompileEvents = new EventCompiler(serverless, options);
+
+  return { serverless, provider, awsCompileEvents, options };
+}
+
+module.exports = { createAwsEventCompilerContext };


### PR DESCRIPTION
This refactors the leaf AWS event and ALB compiler tests to use a shared fake AWS event compiler context instead of constructing full Serverless instances. It keeps the CloudWatch role helper as a focused module seam while preserving deterministic resource-builder coverage.