### PR TITLE
Migrate AWS operational info tests

### DIFF
--- a/test/unit/lib/plugins/aws/deploy-list.test.js
+++ b/test/unit/lib/plugins/aws/deploy-list.test.js
@@ -4,8 +4,7 @@ const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const expect = require('chai').expect;
 const AwsDeployList = require('../../../../../lib/plugins/aws/deploy-list');
-const AwsProvider = require('../../../../../lib/plugins/aws/provider');
-const Serverless = require('../../../../../lib/serverless');
+const ServerlessError = require('../../../../../lib/serverless-error');
 const { S3Client, ListObjectsV2Command } = require('@aws-sdk/client-s3');
 const {
   LambdaClient,
@@ -21,6 +20,42 @@ function formatDeploymentDate(dateString) {
   ).padStart(2, 0)} ${String(date.getUTCHours()).padStart(2, 0)}:${String(
     date.getUTCMinutes()
   ).padStart(2, 0)}:${String(date.getUTCSeconds()).padStart(2, 0)} UTC`;
+}
+
+function createServerlessContext(options) {
+  const provider = {
+    getStage: () => options.stage,
+    getRegion: () => options.region,
+    getDeploymentPrefix: () => 'serverless',
+    getAwsSdkV3Config: async () => ({ region: options.region }),
+  };
+  const service = {
+    service: 'listDeployments',
+    functions: {},
+    getAllFunctions() {
+      return Object.keys(this.functions);
+    },
+    getFunction(functionName) {
+      if (!this.functions || !Object.hasOwn(this.functions, functionName)) {
+        throw new ServerlessError(
+          `Function "${functionName}" doesn't exist in this Service`,
+          'FUNCTION_MISSING_IN_SERVICE'
+        );
+      }
+      return this.functions[functionName];
+    },
+    getAllFunctionsNames() {
+      return this.getAllFunctions().map((functionName) => this.getFunction(functionName).name);
+    },
+  };
+
+  return {
+    provider,
+    serverless: {
+      service,
+      getProvider: sinon.stub().withArgs('aws').returns(provider),
+    },
+  };
 }
 
 async function waitForPendingRequests(pendingResolvers, count) {
@@ -46,10 +81,7 @@ describe('AwsDeployList', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
-    provider = new AwsProvider(serverless, options);
-    serverless.setProvider('aws', provider);
-    serverless.service.service = 'listDeployments';
+    ({ serverless, provider } = createServerlessContext(options));
     const prefix = provider.getDeploymentPrefix();
     s3Key = `${prefix}/${serverless.service.service}/${provider.getStage()}`;
     awsDeployList = new AwsDeployList(serverless, options);

--- a/test/unit/lib/plugins/aws/info/display.test.js
+++ b/test/unit/lib/plugins/aws/info/display.test.js
@@ -16,7 +16,7 @@ describe('test/unit/lib/plugins/aws/info/display.test.js', () => {
     } = await runServerless({
       fixture: 'api-gateway',
       command: 'info',
-      awsRequestStubMap: {
+      awsSdkV3StubMap: {
         APIGateway: {
           getApiKey: {
             value: 'test-key-value',

--- a/test/unit/lib/plugins/aws/info/get-api-key-values.test.js
+++ b/test/unit/lib/plugins/aws/info/get-api-key-values.test.js
@@ -3,14 +3,34 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const AwsInfo = require('../../../../../../lib/plugins/aws/info/index');
-const AwsProvider = require('../../../../../../lib/plugins/aws/provider');
-const Serverless = require('../../../../../../lib/serverless');
 const {
   CloudFormationClient,
   DescribeStackResourcesCommand,
 } = require('@aws-sdk/client-cloudformation');
 const { APIGatewayClient, GetApiKeyCommand } = require('@aws-sdk/client-api-gateway');
 const releasePendingRequestsUntilSettled = require('../../../../../utils/release-pending-requests-until-settled');
+
+function createServerlessContext(options) {
+  const provider = {
+    getStage: () => options.stage,
+    getRegion: () => options.region,
+    getAwsSdkV3Config: async () => ({ region: options.region }),
+    naming: {
+      getStackName: () => 'my-service-dev',
+    },
+  };
+
+  return {
+    provider,
+    serverless: {
+      service: {
+        service: 'my-service',
+        provider: {},
+      },
+      getProvider: sinon.stub().withArgs('aws').returns(provider),
+    },
+  };
+}
 
 describe('#getApiKeyValues()', () => {
   let serverless;
@@ -23,9 +43,7 @@ describe('#getApiKeyValues()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    serverless.service.service = 'my-service';
+    ({ serverless } = createServerlessContext(options));
     awsInfo = new AwsInfo(serverless, options);
     cloudFormationSendStub = sinon.stub(CloudFormationClient.prototype, 'send');
     apiGatewaySendStub = sinon.stub(APIGatewayClient.prototype, 'send');

--- a/test/unit/lib/plugins/aws/info/get-resource-count.test.js
+++ b/test/unit/lib/plugins/aws/info/get-resource-count.test.js
@@ -3,12 +3,32 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const AwsInfo = require('../../../../../../lib/plugins/aws/info/index');
-const AwsProvider = require('../../../../../../lib/plugins/aws/provider');
-const Serverless = require('../../../../../../lib/serverless');
 const {
   CloudFormationClient,
   ListStackResourcesCommand,
 } = require('@aws-sdk/client-cloudformation');
+
+function createServerlessContext(options) {
+  const provider = {
+    getStage: () => options.stage,
+    getRegion: () => options.region,
+    getAwsSdkV3Config: async () => ({ region: options.region }),
+    naming: {
+      getStackName: () => 'my-service-dev',
+    },
+  };
+
+  return {
+    provider,
+    serverless: {
+      service: {
+        service: 'my-service',
+        functions: {},
+      },
+      getProvider: sinon.stub().withArgs('aws').returns(provider),
+    },
+  };
+}
 
 describe('#getResourceCount()', () => {
   let serverless;
@@ -20,9 +40,7 @@ describe('#getResourceCount()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    serverless.service.service = 'my-service';
+    ({ serverless } = createServerlessContext(options));
     serverless.service.functions = {
       hello: {},
       world: {},

--- a/test/unit/lib/plugins/aws/info/get-stack-info.test.js
+++ b/test/unit/lib/plugins/aws/info/get-stack-info.test.js
@@ -3,14 +3,56 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const AwsInfo = require('../../../../../../lib/plugins/aws/info/index');
-const AwsProvider = require('../../../../../../lib/plugins/aws/provider');
-const Serverless = require('../../../../../../lib/serverless');
 const {
   CloudFormationClient,
   DescribeStacksCommand,
   ListExportsCommand,
 } = require('@aws-sdk/client-cloudformation');
 const { ApiGatewayV2Client, GetApiCommand } = require('@aws-sdk/client-apigatewayv2');
+
+function upperFirst(value) {
+  return `${value[0].toUpperCase()}${value.slice(1)}`;
+}
+
+function createServerlessContext(options) {
+  const provider = {
+    getStage: () => options.stage,
+    getRegion: () => options.region,
+    getAwsSdkV3Config: async () => ({ region: options.region }),
+    naming: {
+      getStackName: () => 'my-service-dev',
+      getServiceEndpointRegex: () => /^(ServiceEndpoint|HttpApiUrl)$/,
+      getLambdaFunctionUrlOutputLogicalId: (functionName) =>
+        `${upperFirst(functionName)}LambdaFunctionUrl`,
+      getLambdaLayerOutputLogicalId: (layerName) =>
+        `${upperFirst(layerName)}LambdaLayerQualifiedArn`,
+      getCloudFrontDistributionDomainNameLogicalId: () => 'CloudFrontDistributionDomainName',
+    },
+  };
+  const service = {
+    service: 'my-service',
+    provider: {},
+    functions: {},
+    layers: {},
+    getAllFunctions() {
+      return Object.keys(this.functions);
+    },
+    getFunction(functionName) {
+      return this.functions[functionName];
+    },
+    getAllLayers() {
+      return Object.keys(this.layers || {});
+    },
+  };
+
+  return {
+    provider,
+    serverless: {
+      service,
+      getProvider: sinon.stub().withArgs('aws').returns(provider),
+    },
+  };
+}
 
 describe('#getStackInfo()', () => {
   let serverless;
@@ -23,9 +65,7 @@ describe('#getStackInfo()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    serverless.service.service = 'my-service';
+    ({ serverless } = createServerlessContext(options));
     serverless.service.functions = {
       hello: { name: 'my-service-dev-hello' },
       world: { name: 'customized' },

--- a/test/unit/lib/plugins/aws/info/index.test.js
+++ b/test/unit/lib/plugins/aws/info/index.test.js
@@ -3,8 +3,40 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const AwsInfo = require('../../../../../../lib/plugins/aws/info/index');
-const AwsProvider = require('../../../../../../lib/plugins/aws/provider');
-const Serverless = require('../../../../../../lib/serverless');
+
+function createServerlessContext(options, getAwsInfo) {
+  const provider = {
+    getStage: () => options.stage,
+    getRegion: () => options.region,
+    getAwsSdkV3Config: async () => ({ region: options.region }),
+  };
+
+  return {
+    provider,
+    serverless: {
+      processedInput: { commands: ['info'] },
+      serviceOutputs: new Map(),
+      servicePluginOutputs: new Map(),
+      getProvider: sinon.stub().withArgs('aws').returns(provider),
+      pluginManager: {
+        spawn: sinon.stub().callsFake(async (command) => {
+          if (command !== 'aws:info') throw new Error(`Unexpected command ${command}`);
+          const awsInfo = getAwsInfo();
+          const lifecycleEvents = awsInfo.commands.aws.commands.info.lifecycleEvents;
+          for (const event of lifecycleEvents) {
+            for (const hookName of [
+              `before:${command}:${event}`,
+              `${command}:${event}`,
+              `after:${command}:${event}`,
+            ]) {
+              if (awsInfo.hooks[hookName]) await awsInfo.hooks[hookName]();
+            }
+          }
+        }),
+      },
+    },
+  };
+}
 
 describe('AwsInfo', () => {
   let serverless;
@@ -25,15 +57,8 @@ describe('AwsInfo', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    serverless.cli = {
-      log: sinon.stub().returns(),
-    };
+    ({ serverless } = createServerlessContext(options, () => awsInfo));
     awsInfo = new AwsInfo(serverless, options);
-    // Load commands and hooks into pluginManager
-    serverless.pluginManager.loadCommands(awsInfo);
-    serverless.pluginManager.loadHooks(awsInfo);
     validateStub = sinon.stub(awsInfo, 'validate').resolves();
     getStackInfoStub = sinon.stub(awsInfo, 'getStackInfo').resolves();
     getResourceCountStub = sinon.stub(awsInfo, 'getResourceCount').resolves();
@@ -55,14 +80,15 @@ describe('AwsInfo', () => {
     awsInfo.displayApiKeys.restore();
     awsInfo.displayEndpoints.restore();
     awsInfo.displayFunctions.restore();
+    awsInfo.displayLayers.restore();
     awsInfo.displayStackOutputs.restore();
   });
 
   describe('#constructor()', () => {
     it('should have hooks', () => expect(awsInfo.hooks).to.be.not.empty);
 
-    it('should set the provider variable to the AwsProvider instance', () =>
-      expect(awsInfo.provider).to.be.instanceof(AwsProvider));
+    it('should set the provider variable to the aws provider', () =>
+      expect(awsInfo.provider).to.equal(serverless.getProvider('aws')));
 
     it('should set an empty options object if no options are given', () => {
       const awsInfoWithEmptyOptions = new AwsInfo(serverless);

--- a/test/unit/lib/plugins/aws/logs.test.js
+++ b/test/unit/lib/plugins/aws/logs.test.js
@@ -2,9 +2,8 @@
 
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
-const AwsProvider = require('../../../../../lib/plugins/aws/provider');
 const AwsLogs = require('../../../../../lib/plugins/aws/logs');
-const Serverless = require('../../../../../lib/serverless');
+const ServerlessError = require('../../../../../lib/serverless-error');
 const {
   CloudWatchLogsClient,
   DescribeLogStreamsCommand,
@@ -13,6 +12,40 @@ const {
 
 // Configure chai
 const expect = require('chai').expect;
+
+function createServerlessContext(options) {
+  const provider = {
+    getStage: () => options.stage,
+    getRegion: () => options.region,
+    getAwsSdkV3Config: async () => ({ region: options.region }),
+    naming: {
+      getLogGroupName: (lambdaName) => `/aws/lambda/${lambdaName}`,
+    },
+  };
+  const service = {
+    service: 'new-service',
+    functions: {},
+    getFunction(functionName) {
+      if (!this.functions || !Object.hasOwn(this.functions, functionName)) {
+        throw new ServerlessError(
+          `Function "${functionName}" doesn't exist in this Service`,
+          'FUNCTION_MISSING_IN_SERVICE'
+        );
+      }
+      return this.functions[functionName];
+    },
+  };
+
+  return {
+    provider,
+    serverless: {
+      service,
+      serviceDir: false,
+      processedInput: { commands: ['logs'] },
+      getProvider: sinon.stub().withArgs('aws').returns(provider),
+    },
+  };
+}
 
 describe('AwsLogs', () => {
   let serverless;
@@ -24,10 +57,7 @@ describe('AwsLogs', () => {
       region: 'us-east-1',
       function: 'first',
     };
-    serverless = new Serverless({ commands: [], options: {} });
-    const provider = new AwsProvider(serverless, options);
-    serverless.setProvider('aws', provider);
-    serverless.processedInput = { commands: ['logs'] };
+    ({ serverless } = createServerlessContext(options));
     awsLogs = new AwsLogs(serverless, options);
   });
 
@@ -46,8 +76,8 @@ describe('AwsLogs', () => {
       expect(awsLogsWithEmptyOptions.options).to.deep.equal({});
     });
 
-    it('should set the provider variable to an instance of AwsProvider', () =>
-      expect(awsLogs.provider).to.be.instanceof(AwsProvider));
+    it('should set the provider variable to the aws provider', () =>
+      expect(awsLogs.provider).to.equal(serverless.getProvider('aws')));
 
     it('should run promise chain in order', async () => {
       const validateStub = sinon.stub(awsLogs, 'extendedValidate').resolves();
@@ -336,11 +366,8 @@ describe('AwsLogs', () => {
         region: 'us-east-1',
         function: 'first',
       };
-      serverless = new Serverless({ commands: [], options: {} });
-      const provider = new AwsProvider(serverless, options);
-      serverless.setProvider('aws', provider);
-      serverless.processedInput = { commands: ['logs'] };
-      const mockedAwsLogs = new MockedAwsLogs(serverless, options);
+      const { serverless: mockedServerless } = createServerlessContext(options);
+      const mockedAwsLogs = new MockedAwsLogs(mockedServerless, options);
 
       const filterLogEventsStub = sinon
         .stub(CloudWatchLogsClient.prototype, 'send')

--- a/test/unit/lib/plugins/aws/metrics.test.js
+++ b/test/unit/lib/plugins/aws/metrics.test.js
@@ -3,10 +3,8 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
-const AwsProvider = require('../../../../../lib/plugins/aws/provider');
 const AwsMetrics = require('../../../../../lib/plugins/aws/metrics');
-const Serverless = require('../../../../../lib/serverless');
-const CLI = require('../../../../../lib/classes/cli');
+const ServerlessError = require('../../../../../lib/serverless-error');
 const dayjs = require('dayjs');
 const { CloudWatchClient, GetMetricStatisticsCommand } = require('@aws-sdk/client-cloudwatch');
 const releasePendingRequestsUntilSettled = require('../../../../utils/release-pending-requests-until-settled');
@@ -15,18 +13,51 @@ const LocalizedFormat = require('dayjs/plugin/localizedFormat');
 
 dayjs.extend(LocalizedFormat);
 
+function createServerlessContext(options) {
+  const provider = {
+    getStage: () => options.stage,
+    getRegion: () => options.region,
+    getAwsSdkV3Config: async () => ({ region: options.region }),
+  };
+  const service = {
+    service: 'my-service',
+    functions: {},
+    getAllFunctions() {
+      return Object.keys(this.functions);
+    },
+    getFunction(functionName) {
+      if (!this.functions || !Object.hasOwn(this.functions, functionName)) {
+        throw new ServerlessError(
+          `Function "${functionName}" doesn't exist in this Service`,
+          'FUNCTION_MISSING_IN_SERVICE'
+        );
+      }
+      return this.functions[functionName];
+    },
+    getAllFunctionsNames() {
+      return this.getAllFunctions().map((functionName) => this.getFunction(functionName).name);
+    },
+  };
+
+  return {
+    provider,
+    serverless: {
+      service,
+      getProvider: sinon.stub().withArgs('aws').returns(provider),
+    },
+  };
+}
+
 describe('AwsMetrics', () => {
   let awsMetrics;
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.cli = new CLI(serverless);
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
+    ({ serverless } = createServerlessContext(options));
     awsMetrics = new AwsMetrics(serverless, options);
   });
 
@@ -39,8 +70,8 @@ describe('AwsMetrics', () => {
       expect(awsMetrics.options).to.deep.equal({ stage: 'dev', region: 'us-east-1' });
     });
 
-    it('should set the provider variable to the AwsProvider instance', () =>
-      expect(awsMetrics.provider).to.be.instanceof(AwsProvider));
+    it('should set the provider variable to the aws provider', () =>
+      expect(awsMetrics.provider).to.equal(serverless.getProvider('aws')));
 
     it('should have a "metrics:metrics" hook', () => {
       expect(awsMetrics.hooks['metrics:metrics']).to.not.be.undefined;


### PR DESCRIPTION
This migrates the AWS operational and info helper tests away from direct Serverless provider setup. It keeps the focused SDK and output unit seams while moving the info display smoke coverage to the AWS SDK v3 stub map.