### PR TITLE
Migrate remove command lifecycle tests

### DIFF
--- a/test/unit/lib/plugins/aws/remove/index.test.js
+++ b/test/unit/lib/plugins/aws/remove/index.test.js
@@ -25,7 +25,7 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
   });
   const describeRepositoriesStub = sinon.stub();
   const deleteRepositoryStub = sinon.stub().resolves();
-  const awsRequestStubMap = {
+  const awsSdkV3StubMap = {
     ECR: {
       deleteRepository: deleteRepositoryStub,
       describeRepositories: describeRepositoriesStub,
@@ -89,6 +89,11 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     describeRepositoriesStub.reset();
     deleteRepositoryStub.resetHistory();
   });
+
+  const expectAwsSdkV3StubInput = (stub, input) => {
+    expect(stub).to.be.calledOnce;
+    expect(stub.firstCall.args[0]).to.deep.equal(input);
+  };
 
   it('preserves deleteObjectBatches one-argument plugin method signature', async () => {
     const sendStub = sinon.stub(S3Client.prototype, 'send').resolves({});
@@ -214,7 +219,7 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     const { awsNaming, awsSdkV3Stub, serverless } = await runServerless({
       fixture: 'function',
       command: 'remove',
-      awsRequestStubMap,
+      awsSdkV3StubMap,
     });
 
     expect(deleteObjectsStub).to.be.calledOnce;
@@ -224,8 +229,8 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
         Objects: [{ Key: 'first' }, { Key: 'second' }],
       },
     });
-    expect(deleteStackStub).to.be.calledWithExactly({ StackName: awsNaming.getStackName() });
-    expect(describeStackEventsStub).to.be.calledWithExactly({
+    expectAwsSdkV3StubInput(deleteStackStub, { StackName: awsNaming.getStackName() });
+    expectAwsSdkV3StubInput(describeStackEventsStub, {
       StackName: awsNaming.getStackName(),
     });
     expect(deleteStackStub.calledAfter(deleteObjectsStub)).to.be.true;
@@ -259,7 +264,7 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     const { awsNaming } = await runServerless({
       fixture: 'function',
       command: 'remove',
-      awsRequestStubMap,
+      awsSdkV3StubMap,
     });
 
     expect(deleteObjectsStub).to.be.calledOnce;
@@ -269,8 +274,8 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
         Objects: [{ Key: 'first' }, { Key: 'second' }],
       },
     });
