### PR TITLE
Refactor CloudWatch log compiler tests

### DIFF
--- a/test/unit/lib/plugins/aws/package/compile/events/cloud-watch-log.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cloud-watch-log.test.js
@@ -3,19 +3,20 @@
 const expect = require('chai').expect;
 const AwsProvider = require('../../../../../../../../lib/plugins/aws/provider');
 const AwsCompileCloudWatchLogEvents = require('../../../../../../../../lib/plugins/aws/package/compile/events/cloud-watch-log');
-const Serverless = require('../../../../../../../../lib/serverless');
 const runServerless = require('../../../../../../../utils/run-serverless');
+const { createAwsEventCompilerContext } = require('./test-utils');
+
+function createAwsCompileCloudWatchLogEvents(config = {}) {
+  const { awsCompileEvents } = createAwsEventCompilerContext(AwsCompileCloudWatchLogEvents, config);
+
+  return awsCompileEvents;
+}
 
 describe('AwsCompileCloudWatchLogEvents', () => {
-  let serverless;
   let awsCompileCloudWatchLogEvents;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    awsCompileCloudWatchLogEvents = new AwsCompileCloudWatchLogEvents(serverless);
-    awsCompileCloudWatchLogEvents.serverless.service.service = 'new-service';
+    awsCompileCloudWatchLogEvents = createAwsCompileCloudWatchLogEvents();
   });
 
   describe('#constructor()', () => {


### PR DESCRIPTION
This replaces the CloudWatch Log event compiler test's direct Serverless and AWS provider bootstrap with the shared event compiler fake. It keeps the existing package-level runServerless coverage for subscription filter and Lambda alias dependencies.