### PR TITLE
Migrate AWS provider helper tests

### DIFF
--- a/test/unit/lib/plugins/aws/config-credentials.test.js
+++ b/test/unit/lib/plugins/aws/config-credentials.test.js
@@ -8,7 +8,6 @@ const fsp = require('fs').promises;
 const os = require('os');
 const path = require('path');
 const AwsConfigCredentials = require('../../../../../lib/plugins/aws/config-credentials');
-const Serverless = require('../../../../../lib/serverless');
 const runServerless = require('../../../../utils/run-serverless');
 const { outputFile, outputFileSync, remove } = require('../../../../utils/fs');
 
@@ -16,7 +15,6 @@ const { expect } = chai;
 
 describe('AwsConfigCredentials', () => {
   let awsConfigCredentials;
-  let serverless;
   const homeDirPath = os.homedir();
   const awsDirectoryPath = path.join(homeDirPath, '.aws');
   const credentialsFilePath = path.join(awsDirectoryPath, 'credentials');
@@ -40,16 +38,13 @@ describe('AwsConfigCredentials', () => {
     );
   });
 
-  beforeEach(async () => {
-    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
-    return serverless.init().then(() => {
-      const options = {
-        provider: 'aws',
-        key: 'some-key',
-        secret: 'some-secret',
-      };
-      awsConfigCredentials = new AwsConfigCredentials(serverless, options);
-    });
+  beforeEach(() => {
+    const options = {
+      provider: 'aws',
+      key: 'some-key',
+      secret: 'some-secret',
+    };
+    awsConfigCredentials = new AwsConfigCredentials({}, options);
   });
 
   afterEach(() => remove(awsDirectoryPath));
@@ -99,7 +94,7 @@ describe('AwsConfigCredentials', () => {
     it('should throw an error if the home directory was not found', () => {
       sandbox.stub(os, 'homedir').returns(null);
       try {
-        expect(() => new AwsConfigCredentials(serverless, {})).to.throw(Error);
+        expect(() => new AwsConfigCredentials({}, {})).to.throw(Error);
       } finally {
         sandbox.restore();
       }

--- a/test/unit/lib/plugins/aws/custom-resources/index.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/index.test.js
@@ -2,9 +2,7 @@
 
 const chai = require('chai');
 const path = require('path');
-const AwsProvider = require('../../../../../../lib/plugins/aws/provider');
-const Serverless = require('../../../../../../lib/serverless');
-const CLI = require('../../../../../../lib/classes/cli');
+const awsNaming = require('../../../../../../lib/plugins/aws/lib/naming');
 const { createTmpDir, pathExists } = require('../../../../../utils/fs');
 const {
   addCustomResourceToService,
@@ -26,23 +24,35 @@ describe('#addCustomResourceToService()', () => {
     },
   ];
 
+  const createProviderContext = () => {
+    const serverless = {
+      serviceDir: tmpDirPath,
+      service: {
+        service: serviceName,
+        provider: {
+          compiledCloudFormationTemplate: { Resources: {} },
+        },
+        package: {
+          artifactDirectoryName: 'artifact-dir-name',
+        },
+      },
+    };
+    const provider = {
+      serverless,
+      naming: Object.create(awsNaming),
+      getStage: () => 'dev',
+      getRuntime: () => serverless.service.provider.runtime || 'nodejs24.x',
+      getCustomDeploymentRole: () => serverless.service.provider.iam?.deploymentRole,
+      getLogRetentionInDays: () => serverless.service.provider.logRetentionInDays,
+      getLogDataProtectionPolicy: () => serverless.service.provider.logDataProtectionPolicy,
+    };
+    provider.naming.provider = provider;
+    return { serverless, provider };
+  };
+
   beforeEach(() => {
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
     tmpDirPath = createTmpDir();
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.cli = new CLI();
-    serverless.pluginManager.cliOptions = options;
-    provider = new AwsProvider(serverless, options);
-    serverless.setProvider('aws', provider);
-    serverless.service.service = serviceName;
-    serverless.service.provider.compiledCloudFormationTemplate = {
-      Resources: {},
-    };
-    serverless.serviceDir = tmpDirPath;
-    serverless.service.package.artifactDirectoryName = 'artifact-dir-name';
+    ({ serverless, provider } = createProviderContext());
   });
 
   it('should add one IAM role and the custom resources to the service', async () => {

--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -21,6 +21,16 @@ const { STSClient, GetCallerIdentityCommand } = require('@aws-sdk/client-sts');
 const expect = chai.expect;
 const spawnModulePath = path.resolve(__dirname, '../../../../../lib/utils/spawn.js');
 
+const createProviderStub = ({ provider = {}, config = {}, providerOptions = {} } = {}) => {
+  const providerStub = Object.create(AwsProvider.prototype);
+  providerStub.options = { ...providerOptions };
+  providerStub.serverless = {
+    config,
+    service: { provider },
+  };
+  return providerStub;
+};
+
 describe('AwsProvider', () => {
   let awsProvider;
   let serverless;
@@ -30,11 +40,29 @@ describe('AwsProvider', () => {
     region: 'us-east-1',
   };
 
+  const createServerless = (serverlessOptions = {}) => {
+    const serverlessInstance = new Serverless({
+      ...options,
+      commands: [],
+      options: {},
+      ...serverlessOptions,
+    });
+    serverlessInstance.cli = new serverlessInstance.classes.CLI();
+    return serverlessInstance;
+  };
+
+  const createAwsProvider = ({ serverlessOptions, providerOptions = options } = {}) => {
+    const serverlessInstance = createServerless(serverlessOptions);
+    return {
+      serverless: serverlessInstance,
+      awsProvider: new AwsProvider(serverlessInstance, providerOptions),
+    };
+  };
+
   beforeEach(() => {
     ({ restoreEnv } = overrideEnv());
-    serverless = new Serverless({ ...options, commands: [], options: {} });
-    serverless.cli = new serverless.classes.CLI();
-    awsProvider = new AwsProvider(serverless, options);
+    awsProvider = createProviderStub({ providerOptions: options });
+    serverless = awsProvider.serverless;
   });
   afterEach(() => {
     if (CloudFormationClient.prototype.send.restore) {
@@ -144,12 +172,11 @@ describe('AwsProvider', () => {
 
   describe('runtime schema parity', () => {
     it('should keep `awsLambdaRuntime` in sync with `AwsLambdaRuntime`', () => {
-      const localServerless = new Serverless({ ...options, commands: [], options: {} });
+      const localServerless = createServerless();
       const runtimeTypePath = path.resolve(__dirname, '../../../../../types/index.d.ts');
       const runtimeTypeSource = fs.readFileSync(runtimeTypePath, 'utf8');
 
       localServerless.service.provider.name = 'aws';
-      localServerless.cli = new localServerless.classes.CLI();
       const localAwsProvider = new AwsProvider(localServerless, options);
       expect(localAwsProvider.serverless).to.equal(localServerless);
 
@@ -182,6 +209,10 @@ describe('AwsProvider', () => {
   });
 
   describe('#constructor()', () => {
+    beforeEach(() => {
+      ({ serverless, awsProvider } = createAwsProvider());
+    });
+
     it('should set Serverless instance', () => {
       expect(typeof awsProvider.serverless).to.not.equal('undefined');
     });
@@ -308,6 +339,10 @@ describe('AwsProvider', () => {
   });
 
   describe('#getAwsSdkV3Config()', () => {
+    beforeEach(() => {
+      ({ serverless, awsProvider } = createAwsProvider());
+    });
+
     it('returns SDK v3 config with explicit region and env credentials', async () => {
       process.env.AWS_ACCESS_KEY_ID = 'accessKeyId';
       process.env.AWS_SECRET_ACCESS_KEY = 'secretAccessKey';
@@ -557,6 +592,10 @@ describe('AwsProvider', () => {
   });
 
   describe('#getServerlessDeploymentBucketName()', () => {
+    beforeEach(() => {
+      ({ awsProvider } = createAwsProvider());
+    });
+
     it('should return the name of the serverless deployment bucket', async () => {
       const describeStackResourcesStub = sinon
         .stub(CloudFormationClient.prototype, 'send')
@@ -642,6 +681,10 @@ describe('AwsProvider', () => {
   });
 
   describe('#getStackResources()', () => {
+    beforeEach(() => {
+      ({ awsProvider } = createAwsProvider());
+    });
+
     it('paginates ListStackResources with one SDK v3 client', async () => {
       const getAwsSdkV3ConfigSpy = sinon.spy(awsProvider, 'getAwsSdkV3Config');
       const listStackResourcesStub = sinon
@@ -731,6 +774,10 @@ describe('AwsProvider', () => {
   });
 
   describe('#getAccountInfo()', () => {
+    beforeEach(() => {
+      ({ awsProvider } = createAwsProvider());
+    });
+
     it('defines memoized provider methods as lazy non-enumerable descriptors', () => {
       const protoDescriptor = Object.getOwnPropertyDescriptor(
         AwsProvider.prototype,
@@ -804,6 +851,10 @@ describe('AwsProvider', () => {
   });
 
   describe('#getAccountId()', () => {
+    beforeEach(() => {
+      ({ awsProvider } = createAwsProvider());
+    });
+
     it('should return the AWS account id', async () => {
       const accountId = '12345678';
 
@@ -1058,8 +1109,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
     });
 
     it('should reject invalid stage from provider options', () => {
-      const serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
-      const provider = new AwsProvider(serverless, { stage: 'foo/bar' });
+      const provider = createProviderStub({ providerOptions: { stage: 'foo/bar' } });
 
       expect(() => provider.getStage())
         .to.throw(ServerlessError)
@@ -1067,9 +1117,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
     });
 
     it('should reject invalid stage from serverless config', () => {
-      const serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
-      serverless.config.stage = 'feature.prod';
-      const provider = new AwsProvider(serverless, {});
+      const provider = createProviderStub({
+        config: { stage: 'feature.prod' },
+        providerOptions: {},
+      });
 
       expect(() => provider.getStage())
         .to.throw(ServerlessError)
@@ -1077,9 +1128,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
     });
 
     it('should reject invalid stage from service provider config', () => {
-      const serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
-      const provider = new AwsProvider(serverless, {});
-      serverless.service.provider.stage = 'my_stage';
+      const provider = createProviderStub({
+        provider: { stage: 'my_stage' },
+        providerOptions: {},
+      });
 
       expect(() => provider.getStage())
         .to.throw(ServerlessError)
@@ -1087,9 +1139,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
     });
 
     it('should reject empty CLI stage instead of falling back to provider stage', () => {
-      const serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
-      serverless.service.provider.stage = 'prod';
-      const provider = new AwsProvider(serverless, { stage: '' });
+      const provider = createProviderStub({
+        provider: { stage: 'prod' },
+        providerOptions: { stage: '' },
+      });
 
       expect(() => provider.getStage())
         .to.throw(ServerlessError)

--- a/test/unit/lib/plugins/aws/prune.test.js
+++ b/test/unit/lib/plugins/aws/prune.test.js
@@ -4,30 +4,40 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const { ListVersionsByFunctionCommand } = require('@aws-sdk/client-lambda');
 const AwsPrune = require('../../../../../lib/plugins/aws/prune');
-const AwsProvider = require('../../../../../lib/plugins/aws/provider');
-const Serverless = require('../../../../../lib/serverless');
 const ServerlessError = require('../../../../../lib/serverless-error');
-const CLI = require('../../../../../lib/classes/cli');
 
 describe('AwsPrune', () => {
   let serverless;
   let awsPrune;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.cli = new CLI(serverless);
-    serverless.service.provider = { name: 'aws', versionFunctions: true };
-    serverless.service.functions = {
-      FunctionA: { name: 'service-FunctionA' },
-      FunctionB: { name: 'service-FunctionB' },
-    };
-    serverless.service.layers = {
-      LayerA: { name: 'layer-LayerA' },
-    };
-    serverless.service.getAllLayers = () => Object.keys(serverless.service.layers);
-    serverless.service.getLayer = (key) => serverless.service.layers[key];
     const options = { stage: 'dev', region: 'us-east-1' };
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
+    const provider = { getAwsSdkV3Config: sinon.stub().resolves({}) };
+    serverless = {
+      service: {
+        provider: { name: 'aws', versionFunctions: true },
+        functions: {
+          FunctionA: { name: 'service-FunctionA' },
+          FunctionB: { name: 'service-FunctionB' },
+        },
+        layers: {
+          LayerA: { name: 'layer-LayerA' },
+        },
+        getAllFunctions() {
+          return Object.keys(this.functions);
+        },
+        getFunction(key) {
+          return this.functions[key];
+        },
+        getAllLayers() {
+          return Object.keys(this.layers);
+        },
+        getLayer(key) {
+          return this.layers[key];
+        },
+      },
+      getProvider: sinon.stub().withArgs('aws').returns(provider),
+    };
     awsPrune = new AwsPrune(serverless, options);
   });
 


### PR DESCRIPTION
This refactors the AWS provider, credentials, custom resource, and prune coverage away from unnecessary full framework setup. It keeps provider-specific constructor and SDK behavior on real provider instances while using focused fakes for pure helper behavior.