### PR TITLE
Migrate Lambda action plugin tests

### DIFF
--- a/test/unit/lib/plugins/aws/deploy-function.test.js
+++ b/test/unit/lib/plugins/aws/deploy-function.test.js
@@ -498,7 +498,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
   const imageWithSha = `000000000000.dkr.ecr.sa-east-1.amazonaws.com/test-lambda-docker@sha256:${imageSha}`;
   const updateFunctionCodeStub = sinon.stub();
   const updateFunctionConfigurationStub = sinon.stub();
-  const awsRequestStubMap = {
+  const awsSdkV3StubMap = {
     Lambda: {
       getFunction: {
         Configuration: {
@@ -525,6 +525,11 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
     updateFunctionConfigurationStub.resetHistory();
   });
 
+  const expectUpdateFunctionConfigurationInput = (expectedInput) => {
+    expect(updateFunctionConfigurationStub).to.be.calledOnce;
+    expect(updateFunctionConfigurationStub.firstCall.args[0]).to.deep.equal(expectedInput);
+  };
+
   // This is just a happy-path test of images support. Due to sharing code from `provider.js`
   // all further configurations are tested as a part of `test/unit/lib/plugins/aws/provider.test.js`
   it('should support deploying function that has image defined with sha', async () => {
@@ -532,7 +537,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'foo' },
-      awsRequestStubMap,
+      awsSdkV3StubMap,
       configExt: {
         functions: {
           foo: {
@@ -550,7 +555,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'foo' },
-      awsRequestStubMap,
+      awsSdkV3StubMap,
       configExt: {
         functions: {
           foo: {
@@ -585,10 +590,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -629,10 +634,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -665,10 +670,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -696,10 +701,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
         fixture: 'function',
         command: 'deploy function',
         options: { function: 'basic' },
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           Lambda: {
-            ...awsRequestStubMap.Lambda,
+            ...awsSdkV3StubMap.Lambda,
             getFunction: {
               Configuration: {
                 LastModified: '2020-05-20T15:34:16.494+0000',
@@ -730,10 +735,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
         fixture: 'function',
         command: 'deploy function',
         options: { function: 'basic' },
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           Lambda: {
-            ...awsRequestStubMap.Lambda,
+            ...awsSdkV3StubMap.Lambda,
             getFunction: {
               Configuration: {
                 LastModified: '2020-05-20T15:34:16.494+0000',
@@ -766,10 +771,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           updateFunctionConfiguration: innerUpdateFunctionConfigurationStub,
         },
       },
@@ -793,10 +798,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -835,7 +840,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
         },
       },
     });
-    expect(updateFunctionConfigurationStub).to.be.calledWithExactly({
+    expectUpdateFunctionConfigurationInput({
       FunctionName: functionName,
       KMSKeyArn: kmsKeyArn,
       Description: description,
@@ -865,10 +870,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -907,7 +912,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
         },
       },
     });
-    expect(updateFunctionConfigurationStub).to.be.calledWithExactly({
+    expectUpdateFunctionConfigurationInput({
       FunctionName: functionName,
       KMSKeyArn: kmsKeyArn,
       Description: description,
@@ -937,10 +942,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -982,7 +987,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
         },
       },
     });
-    expect(updateFunctionConfigurationStub).to.be.calledWithExactly({
+    expectUpdateFunctionConfigurationInput({
       FunctionName: functionName,
       Layers: [],
     });
@@ -993,10 +998,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -1041,7 +1046,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
         },
       },
     });
-    expect(updateFunctionConfigurationStub).to.be.calledWithExactly({
+    expectUpdateFunctionConfigurationInput({
       FunctionName: functionName,
       Environment: {
         Variables: {
@@ -1061,10 +1066,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -1107,7 +1112,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       },
     });
 
-    expect(updateFunctionConfigurationStub).to.be.calledWithExactly({
+    expectUpdateFunctionConfigurationInput({
       FunctionName: functionName,
       Environment: {
         Variables: {
@@ -1125,10 +1130,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -1159,7 +1164,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       },
     });
 
-    expect(updateFunctionConfigurationStub).to.be.calledWithExactly({
+    expectUpdateFunctionConfigurationInput({
       FunctionName: functionName,
       Handler: 'basic.handler',
       Timeout: timeout,
@@ -1175,10 +1180,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -1218,7 +1223,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
         },
       },
     });
-    expect(updateFunctionConfigurationStub).to.be.calledWithExactly({
+    expectUpdateFunctionConfigurationInput({
       FunctionName: functionName,
       KMSKeyArn: kmsKeyArn,
       Description: description,
@@ -1249,10 +1254,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -1292,7 +1297,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
         },
       },
     });
-    expect(updateFunctionConfigurationStub).to.be.calledWithExactly({
+    expectUpdateFunctionConfigurationInput({
       FunctionName: functionName,
       KMSKeyArn: kmsKeyArn,
       Description: description,
@@ -1322,10 +1327,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -1358,7 +1363,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       },
     });
 
-    expect(updateFunctionConfigurationStub).to.be.calledWithExactly({
+    expectUpdateFunctionConfigurationInput({
       FunctionName: functionName,
       Handler: 'basic.handler',
       Environment: {
@@ -1382,13 +1387,13 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         IAM: {
           getRole: { Role: { Arn: role } },
         },
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -1424,10 +1429,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -1498,10 +1503,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -1573,10 +1578,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -1631,10 +1636,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -1688,10 +1693,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       fixture: 'function',
       command: 'deploy function',
       options: { function: 'basic' },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
@@ -1744,7 +1749,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       command: 'deploy function',
       options: { function: 'basic' },
       lastLifecycleHookName: 'deploy:function:deploy',
-      awsRequestStubMap,
+      awsSdkV3StubMap,
       configExt: {
         provider: {
           kmsKeyArn: 'arn:aws:kms:us-east-1:oldKey',
@@ -1758,7 +1763,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       },
     });
 
-    sinon.assert.calledWith(updateFunctionConfigurationStub, {
+    expectUpdateFunctionConfigurationInput({
       Handler: 'index.handler',
       FunctionName: 'foobar',
       KMSKeyArn: 'arn:aws:kms:us-east-1:oldKey',
@@ -1772,10 +1777,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
         command: 'deploy function',
         options: { function: 'basic' },
         lastLifecycleHookName: 'deploy:function:deploy',
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           Lambda: {
-            ...awsRequestStubMap.Lambda,
+            ...awsSdkV3StubMap.Lambda,
             getFunction: () => {
               throw new Error('Some side error');
             },
@@ -1792,10 +1797,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
         command: 'deploy function',
         options: { function: 'basic' },
         lastLifecycleHookName: 'deploy:function:deploy',
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           Lambda: {
-            ...awsRequestStubMap.Lambda,
+            ...awsSdkV3StubMap.Lambda,
             getFunction: () => {
               throw Object.assign(new Error('Function not found'), {
                 name: 'ResourceNotFoundException',
@@ -1835,10 +1840,10 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       command: 'deploy function',
       options: { function: 'basic' },
       lastLifecycleHookName: 'deploy:function:deploy',
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         Lambda: {
-          ...awsRequestStubMap.Lambda,
+          ...awsSdkV3StubMap.Lambda,
           getFunction: getFunctionStub,
         },
       },

--- a/test/unit/lib/plugins/aws/invoke.test.js
+++ b/test/unit/lib/plugins/aws/invoke.test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 const path = require('path');
 const { getTmpDirPath } = require('../../../../utils/fs');
 const runServerless = require('../../../../utils/run-serverless');
-const fixtures = require('../../../../fixtures/programmatic');
+const setupProgrammaticFixture = require('../../../../utils/setup-programmatic-fixture');
 const AwsInvoke = require('../../../../../lib/plugins/aws/invoke');
 const AwsProvider = require('../../../../../lib/plugins/aws/provider');
 const Serverless = require('../../../../../lib/serverless');
@@ -29,7 +29,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
           data: '{"inputKey":"inputValue"}',
           log: true,
         },
-        awsRequestStubMap: {
+        awsSdkV3StubMap: {
           Lambda: {
             invoke: (args) => {
               lambdaInvokeStub.returns({
@@ -115,7 +115,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
       options: {
         function: 'callback',
       },
-      awsRequestStubMap: {
+      awsSdkV3StubMap: {
         Lambda: {
           invoke: (args) => {
             lambdaInvokeStub.returns('payload');
@@ -140,7 +140,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
         options: {
           function: 'callback',
         },
-        awsRequestStubMap: {
+        awsSdkV3StubMap: {
           Lambda: {
             invoke: {
               Payload: Buffer.alloc(0),
@@ -159,7 +159,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
         function: 'callback',
         data: '{"inputKey":"inputValue"}',
       },
-      awsRequestStubMap: {
+      awsSdkV3StubMap: {
         Lambda: {
           invoke: {
             Payload: new Uint8Array(Buffer.from(JSON.stringify({ outputKey: 'outputValue' }))),
@@ -192,7 +192,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
         options: {
           function: 'callback',
         },
-        awsRequestStubMap: {
+        awsSdkV3StubMap: {
           Lambda: {
             invoke: {
               Payload: new Uint8Array(),
@@ -210,7 +210,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
       options: {
         function: 'callback',
       },
-      awsRequestStubMap: {
+      awsSdkV3StubMap: {
         Lambda: {
           invoke: {
             Payload: JSON.stringify({ outputKey: 'outputValue' }),
@@ -230,7 +230,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
         options: {
           function: 'callback',
         },
-        awsRequestStubMap: {
+        awsSdkV3StubMap: {
           Lambda: {
             invoke: {
               FunctionError: 'Unhandled',
@@ -251,7 +251,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
         function: 'callback',
         data: 'simple-string',
       },
-      awsRequestStubMap: {
+      awsSdkV3StubMap: {
         Lambda: {
           invoke: (args) => {
             lambdaInvokeStub.returns('payload');
@@ -278,7 +278,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
         data: '{"inputKey":"inputValue"}',
         raw: true,
       },
-      awsRequestStubMap: {
+      awsSdkV3StubMap: {
         Lambda: {
           invoke: (args) => {
             lambdaInvokeStub.returns('payload');
@@ -304,7 +304,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
         function: 'callback',
         path: 'payload.json',
       },
-      awsRequestStubMap: {
+      awsSdkV3StubMap: {
         Lambda: {
           invoke: (args) => {
             lambdaInvokeStub.returns('payload');
@@ -323,7 +323,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
 
   it('should support absolute file path as data', async () => {
     const lambdaInvokeStub = sinon.stub();
-    const { servicePath: serviceDir } = await fixtures.setup('invocation');
+    const { servicePath: serviceDir } = await setupProgrammaticFixture('invocation');
     const pathToPayload = path.join(serviceDir, 'payload.json');
     const result = await runServerless({
       cwd: serviceDir,
@@ -332,7 +332,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
         function: 'callback',
         path: pathToPayload,
       },
-      awsRequestStubMap: {
+      awsSdkV3StubMap: {
         Lambda: {
           invoke: (args) => {
             lambdaInvokeStub.returns('payload');
@@ -358,7 +358,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
         function: 'callback',
         path: 'payload.yaml',
       },
-      awsRequestStubMap: {
+      awsSdkV3StubMap: {
         Lambda: {
           invoke: (args) => {
             lambdaInvokeStub.returns('payload');
@@ -407,7 +407,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
         function: 'callback',
         type: 'Event',
       },
-      awsRequestStubMap: {
+      awsSdkV3StubMap: {
         Lambda: {
           invoke: (args) => {
             lambdaInvokeStub.returns('payload');
@@ -433,7 +433,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
         function: 'callback',
         qualifier: 'foo',
       },
-      awsRequestStubMap: {
+      awsSdkV3StubMap: {
         Lambda: {
           invoke: (args) => {
             lambdaInvokeStub.returns('payload');
@@ -461,7 +461,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
         function: 'callback',
         context: 'somecontext',
       },
-      awsRequestStubMap: {
+      awsSdkV3StubMap: {
         Lambda: {
           invoke: (args) => {
             lambdaInvokeStub.returns('payload');
@@ -491,7 +491,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
         context: '{"ctx": "somecontext"}',
         raw: true,
       },
-      awsRequestStubMap: {
+      awsSdkV3StubMap: {
         Lambda: {
           invoke: (args) => {
             lambdaInvokeStub.returns('payload');
@@ -531,7 +531,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
         function: 'callback',
         contextPath: contextDataFilePath,
       },
-      awsRequestStubMap: {
+      awsSdkV3StubMap: {
         Lambda: {
           invoke: (args) => {
             lambdaInvokeStub.returns('payload');
@@ -563,7 +563,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
           function: 'callback',
           contextPath: contextDataFilePath,
         },
-        awsRequestStubMap: {
+        awsSdkV3StubMap: {
           Lambda: {
             invoke: (args) => {
               lambdaInvokeStub.returns('payload');
@@ -585,7 +585,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
         options: {
           function: 'callback',
         },
-        awsRequestStubMap: {
+        awsSdkV3StubMap: {
           Lambda: {
             invoke: (args) => {
               lambdaInvokeStub.returns({
@@ -609,7 +609,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
         options: {
           function: 'callback',
         },
-        awsRequestStubMap: {
+        awsSdkV3StubMap: {
           Lambda: {
             invoke: {
               Payload: Buffer.alloc(0),
@@ -631,7 +631,7 @@ describe('test/unit/lib/plugins/aws/invoke.test.js', () => {
           function: 'callback',
           path: false,
         },
-        awsRequestStubMap: {
+        awsSdkV3StubMap: {
           Lambda: {
             invoke: (args) => {
               lambdaInvokeStub.returns('payload');

--- a/test/unit/lib/plugins/aws/rollback-function.test.js
+++ b/test/unit/lib/plugins/aws/rollback-function.test.js
@@ -14,6 +14,7 @@ const AwsProvider = require('../../../../../lib/plugins/aws/provider');
 const CLI = require('../../../../../lib/classes/cli');
 const AwsRollbackFunction = require('../../../../../lib/plugins/aws/rollback-function.js');
 const configureAwsSdkV3Stub = require('../../../../lib/configure-aws-sdk-v3-stub');
+const runServerless = require('../../../../utils/run-serverless');
 
 describe('AwsRollbackFunction', () => {
   let serverless;
@@ -98,6 +99,48 @@ describe('AwsRollbackFunction', () => {
         expect(fetchFunctionCodeStub.calledOnce).to.equal(true);
         expect(restoreFunctionStub.calledOnce).to.equal(true);
       }));
+  });
+
+  describe('command lifecycle', () => {
+    it('should rollback a function through the command', async () => {
+      const zipBytes = Uint8Array.from([1, 2, 3]);
+      const zipBuffer = Buffer.from(zipBytes);
+      const functionVersion = '4711';
+      const codeLocation = 'https://example.test/function.zip';
+      fetchStub.resolves({ arrayBuffer: async () => zipBytes.buffer });
+
+      const { awsSdkV3Stub, serverless } = await runServerless({
+        fixture: 'function',
+        command: 'rollback function',
+        options: { 'function': 'basic', 'function-version': functionVersion },
+        awsSdkV3StubMap: {
+          Lambda: {
+            getFunction: { Code: { Location: codeLocation } },
+            updateFunctionCode: {},
+          },
+        },
+      });
+      const functionName = serverless.service.getFunction('basic').name;
+      const lambdaSends = awsSdkV3Stub.sends.filter(({ service }) => service === 'Lambda');
+      const expectedCredentials = serverless.getProvider('aws').getAwsSdkV3CredentialsProvider();
+
+      expect(fetchStub).to.have.been.calledOnceWithExactly(codeLocation);
+      expect(lambdaSends.map(({ method }) => method)).to.deep.equal([
+        'getFunction',
+        'updateFunctionCode',
+      ]);
+      expect(lambdaSends[0].input).to.deep.equal({
+        FunctionName: functionName,
+        Qualifier: functionVersion,
+      });
+      expect(lambdaSends[1].input).to.deep.equal({
+        FunctionName: functionName,
+        ZipFile: zipBuffer,
+      });
+      expect(
+        lambdaSends.every(({ clientConfig }) => clientConfig.credentials === expectedCredentials)
+      ).to.equal(true);
+    });
   });
 
   describe('#getFunctionToBeRestored()', () => {

--- a/test/unit/lib/plugins/aws/rollback.test.js
+++ b/test/unit/lib/plugins/aws/rollback.test.js
@@ -493,7 +493,7 @@ describe('test/unit/lib/plugins/aws/rollback.test.js', () => {
       runServerless({
         fixture: 'function',
         command: 'rollback',
-        awsRequestStubMap: {
+        awsSdkV3StubMap: {
           CloudFormation: {
             describeStacks: {},
             describeStackResource: {


### PR DESCRIPTION
This migrates Lambda action plugin command coverage to strict awsSdkV3StubMap usage. It removes the direct invocation fixture wrapper setup and adds rollback function command lifecycle coverage while keeping focused helper-level Lambda units in place.