### PR TITLE
Migrate AWS common helper tests

### DIFF
--- a/test/unit/lib/plugins/aws/common/index.test.js
+++ b/test/unit/lib/plugins/aws/common/index.test.js
@@ -1,23 +1,25 @@
 'use strict';
 
-const AwsProvider = require('../../../../../../lib/plugins/aws/provider');
 const AwsCommon = require('../../../../../../lib/plugins/aws/common/index');
-const Serverless = require('../../../../../../lib/serverless');
 const expect = require('chai').expect;
 const sinon = require('sinon');
 
 describe('AwsCommon', () => {
   let awsCommon;
+  let provider;
+  let serverless;
+
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    provider = { name: 'aws' };
+    serverless = {
+      serviceDir: 'foo',
+      getProvider: sinon.stub().withArgs('aws').returns(provider),
+    };
     const options = {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    serverless.serviceDir = 'foo';
     awsCommon = new AwsCommon(serverless, options);
-    awsCommon.serverless.cli = new serverless.classes.CLI();
   });
 
   describe('#constructor()', () => {
@@ -25,8 +27,10 @@ describe('AwsCommon', () => {
 
     it('should have commands', () => expect(awsCommon.commands).to.be.not.empty);
 
-    it('should set the provider variable to an instance of AwsProvider', () =>
-      expect(awsCommon.provider).to.be.instanceof(AwsProvider));
+    it('should set the provider variable from the aws provider lookup', () => {
+      expect(serverless.getProvider).to.have.been.calledOnceWithExactly('aws');
+      expect(awsCommon.provider).to.equal(provider);
+    });
   });
 
   describe('hooks', () => {

--- a/test/unit/lib/plugins/aws/common/lib/artifacts.test.js
+++ b/test/unit/lib/plugins/aws/common/lib/artifacts.test.js
@@ -2,180 +2,280 @@
 
 const expect = require('chai').expect;
 const path = require('path');
-const AWSCommon = require('../../../../../../../lib/plugins/aws/common/index');
-const Serverless = require('../../../../../../../lib/serverless');
-const { getTmpDirPath, removeSync } = require('../../../../../../utils/fs');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
 
 describe('#moveArtifactsToPackage()', () => {
-  let serverless;
-  let awsCommon;
-  const moveBasePath = path.join(getTmpDirPath(), 'move');
-  const moveServerlessPath = path.join(moveBasePath, '.serverless');
+  let artifacts;
+  let removeSync;
+
+  const serviceDir = 'service';
+  const serverlessTmpDirPath = path.join(serviceDir, '.serverless');
+  const targetPath = path.join(serviceDir, 'target');
+
+  const createContext = ({
+    options = {},
+    servicePackage = {},
+    serviceDirValue = serviceDir,
+  } = {}) => {
+    const utils = {
+      dirExistsSync: sinon.stub(),
+      writeFileDir: sinon.stub(),
+      copyDirContentsSync: sinon.stub(),
+    };
+
+    return {
+      options,
+      serverless: {
+        serviceDir: serviceDirValue,
+        service: { package: servicePackage },
+        utils,
+      },
+      ...artifacts,
+    };
+  };
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    awsCommon = new AWSCommon(serverless, {});
-
-    serverless.serviceDir = moveBasePath;
-    if (!serverless.utils.dirExistsSync(moveServerlessPath)) {
-      serverless.utils.writeFileDir(moveServerlessPath);
-    }
+    removeSync = sinon.stub();
+    artifacts = proxyquire
+      .noCallThru()
+      .load('../../../../../../../lib/plugins/aws/common/lib/artifacts', {
+        '../../../../utils/fs/remove': { removeSync },
+      });
   });
 
-  afterEach(() => {
-    if (serverless.utils.dirExistsSync(moveBasePath)) {
-      removeSync(moveBasePath);
-    }
+  it('should resolve if servicePath is not present', async () => {
+    const context = createContext({ serviceDirValue: undefined });
+
+    await context.moveArtifactsToPackage();
+
+    expect(context.serverless.utils.dirExistsSync).to.not.have.been.called;
+    expect(removeSync).to.not.have.been.called;
   });
 
-  it('should resolve if servicePath is not present', () => {
-    delete serverless.serviceDir;
-    return awsCommon.moveArtifactsToPackage();
-  });
+  it('should resolve if no package is set', async () => {
+    const context = createContext();
 
-  it('should resolve if no package is set', () => awsCommon.moveArtifactsToPackage());
+    await context.moveArtifactsToPackage();
+
+    expect(context.serverless.utils.dirExistsSync).to.not.have.been.called;
+    expect(removeSync).to.not.have.been.called;
+  });
 
   it('should use package option as target', async () => {
-    const testFileSource = path.join(moveServerlessPath, 'moveTestFile.tmp');
-    const targetPath = path.join(moveBasePath, 'target');
+    const context = createContext({ options: { package: targetPath } });
+    context.serverless.utils.dirExistsSync.withArgs(serverlessTmpDirPath).returns(true);
+    context.serverless.utils.dirExistsSync.withArgs(targetPath).returns(false);
 
-    awsCommon.options.package = targetPath;
-    serverless.utils.writeFileSync(testFileSource, '!!!MOVE TEST FILE!!!');
-    return awsCommon.moveArtifactsToPackage().then(() => {
-      const testFileTarget = path.join(targetPath, 'moveTestFile.tmp');
+    await context.moveArtifactsToPackage();
 
-      expect(serverless.utils.dirExistsSync(targetPath)).to.be.equal(true);
-      expect(serverless.utils.fileExistsSync(testFileTarget)).to.be.equal(true);
-    });
+    expect(context.serverless.utils.writeFileDir).to.have.been.calledOnceWithExactly(targetPath);
+    expect(context.serverless.utils.copyDirContentsSync).to.have.been.calledOnceWithExactly(
+      serverlessTmpDirPath,
+      targetPath
+    );
+    expect(removeSync).to.have.been.calledOnceWithExactly(serverlessTmpDirPath);
+    expect(
+      context.serverless.utils.writeFileDir.calledBefore(
+        context.serverless.utils.copyDirContentsSync
+      )
+    ).to.equal(true);
+    expect(context.serverless.utils.copyDirContentsSync.calledBefore(removeSync)).to.equal(true);
   });
 
   it('should use service package path as target', async () => {
-    const testFileSource = path.join(moveServerlessPath, 'moveTestFile.tmp');
-    const targetPath = path.join(moveBasePath, 'target');
+    const context = createContext({ servicePackage: { path: targetPath } });
+    context.serverless.utils.dirExistsSync.withArgs(serverlessTmpDirPath).returns(true);
+    context.serverless.utils.dirExistsSync.withArgs(targetPath).returns(false);
 
-    serverless.service.package.path = targetPath;
-    serverless.utils.writeFileSync(testFileSource, '!!!MOVE TEST FILE!!!');
-    return awsCommon.moveArtifactsToPackage().then(() => {
-      const testFileTarget = path.join(targetPath, 'moveTestFile.tmp');
+    await context.moveArtifactsToPackage();
 
-      expect(serverless.utils.dirExistsSync(targetPath)).to.be.equal(true);
-      expect(serverless.utils.fileExistsSync(testFileTarget)).to.be.equal(true);
-    });
+    expect(context.serverless.utils.writeFileDir).to.have.been.calledOnceWithExactly(targetPath);
+    expect(context.serverless.utils.copyDirContentsSync).to.have.been.calledOnceWithExactly(
+      serverlessTmpDirPath,
+      targetPath
+    );
+    expect(removeSync).to.have.been.calledOnceWithExactly(serverlessTmpDirPath);
+    expect(
+      context.serverless.utils.writeFileDir.calledBefore(
+        context.serverless.utils.copyDirContentsSync
+      )
+    ).to.equal(true);
+    expect(context.serverless.utils.copyDirContentsSync.calledBefore(removeSync)).to.equal(true);
   });
 
   it('should not fail with non existing temp dir', async () => {
-    const targetPath = path.join(moveBasePath, 'target');
+    const context = createContext({ options: { package: targetPath } });
+    context.serverless.utils.dirExistsSync.withArgs(serverlessTmpDirPath).returns(false);
 
-    if (serverless.utils.dirExistsSync(moveServerlessPath)) {
-      removeSync(moveServerlessPath);
-    }
+    await context.moveArtifactsToPackage();
 
-    awsCommon.options.package = targetPath;
-    return awsCommon.moveArtifactsToPackage().then(() => {
-      expect(serverless.utils.dirExistsSync(targetPath)).to.be.equal(false);
-    });
+    expect(context.serverless.utils.writeFileDir).to.not.have.been.called;
+    expect(context.serverless.utils.copyDirContentsSync).to.not.have.been.called;
+    expect(removeSync).to.not.have.been.called;
   });
 
   it('should not fail with existing package dir', async () => {
-    const testFileSource = path.join(moveServerlessPath, 'moveTestFile.tmp');
-    const targetPath = path.join(moveBasePath, 'target');
-    const testFileTarget = path.join(targetPath, 'moveTestFile.tmp');
+    const context = createContext({ servicePackage: { path: targetPath } });
+    context.serverless.utils.dirExistsSync.withArgs(serverlessTmpDirPath).returns(true);
+    context.serverless.utils.dirExistsSync.withArgs(targetPath).returns(true);
 
-    if (!serverless.utils.dirExistsSync(targetPath)) {
-      serverless.utils.writeFileDir(targetPath);
-      serverless.utils.writeFileSync(testFileTarget, '!!!MOVE TEST FILE!!!');
-    }
+    await context.moveArtifactsToPackage();
 
-    serverless.service.package.path = targetPath;
-    serverless.utils.writeFileSync(testFileSource, '!!!MOVE TEST FILE!!!');
-    return awsCommon.moveArtifactsToPackage().then(() => {
-      expect(serverless.utils.dirExistsSync(targetPath)).to.be.equal(true);
-      expect(serverless.utils.fileExistsSync(testFileTarget)).to.be.equal(true);
-    });
+    expect(removeSync).to.have.been.calledTwice;
+    expect(removeSync.firstCall.args).to.deep.equal([targetPath]);
+    expect(removeSync.secondCall.args).to.deep.equal([serverlessTmpDirPath]);
+    expect(context.serverless.utils.writeFileDir).to.have.been.calledOnceWithExactly(targetPath);
+    expect(context.serverless.utils.copyDirContentsSync).to.have.been.calledOnceWithExactly(
+      serverlessTmpDirPath,
+      targetPath
+    );
+    expect(
+      removeSync.firstCall.calledBefore(context.serverless.utils.writeFileDir.firstCall)
+    ).to.equal(true);
+    expect(
+      context.serverless.utils.writeFileDir.firstCall.calledBefore(
+        context.serverless.utils.copyDirContentsSync.firstCall
+      )
+    ).to.equal(true);
+    expect(
+      context.serverless.utils.copyDirContentsSync.firstCall.calledBefore(removeSync.secondCall)
+    ).to.equal(true);
   });
 });
 
 describe('#moveArtifactsToTemp()', () => {
-  let serverless;
-  let awsCommon;
-  const moveBasePath = path.join(getTmpDirPath(), 'move');
-  const moveServerlessPath = path.join(moveBasePath, '.serverless');
-  const moveTargetPath = path.join(moveBasePath, 'target');
+  let artifacts;
+  let removeSync;
+
+  const serviceDir = 'service';
+  const serverlessTmpDirPath = path.join(serviceDir, '.serverless');
+  const sourcePath = path.join(serviceDir, 'target');
+
+  const createContext = ({
+    options = {},
+    servicePackage = {},
+    serviceDirValue = serviceDir,
+  } = {}) => {
+    const utils = {
+      dirExistsSync: sinon.stub(),
+      writeFileDir: sinon.stub(),
+      copyDirContentsSync: sinon.stub(),
+    };
+
+    return {
+      options,
+      serverless: {
+        serviceDir: serviceDirValue,
+        service: { package: servicePackage },
+        utils,
+      },
+      ...artifacts,
+    };
+  };
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    awsCommon = new AWSCommon(serverless, {});
-
-    serverless.serviceDir = moveBasePath;
-    if (!serverless.utils.dirExistsSync(moveTargetPath)) {
-      serverless.utils.writeFileDir(moveTargetPath);
-    }
+    removeSync = sinon.stub();
+    artifacts = proxyquire
+      .noCallThru()
+      .load('../../../../../../../lib/plugins/aws/common/lib/artifacts', {
+        '../../../../utils/fs/remove': { removeSync },
+      });
   });
 
-  afterEach(() => {
-    if (serverless.utils.dirExistsSync(moveBasePath)) {
-      removeSync(moveBasePath);
-    }
+  it('should resolve if servicePath is not present', async () => {
+    const context = createContext({ serviceDirValue: undefined });
+
+    await context.moveArtifactsToTemp();
+
+    expect(context.serverless.utils.dirExistsSync).to.not.have.been.called;
+    expect(removeSync).to.not.have.been.called;
   });
 
-  it('should resolve if servicePath is not present', () => {
-    delete serverless.serviceDir;
-    return awsCommon.moveArtifactsToTemp();
-  });
+  it('should resolve if no package is set', async () => {
+    const context = createContext();
 
-  it('should resolve if no package is set', () => awsCommon.moveArtifactsToTemp());
+    await context.moveArtifactsToTemp();
 
-  it('should use package option as source path', async () => {
-    const testFileSource = path.join(moveTargetPath, 'moveTestFile.tmp');
-
-    serverless.utils.writeFileSync(testFileSource, '!!!MOVE TEST FILE!!!');
-    awsCommon.options.package = moveTargetPath;
-    return awsCommon.moveArtifactsToTemp().then(() => {
-      const testFileTarget = path.join(moveServerlessPath, 'moveTestFile.tmp');
-
-      expect(serverless.utils.dirExistsSync(moveServerlessPath)).to.be.equal(true);
-      expect(serverless.utils.fileExistsSync(testFileTarget)).to.be.equal(true);
-    });
+    expect(context.serverless.utils.dirExistsSync).to.not.have.been.called;
+    expect(removeSync).to.not.have.been.called;
   });
 
   it('should use package option as source path', async () => {
-    const testFileSource = path.join(moveTargetPath, 'moveTestFile.tmp');
+    const context = createContext({ options: { package: sourcePath } });
+    context.serverless.utils.dirExistsSync.withArgs(sourcePath).returns(true);
+    context.serverless.utils.dirExistsSync.withArgs(serverlessTmpDirPath).returns(false);
 
-    serverless.utils.writeFileSync(testFileSource, '!!!MOVE TEST FILE!!!');
-    serverless.service.package.path = moveTargetPath;
-    return awsCommon.moveArtifactsToTemp().then(() => {
-      const testFileTarget = path.join(moveServerlessPath, 'moveTestFile.tmp');
+    await context.moveArtifactsToTemp();
 
-      expect(serverless.utils.dirExistsSync(moveServerlessPath)).to.be.equal(true);
-      expect(serverless.utils.fileExistsSync(testFileTarget)).to.be.equal(true);
-    });
+    expect(context.serverless.utils.writeFileDir).to.have.been.calledOnceWithExactly(
+      serverlessTmpDirPath
+    );
+    expect(context.serverless.utils.copyDirContentsSync).to.have.been.calledOnceWithExactly(
+      sourcePath,
+      serverlessTmpDirPath
+    );
+    expect(removeSync).to.not.have.been.called;
+    expect(
+      context.serverless.utils.writeFileDir.calledBefore(
+        context.serverless.utils.copyDirContentsSync
+      )
+    ).to.equal(true);
+  });
+
+  it('should use service package path as source path', async () => {
+    const context = createContext({ servicePackage: { path: sourcePath } });
+    context.serverless.utils.dirExistsSync.withArgs(sourcePath).returns(true);
+    context.serverless.utils.dirExistsSync.withArgs(serverlessTmpDirPath).returns(false);
+
+    await context.moveArtifactsToTemp();
+
+    expect(context.serverless.utils.writeFileDir).to.have.been.calledOnceWithExactly(
+      serverlessTmpDirPath
+    );
+    expect(context.serverless.utils.copyDirContentsSync).to.have.been.calledOnceWithExactly(
+      sourcePath,
+      serverlessTmpDirPath
+    );
+    expect(removeSync).to.not.have.been.called;
+    expect(
+      context.serverless.utils.writeFileDir.calledBefore(
+        context.serverless.utils.copyDirContentsSync
+      )
+    ).to.equal(true);
   });
 
   it('should not fail with non existing source path', async () => {
-    if (serverless.utils.dirExistsSync(moveTargetPath)) {
-      removeSync(moveTargetPath);
-    }
+    const context = createContext({ options: { package: sourcePath } });
+    context.serverless.utils.dirExistsSync.withArgs(sourcePath).returns(false);
 
-    awsCommon.options.package = moveTargetPath;
-    return awsCommon.moveArtifactsToTemp().then(() => {
-      expect(serverless.utils.dirExistsSync(moveTargetPath)).to.be.equal(false);
-    });
+    await context.moveArtifactsToTemp();
+
+    expect(context.serverless.utils.writeFileDir).to.not.have.been.called;
+    expect(context.serverless.utils.copyDirContentsSync).to.not.have.been.called;
+    expect(removeSync).to.not.have.been.called;
   });
 
   it('should not fail with existing temp dir', async () => {
-    const testFileSource = path.join(moveServerlessPath, 'moveTestFile.tmp');
-    const testFileTarget = path.join(moveTargetPath, 'moveTestFile.tmp');
+    const context = createContext({ servicePackage: { path: sourcePath } });
+    context.serverless.utils.dirExistsSync.withArgs(sourcePath).returns(true);
+    context.serverless.utils.dirExistsSync.withArgs(serverlessTmpDirPath).returns(true);
 
-    if (!serverless.utils.dirExistsSync(moveServerlessPath)) {
-      serverless.utils.writeFileDir(moveServerlessPath);
-      serverless.utils.writeFileSync(testFileSource, '!!!MOVE TEST FILE!!!');
-    }
+    await context.moveArtifactsToTemp();
 
-    serverless.service.package.path = moveTargetPath;
-    serverless.utils.writeFileSync(testFileTarget, '!!!MOVE TEST FILE!!!');
-    return awsCommon.moveArtifactsToTemp().then(() => {
-      expect(serverless.utils.dirExistsSync(moveServerlessPath)).to.be.equal(true);
-      expect(serverless.utils.fileExistsSync(testFileSource)).to.be.equal(true);
-    });
+    expect(removeSync).to.have.been.calledOnceWithExactly(serverlessTmpDirPath);
+    expect(context.serverless.utils.writeFileDir).to.have.been.calledOnceWithExactly(
+      serverlessTmpDirPath
+    );
+    expect(context.serverless.utils.copyDirContentsSync).to.have.been.calledOnceWithExactly(
+      sourcePath,
+      serverlessTmpDirPath
+    );
+    expect(removeSync.calledBefore(context.serverless.utils.writeFileDir)).to.equal(true);
+    expect(
+      context.serverless.utils.writeFileDir.calledBefore(
+        context.serverless.utils.copyDirContentsSync
+      )
+    ).to.equal(true);
   });
 });

--- a/test/unit/lib/plugins/aws/common/lib/cleanup-temp-dir.test.js
+++ b/test/unit/lib/plugins/aws/common/lib/cleanup-temp-dir.test.js
@@ -2,46 +2,57 @@
 
 const chai = require('chai');
 const path = require('path');
-const Package = require('../../../../../../../lib/plugins/aws/common/index');
-const Serverless = require('../../../../../../../lib/serverless');
-const { getTmpDirPath } = require('../../../../../../utils/fs');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
 
 const expect = chai.expect;
 
 describe('#cleanupTempDir()', () => {
-  let serverless;
-  let packageService;
+  let context;
+  let dirExistsSync;
+  let removeSync;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    packageService = new Package(serverless);
-
-    serverless.serviceDir = getTmpDirPath();
+    dirExistsSync = sinon.stub();
+    removeSync = sinon.stub();
+    const cleanupTempDir = proxyquire
+      .noCallThru()
+      .load('../../../../../../../lib/plugins/aws/common/lib/cleanup-temp-dir', {
+        '../../../../utils/fs/remove': { removeSync },
+      });
+    context = {
+      serverless: {
+        serviceDir: '/service',
+        utils: { dirExistsSync },
+      },
+      ...cleanupTempDir,
+    };
   });
 
   it('should remove .serverless in the service directory', async () => {
-    const serverlessTmpDirPath = path.join(
-      packageService.serverless.serviceDir,
-      '.serverless',
-      'README'
-    );
-    serverless.utils.writeFileSync(serverlessTmpDirPath, 'Some README content');
+    const serverlessTmpDirPath = path.join(context.serverless.serviceDir, '.serverless');
+    dirExistsSync.withArgs(serverlessTmpDirPath).returns(true);
 
-    return packageService.cleanupTempDir().then(() => {
-      expect(
-        serverless.utils.dirExistsSync(
-          path.join(packageService.serverless.serviceDir, '.serverless')
-        )
-      ).to.equal(false);
-    });
+    await context.cleanupTempDir();
+
+    expect(dirExistsSync).to.have.been.calledOnceWithExactly(serverlessTmpDirPath);
+    expect(removeSync).to.have.been.calledOnceWithExactly(serverlessTmpDirPath);
   });
 
   it('should resolve if servicePath is not present', async () => {
-    delete serverless.serviceDir;
-    return expect(packageService.cleanupTempDir()).to.eventually.be.fulfilled;
+    delete context.serverless.serviceDir;
+
+    await expect(context.cleanupTempDir()).to.eventually.be.fulfilled;
+
+    expect(dirExistsSync).to.not.have.been.called;
+    expect(removeSync).to.not.have.been.called;
   });
 
   it('should resolve if the .serverless directory is not present', async () => {
-    return expect(packageService.cleanupTempDir()).to.eventually.be.fulfilled;
+    dirExistsSync.returns(false);
+
+    await expect(context.cleanupTempDir()).to.eventually.be.fulfilled;
+
+    expect(removeSync).to.not.have.been.called;
   });
 });

--- a/test/unit/lib/plugins/aws/lib/get-service-state.test.js
+++ b/test/unit/lib/plugins/aws/lib/get-service-state.test.js
@@ -3,45 +3,44 @@
 const path = require('path');
 const chai = require('chai');
 const sinon = require('sinon');
-const Serverless = require('../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../lib/plugins/aws/provider');
 const getServiceState = require('../../../../../../lib/plugins/aws/lib/get-service-state');
 
 const expect = chai.expect;
 
 describe('#getServiceState()', () => {
-  let serverless;
+  let context;
   let readFileSyncStub;
-  const options = {};
-  const awsPlugin = {};
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.serviceDir = 'my-service';
-    awsPlugin.serverless = serverless;
-    awsPlugin.provider = new AwsProvider(serverless, options);
-    awsPlugin.options = options;
-    Object.assign(awsPlugin, getServiceState);
-
-    readFileSyncStub = sinon.stub(awsPlugin.serverless.utils, 'readFileSync').returns();
-  });
-
-  afterEach(() => {
-    awsPlugin.serverless.utils.readFileSync.restore();
+    readFileSyncStub = sinon.stub().returns();
+    context = {
+      options: {},
+      provider: {
+        naming: {
+          getServiceStateFileName: sinon.stub().returns('serverless-state.json'),
+        },
+      },
+      serverless: {
+        serviceDir: 'my-service',
+        utils: { readFileSync: readFileSyncStub },
+      },
+      ...getServiceState,
+    };
   });
 
   it('should use the default state file path if the "package" option is not used', () => {
     const stateFilePath = path.resolve('my-service', '.serverless', 'serverless-state.json');
-    awsPlugin.getServiceState();
+    context.getServiceState();
 
+    expect(context.provider.naming.getServiceStateFileName).to.have.been.calledOnceWithExactly();
     expect(readFileSyncStub).to.be.calledWithExactly(stateFilePath);
   });
 
   it('should use the argument-based state file path if the "package" option is used ', () => {
     const stateFilePath = path.resolve('my-service', 'some-package-path', 'serverless-state.json');
-    options.package = 'some-package-path';
+    context.options.package = 'some-package-path';
 
-    awsPlugin.getServiceState();
+    context.getServiceState();
     expect(readFileSyncStub).to.be.calledWithExactly(stateFilePath);
   });
 });

--- a/test/unit/lib/plugins/aws/lib/monitor-stack.test.js
+++ b/test/unit/lib/plugins/aws/lib/monitor-stack.test.js
@@ -3,9 +3,6 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
-const Serverless = require('../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../lib/plugins/aws/provider');
-const CLI = require('../../../../../../lib/classes/cli');
 const monitorStack = require('../../../../../../lib/plugins/aws/lib/monitor-stack');
 const {
   CloudFormationClient,
@@ -15,20 +12,27 @@ const {
 const { expect } = chai;
 
 describe('monitorStack', () => {
-  const serverless = new Serverless({ commands: [], options: {} });
-  const awsPlugin = {};
+  let awsPlugin;
+
+  const createAwsPlugin = ({ provider: providerOverrides = {}, options = {} } = {}) => {
+    const provider = {
+      getRegion: sinon.stub().returns('us-east-1'),
+      getAwsSdkV3Config: sinon.stub().resolves({
+        region: 'us-east-1',
+        credentials: async () => ({ accessKeyId: 'key', secretAccessKey: 'secret' }),
+      }),
+      ...providerOverrides,
+    };
+
+    return {
+      provider,
+      options: { ...options },
+      ...monitorStack,
+    };
+  };
 
   beforeEach(() => {
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
-    awsPlugin.serverless = serverless;
-    awsPlugin.provider = new AwsProvider(serverless, options);
-    awsPlugin.serverless.cli = new CLI(serverless);
-    awsPlugin.options = options;
-
-    Object.assign(awsPlugin, monitorStack);
+    awsPlugin = createAwsPlugin();
   });
 
   afterEach(() => {
@@ -201,26 +205,22 @@ describe('monitorStack', () => {
           },
         ],
       });
-      const getAwsSdkV3ConfigStub = sinon
-        .stub(awsPlugin.provider, 'getAwsSdkV3Config')
-        .throws(new Error('Expected existing CloudFormation client to be reused'));
+      awsPlugin.provider.getAwsSdkV3Config.throws(
+        new Error('Expected existing CloudFormation client to be reused')
+      );
       awsPlugin.cloudFormationClientPromise = Promise.resolve({ send });
 
-      try {
-        const stackStatus = await awsPlugin.monitorStack(
-          'create',
-          { StackId: 'stack-id' },
-          { frequency: 10 }
-        );
+      const stackStatus = await awsPlugin.monitorStack(
+        'create',
+        { StackId: 'stack-id' },
+        { frequency: 10 }
+      );
 
-        expect(stackStatus).to.equal('CREATE_COMPLETE');
-        expect(getAwsSdkV3ConfigStub).to.not.have.been.called;
-        expect(send).to.have.been.calledOnce;
-        expect(send.firstCall.args[0]).to.be.instanceOf(DescribeStackEventsCommand);
-        expect(send.firstCall.args[0].input).to.deep.equal({ StackName: 'stack-id' });
-      } finally {
-        getAwsSdkV3ConfigStub.restore();
-      }
+      expect(stackStatus).to.equal('CREATE_COMPLETE');
+      expect(awsPlugin.provider.getAwsSdkV3Config).to.not.have.been.called;
+      expect(send).to.have.been.calledOnce;
+      expect(send.firstCall.args[0]).to.be.instanceOf(DescribeStackEventsCommand);
+      expect(send.firstCall.args[0].input).to.deep.equal({ StackName: 'stack-id' });
     });
 
     it('should keep monitoring until CREATE_COMPLETE stack status', async () => {

--- a/test/unit/lib/plugins/aws/lib/naming.test.js
+++ b/test/unit/lib/plugins/aws/lib/naming.test.js
@@ -2,8 +2,10 @@
 
 const expect = require('chai').expect;
 
-const SDK = require('../../../../../../lib/plugins/aws/provider');
-const Serverless = require('../../../../../../lib/serverless');
+const awsNaming = require('../../../../../../lib/plugins/aws/lib/naming');
+const validateStage = require('../../../../../../lib/utils/validate-stage');
+
+const hasOwn = (object, key) => Object.prototype.hasOwnProperty.call(object, key);
 
 const setByPath = (source, path, value) => {
   let current = source;
@@ -21,19 +23,58 @@ const setByPath = (source, path, value) => {
 };
 
 describe('#naming()', () => {
-  let options;
   let serverless;
   let sdk;
 
-  beforeEach(() => {
-    options = {
+  const createNamingContext = () => {
+    const localOptions = {
       stage: 'dev',
       region: 'us-east-1',
-      commands: [],
-      options: {},
     };
-    serverless = new Serverless(options);
-    sdk = new SDK(serverless, options);
+    const localServerless = {
+      config: {},
+      service: {
+        service: undefined,
+        serviceObject: {},
+        provider: {},
+        getServiceName() {
+          return this.serviceObject.name;
+        },
+      },
+    };
+    const provider = {
+      options: localOptions,
+      serverless: localServerless,
+      getStageSourceValue() {
+        if (hasOwn(this.options, 'stage')) return { value: this.options.stage };
+        if (hasOwn(this.serverless.config, 'stage')) return { value: this.serverless.config.stage };
+        if (hasOwn(this.serverless.service.provider, 'stage')) {
+          return { value: this.serverless.service.provider.stage };
+        }
+        return {};
+      },
+      getStage() {
+        const stageSourceValue = this.getStageSourceValue();
+        return validateStage(hasOwn(stageSourceValue, 'value') ? stageSourceValue.value : 'dev');
+      },
+      getAlbTargetGroupPrefix() {
+        return this.serverless.service.provider.alb?.targetGroupPrefix || '';
+      },
+    };
+    const naming = Object.create(awsNaming);
+    naming.provider = provider;
+
+    return {
+      serverless: localServerless,
+      sdk: {
+        options: localOptions,
+        naming,
+      },
+    };
+  };
+
+  beforeEach(() => {
+    ({ serverless, sdk } = createNamingContext());
   });
 
   describe('#normalizeName()', () => {

--- a/test/unit/lib/plugins/aws/lib/set-bucket-name.test.js
+++ b/test/unit/lib/plugins/aws/lib/set-bucket-name.test.js
@@ -2,44 +2,36 @@
 
 const expect = require('chai').expect;
 const sinon = require('sinon');
-const AwsProvider = require('../../../../../../lib/plugins/aws/provider');
-const AwsDeploy = require('../../../../../../lib/plugins/aws/deploy/index');
-const Serverless = require('../../../../../../lib/serverless');
+const setBucketName = require('../../../../../../lib/plugins/aws/lib/set-bucket-name');
 
 describe('#setBucketName()', () => {
-  let serverless;
-  let awsDeploy;
+  let context;
   let getServerlessDeploymentBucketNameStub;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.serviceDir = 'foo';
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
+    getServerlessDeploymentBucketNameStub = sinon.stub().resolves('bucket-name');
+    context = {
+      provider: {
+        getServerlessDeploymentBucketName: getServerlessDeploymentBucketNameStub,
+      },
+      ...setBucketName,
     };
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    awsDeploy = new AwsDeploy(serverless, options);
-
-    getServerlessDeploymentBucketNameStub = sinon
-      .stub(awsDeploy.provider, 'getServerlessDeploymentBucketName')
-      .resolves('bucket-name');
   });
 
-  it('should store the name of the Serverless deployment bucket', async () =>
-    awsDeploy.setBucketName().then(() => {
-      expect(awsDeploy.bucketName).to.equal('bucket-name');
-      expect(getServerlessDeploymentBucketNameStub.calledOnce).to.be.equal(true);
-      expect(getServerlessDeploymentBucketNameStub.calledWithExactly()).to.be.equal(true);
-      awsDeploy.provider.getServerlessDeploymentBucketName.restore();
-    }));
+  it('should store the name of the Serverless deployment bucket', async () => {
+    await context.setBucketName();
+
+    expect(context.bucketName).to.equal('bucket-name');
+    expect(getServerlessDeploymentBucketNameStub).to.have.been.calledOnceWithExactly();
+  });
 
   it('should resolve if the bucketName is already set', async () => {
     const bucketName = 'someBucket';
-    awsDeploy.bucketName = bucketName;
-    return awsDeploy
-      .setBucketName()
-      .then(() => expect(getServerlessDeploymentBucketNameStub.calledOnce).to.be.false)
-      .then(() => expect(awsDeploy.bucketName).to.equal(bucketName));
+    context.bucketName = bucketName;
+
+    await expect(context.setBucketName()).to.eventually.equal(bucketName);
+
+    expect(getServerlessDeploymentBucketNameStub).to.not.have.been.called;
+    expect(context.bucketName).to.equal(bucketName);
   });
 });


### PR DESCRIPTION
This refactors the AWS common and helper coverage away from unnecessary framework construction. It keeps polling and SDK seam coverage focused on provider-shaped fakes while exercising pure helper behavior through direct mixin contexts.