-    expect(deleteStackStub).to.be.calledWithExactly({ StackName: awsNaming.getStackName() });
-    expect(describeStackEventsStub).to.be.calledWithExactly({
+    expectAwsSdkV3StubInput(deleteStackStub, { StackName: awsNaming.getStackName() });
+    expectAwsSdkV3StubInput(describeStackEventsStub, {
       StackName: awsNaming.getStackName(),
     });
     expect(deleteStackStub.calledAfter(deleteObjectsStub)).to.be.true;
@@ -294,12 +299,12 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       const { awsNaming, awsSdkV3Stub, serverless } = await runServerless({
         fixture: 'function',
         command: 'remove',
-        awsRequestStubMap,
+        awsSdkV3StubMap,
       });
 
       expect(deleteObjectsStub).to.be.calledOnce;
-      expect(deleteStackStub).to.be.calledWithExactly({ StackName: awsNaming.getStackName() });
-      expect(describeStackEventsStub).to.be.calledWithExactly({
+      expectAwsSdkV3StubInput(deleteStackStub, { StackName: awsNaming.getStackName() });
+      expectAwsSdkV3StubInput(describeStackEventsStub, {
         StackName: awsNaming.getStackName(),
       });
       expect(deleteRepositoryStub).not.to.be.called;
@@ -321,8 +326,8 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     await runServerless({
       fixture: 'function',
       command: 'remove',
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         S3: {
           deleteObjects: deleteObjectsStub,
           listObjectsV2: { Contents: [] },
@@ -338,7 +343,7 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     await runServerless({
       fixture: 'function',
       command: 'remove',
-      awsRequestStubMap,
+      awsSdkV3StubMap,
     });
 
     expect(deleteObjectsStub).to.be.calledOnce;
@@ -365,8 +370,8 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     const { serverless } = await runServerless({
       fixture: 'function',
       command: 'remove',
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         S3: {
           deleteObjects: innerDeleteObjectsStub,
           listObjectsV2: listObjectsV2Stub,
@@ -410,8 +415,8 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     await runServerless({
       fixture: 'function',
       command: 'remove',
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         S3: {
           deleteObjects: innerDeleteObjectsStub,
           listObjectsV2: { Contents: objects },
@@ -434,8 +439,8 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     const { awsNaming } = await runServerless({
       fixture: 'function',
       command: 'remove',
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         S3: {
           deleteObjects: deleteObjectsStub,
           listObjectsV2: { Contents: [{ Key: 'first' }, { Key: 'second' }] },
@@ -449,8 +454,8 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     });
 
     expect(deleteObjectsStub).not.to.be.called;
-    expect(deleteStackStub).to.be.calledWithExactly({ StackName: awsNaming.getStackName() });
-    expect(describeStackEventsStub).to.be.calledWithExactly({
+    expectAwsSdkV3StubInput(deleteStackStub, { StackName: awsNaming.getStackName() });
+    expectAwsSdkV3StubInput(describeStackEventsStub, {
       StackName: awsNaming.getStackName(),
     });
     expect(describeStackEventsStub.calledAfter(deleteStackStub)).to.be.true;
@@ -461,14 +466,14 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     const { awsNaming } = await runServerless({
       fixture: 'function',
       command: 'remove',
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         S3: {
-          ...awsRequestStubMap.S3,
+          ...awsSdkV3StubMap.S3,
           headBucket: headBucketStub,
         },
         CloudFormation: {
-          ...awsRequestStubMap.CloudFormation,
+          ...awsSdkV3StubMap.CloudFormation,
           describeStackResource: () => {
             const err = new Error('does not exist for stack');
             err.providerError = {
@@ -482,8 +487,8 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
 
     expect(headBucketStub).not.to.be.called;
     expect(deleteObjectsStub).not.to.be.called;
-    expect(deleteStackStub).to.be.calledWithExactly({ StackName: awsNaming.getStackName() });
-    expect(describeStackEventsStub).to.be.calledWithExactly({
+    expectAwsSdkV3StubInput(deleteStackStub, { StackName: awsNaming.getStackName() });
+    expectAwsSdkV3StubInput(describeStackEventsStub, {
       StackName: awsNaming.getStackName(),
     });
     expect(describeStackEventsStub.calledAfter(deleteStackStub)).to.be.true;
@@ -494,14 +499,14 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     const { awsNaming } = await runServerless({
       fixture: 'function',
       command: 'remove',
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         S3: {
-          ...awsRequestStubMap.S3,
+          ...awsSdkV3StubMap.S3,
           headBucket: headBucketStub,
         },
         CloudFormation: {
-          ...awsRequestStubMap.CloudFormation,
+          ...awsSdkV3StubMap.CloudFormation,
           describeStackResource: () => {
             const err = new Error('Resource does not exist for stack new-service-dev');
             err.name = 'ValidationError';
@@ -513,8 +518,8 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
 
     expect(headBucketStub).not.to.be.called;
     expect(deleteObjectsStub).not.to.be.called;
-    expect(deleteStackStub).to.be.calledWithExactly({ StackName: awsNaming.getStackName() });
-    expect(describeStackEventsStub).to.be.calledWithExactly({
+    expectAwsSdkV3StubInput(deleteStackStub, { StackName: awsNaming.getStackName() });
+    expectAwsSdkV3StubInput(describeStackEventsStub, {
       StackName: awsNaming.getStackName(),
     });
     expect(describeStackEventsStub.calledAfter(deleteStackStub)).to.be.true;
@@ -525,10 +530,10 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       runServerless({
         fixture: 'function',
         command: 'remove',
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           CloudFormation: {
-            ...awsRequestStubMap.CloudFormation,
+            ...awsSdkV3StubMap.CloudFormation,
             describeStackResource: () => {
               const err = new Error('Some other validation failure');
               err.name = 'ValidationError';
@@ -545,10 +550,10 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       runServerless({
         fixture: 'function',
         command: 'remove',
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           CloudFormation: {
-            ...awsRequestStubMap.CloudFormation,
+            ...awsSdkV3StubMap.CloudFormation,
             describeStackResource: () => {
               const err = Object.assign(Object.create({ message: 'does not exist for stack' }), {
                 name: 'ValidationError',
@@ -566,7 +571,7 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
     const { awsNaming, awsSdkV3Stub, serverless } = await runServerless({
       fixture: 'function',
       command: 'remove',
-      awsRequestStubMap,
+      awsSdkV3StubMap,
     });
     const ecrSends = awsSdkV3Stub.sends.filter(({ service }) => service === 'ECR');
 
@@ -590,7 +595,7 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
           clientConfig.region === 'us-east-1' && clientConfig.credentials === expectedCredentials
       )
     ).to.equal(true);
-    expect(deleteRepositoryStub).to.be.calledWithExactly({
+    expectAwsSdkV3StubInput(deleteRepositoryStub, {
       repositoryName: awsNaming.getEcrRepositoryName(),
       registryId: '999999999999',
       force: true,
@@ -622,8 +627,8 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
           },
         },
       },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         S3: {
           listObjectVersions: listObjectVersionsStub,
           headBucket: {},
@@ -666,8 +671,8 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
           },
         },
       },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         S3: {
           listObjectVersions: listObjectVersionsStub,
           deleteObjects: innerDeleteObjectsStub,
@@ -721,8 +726,8 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
           },
         },
       },
-      awsRequestStubMap: {
-        ...awsRequestStubMap,
+      awsSdkV3StubMap: {
+        ...awsSdkV3StubMap,
         S3: {
           listObjectVersions: listObjectVersionsStub,
           deleteObjects: innerDeleteObjectsStub,
@@ -778,10 +783,10 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
             },
           },
         },
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           S3: {
-            ...awsRequestStubMap.S3,
+            ...awsSdkV3StubMap.S3,
             listObjectVersions: () => {
               throw listError;
             },
@@ -810,10 +815,10 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
             },
           },
         },
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           S3: {
-            ...awsRequestStubMap.S3,
+            ...awsSdkV3StubMap.S3,
             listObjectVersions: () => {
               throw listError;
             },
@@ -837,8 +842,8 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
             },
           },
         },
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           S3: {
             listObjectVersions: () => {
               const err = new Error('ff');
@@ -866,10 +871,10 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       runServerless({
         command: 'remove',
         fixture: 'function',
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           S3: {
-            ...awsRequestStubMap.S3,
+            ...awsSdkV3StubMap.S3,
             deleteObjects: innerDeleteObjectsStub,
             headBucket: {},
           },
@@ -886,10 +891,10 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       await runServerless({
         command: 'remove',
         fixture: 'function',
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           S3: {
-            ...awsRequestStubMap.S3,
+            ...awsSdkV3StubMap.S3,
             listObjectsV2: { Contents: [{ Key: 'first' }] },
             deleteObjects: sinon.stub().rejects(deleteError),
             headBucket: {},
@@ -916,10 +921,10 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       runServerless({
         command: 'remove',
         fixture: 'function',
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           S3: {
-            ...awsRequestStubMap.S3,
+            ...awsSdkV3StubMap.S3,
             deleteObjects: innerDeleteObjectsStub,
             headBucket: {},
           },
@@ -938,10 +943,10 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       runServerless({
         command: 'remove',
         fixture: 'function',
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           S3: {
-            ...awsRequestStubMap.S3,
+            ...awsSdkV3StubMap.S3,
             deleteObjects: innerDeleteObjectsStub,
             headBucket: {},
           },
@@ -960,10 +965,10 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       runServerless({
         command: 'remove',
         fixture: 'function',
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           S3: {
-            ...awsRequestStubMap.S3,
+            ...awsSdkV3StubMap.S3,
             deleteObjects: innerDeleteObjectsStub,
             headBucket: {},
           },
@@ -982,10 +987,10 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       runServerless({
         command: 'remove',
         fixture: 'function',
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           S3: {
-            ...awsRequestStubMap.S3,
+            ...awsSdkV3StubMap.S3,
             deleteObjects: innerDeleteObjectsStub,
             headBucket: {},
           },
@@ -1001,10 +1006,10 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       await runServerless({
         command: 'remove',
         fixture: 'function',
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           S3: {
-            ...awsRequestStubMap.S3,
+            ...awsSdkV3StubMap.S3,
             listObjectsV2: () => {
               throw listError;
             },
@@ -1025,10 +1030,10 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       runServerless({
         command: 'remove',
         fixture: 'function',
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           S3: {
-            ...awsRequestStubMap.S3,
+            ...awsSdkV3StubMap.S3,
             listObjectsV2: () => {
               throw listError;
             },
@@ -1046,10 +1051,10 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       runServerless({
         command: 'remove',
         fixture: 'function',
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           S3: {
-            ...awsRequestStubMap.S3,
+            ...awsSdkV3StubMap.S3,
             listObjectsV2: () => {
               throw listError;
             },
@@ -1067,10 +1072,10 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       runServerless({
         command: 'remove',
         fixture: 'function',
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           S3: {
-            ...awsRequestStubMap.S3,
+            ...awsSdkV3StubMap.S3,
             listObjectsV2: () => {
               throw listError;
             },
@@ -1086,10 +1091,10 @@ describe('test/unit/lib/plugins/aws/remove/index.test.js', () => {
       runServerless({
         command: 'remove',
         fixture: 'function',
-        awsRequestStubMap: {
-          ...awsRequestStubMap,
+        awsSdkV3StubMap: {
+          ...awsSdkV3StubMap,
           S3: {
-            ...awsRequestStubMap.S3,
+            ...awsSdkV3StubMap.S3,
             listObjectsV2: () => {
               const err = new Error('ff');
               err.code = 'AWS_S3_LIST_OBJECTS_V2_ACCESS_DENIED';

--- a/test/unit/lib/plugins/aws/remove/lib/stack.test.js
+++ b/test/unit/lib/plugins/aws/remove/lib/stack.test.js
@@ -2,26 +2,30 @@
 
 const expect = require('chai').expect;
 const sinon = require('sinon');
-const AwsProvider = require('../../../../../../../lib/plugins/aws/provider');
-const AwsRemove = require('../../../../../../../lib/plugins/aws/remove/index');
-const Serverless = require('../../../../../../../lib/serverless');
 const { CloudFormationClient, DeleteStackCommand } = require('@aws-sdk/client-cloudformation');
+const removeStack = require('../../../../../../../lib/plugins/aws/remove/lib/stack');
 
 describe('removeStack', () => {
-  const options = {
-    stage: 'dev',
-    region: 'us-east-1',
-  };
-  const serverless = new Serverless({ commands: [], options: {} });
-  serverless.service.service = 'removeStack';
-  serverless.setProvider('aws', new AwsProvider(serverless, options));
+  const stackName = 'removeStack-dev';
+  const customDeploymentRole = 'arn:aws:iam::123456789012:role/myrole';
 
-  let awsRemove;
   let removeStackStub;
 
+  const createRemoveStackContext = (overrides = {}) => {
+    const provider = {
+      naming: { getStackName: sinon.stub().returns(stackName) },
+      getAwsSdkV3Config: sinon.stub().resolves({ region: 'us-east-1' }),
+      getCustomDeploymentRole: sinon.stub().returns(null),
+      ...overrides.provider,
+    };
+    return {
+      ...removeStack,
+      ...overrides,
+      provider,
+    };
+  };
+
   beforeEach(() => {
-    awsRemove = new AwsRemove(serverless, options);
-    awsRemove.serverless.cli = new serverless.classes.CLI();
     removeStackStub = sinon.stub(CloudFormationClient.prototype, 'send').resolves();
   });
 
@@ -30,57 +34,61 @@ describe('removeStack', () => {
   });
 
   describe('#remove()', () => {
-    it('should remove a stack', async () =>
-      awsRemove.remove().then((result) => {
-        const stackName = `${serverless.service.service}-${awsRemove.provider.getStage()}`;
+    it('should remove a stack', async () => {
+      const context = createRemoveStackContext();
 
-        expect(result).to.deep.equal({ StackId: stackName });
-        expect(removeStackStub.calledOnce).to.be.equal(true);
-        expect(removeStackStub.firstCall.args[0]).to.be.instanceOf(DeleteStackCommand);
-        expect(removeStackStub.firstCall.args[0].input).to.deep.equal({ StackName: stackName });
-      }));
+      const result = await context.remove();
+
+      expect(result).to.deep.equal({ StackId: stackName });
+      expect(context.provider.getAwsSdkV3Config).to.have.been.calledOnceWithExactly();
+      expect(removeStackStub).to.have.been.calledOnce;
+      expect(removeStackStub.firstCall.args[0]).to.be.instanceOf(DeleteStackCommand);
+      expect(removeStackStub.firstCall.args[0].input).to.deep.equal({ StackName: stackName });
+    });
 
     it('uses an existing CloudFormation client promise from the plugin context', async () => {
       const send = sinon.stub().resolves();
-      sinon
-        .stub(awsRemove.provider, 'getAwsSdkV3Config')
-        .throws(new Error('Expected existing CloudFormation client to be reused'));
-      awsRemove.cloudFormationClientPromise = Promise.resolve({ send });
+      const context = createRemoveStackContext({
+        cloudFormationClientPromise: Promise.resolve({ send }),
+        provider: {
+          getAwsSdkV3Config: sinon
+            .stub()
+            .throws(new Error('Expected existing CloudFormation client to be reused')),
+        },
+      });
 
-      try {
-        const result = await awsRemove.remove();
-        const stackName = `${serverless.service.service}-${awsRemove.provider.getStage()}`;
+      const result = await context.remove();
 
-        expect(result).to.deep.equal({ StackId: stackName });
-        expect(awsRemove.provider.getAwsSdkV3Config).to.not.have.been.called;
-        expect(send).to.have.been.calledOnce;
-        expect(send.firstCall.args[0]).to.be.instanceOf(DeleteStackCommand);
-        expect(send.firstCall.args[0].input).to.deep.equal({ StackName: stackName });
-      } finally {
-        awsRemove.provider.getAwsSdkV3Config.restore();
-      }
+      expect(result).to.deep.equal({ StackId: stackName });
+      expect(context.provider.getAwsSdkV3Config).to.not.have.been.called;
+      expect(send).to.have.been.calledOnce;
+      expect(send.firstCall.args[0]).to.be.instanceOf(DeleteStackCommand);
+      expect(send.firstCall.args[0].input).to.deep.equal({ StackName: stackName });
     });
 
     it('should use CloudFormation service role if it is specified', async () => {
-      awsRemove.serverless.service.provider.cfnRole = 'arn:aws:iam::123456789012:role/myrole';
-
-      return awsRemove.remove().then(() => {
-        expect(removeStackStub.firstCall.args[0]).to.be.instanceOf(DeleteStackCommand);
-        expect(removeStackStub.firstCall.args[0].input.RoleARN).to.equal(
-          'arn:aws:iam::123456789012:role/myrole'
-        );
+      const context = createRemoveStackContext({
+        provider: {
+          getCustomDeploymentRole: sinon.stub().returns(customDeploymentRole),
+        },
       });
+
+      await context.remove();
+
+      expect(context.provider.getCustomDeploymentRole).to.have.been.calledOnceWithExactly();
+      expect(removeStackStub.firstCall.args[0]).to.be.instanceOf(DeleteStackCommand);
+      expect(removeStackStub.firstCall.args[0].input.RoleARN).to.equal(customDeploymentRole);
     });
   });
 
   describe('#removeStack()', () => {
     it('should run promise chain in order', async () => {
-      const removeStub = sinon.stub(awsRemove, 'remove').resolves();
+      const context = createRemoveStackContext();
+      const removeStub = sinon.stub(context, 'remove').resolves();
 
-      return awsRemove.removeStack().then(() => {
-        expect(removeStub.calledOnce).to.be.equal(true);
-        awsRemove.remove.restore();
-      });
+      await context.removeStack();
+
+      expect(removeStub).to.have.been.calledOnceWithExactly();
     });
   });
 });


### PR DESCRIPTION
This migrates remove command lifecycle coverage to the AWS SDK v3 stub map. It keeps the stack removal helper covered with focused fake contexts instead of full Serverless provider construction.