### PR TITLE
Migrate AWS package and deploy helper tests

### DIFF
--- a/test/unit/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.test.js
@@ -4,9 +4,7 @@ const sinon = require('sinon');
 const chai = require('chai');
 const proxyquire = require('proxyquire');
 const { S3Client, ListObjectsV2Command, DeleteObjectsCommand } = require('@aws-sdk/client-s3');
-const AwsProvider = require('../../../../../../../lib/plugins/aws/provider');
-const AwsDeploy = require('../../../../../../../lib/plugins/aws/deploy/index');
-const Serverless = require('../../../../../../../lib/serverless');
+const cleanupS3BucketMixin = require('../../../../../../../lib/plugins/aws/deploy/lib/cleanup-s3-bucket');
 
 const expect = chai.expect;
 
@@ -16,23 +14,37 @@ describe('cleanupS3Bucket', () => {
   let awsDeploy;
   let s3Key;
   let s3SendStub;
+  let sandbox;
+
+  const serviceName = 'cleanupS3Bucket';
+  const stage = 'dev';
+  const deploymentPrefix = 'serverless';
 
   beforeEach(() => {
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
+    sandbox = sinon.createSandbox();
+    serverless = {
+      service: {
+        service: serviceName,
+        provider: {},
+        package: {},
+      },
     };
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.serviceDir = 'foo';
-    provider = new AwsProvider(serverless, options);
-    serverless.setProvider('aws', provider);
-    serverless.service.service = 'cleanupS3Bucket';
-    const prefix = provider.getDeploymentPrefix();
-    s3Key = `${prefix}/${serverless.service.service}/${provider.getStage()}`;
-    awsDeploy = new AwsDeploy(serverless, options);
-    awsDeploy.bucketName = 'deployment-bucket';
-    awsDeploy.serverless.cli = new serverless.classes.CLI();
-    s3SendStub = sinon.stub(S3Client.prototype, 'send');
+    provider = {
+      getAwsSdkV3Config: async () => ({ region: 'us-east-1' }),
+      getDeploymentPrefix: () => deploymentPrefix,
+      getStage: () => stage,
+      naming: {
+        getServiceStateFileName: () => 'serverless-state.json',
+      },
+    };
+    s3Key = `${deploymentPrefix}/${serviceName}/${stage}`;
+    awsDeploy = {
+      ...cleanupS3BucketMixin,
+      bucketName: 'deployment-bucket',
+      provider,
+      serverless,
+    };
+    s3SendStub = sandbox.stub(S3Client.prototype, 'send');
   });
 
   const createSignatureMismatchListError = () => {
@@ -68,7 +80,7 @@ describe('cleanupS3Bucket', () => {
   };
 
   afterEach(() => {
-    if (S3Client.prototype.send.restore) S3Client.prototype.send.restore();
+    sandbox.restore();
   });
 
   function expectListObjectsCall(call, input) {
@@ -108,7 +120,7 @@ describe('cleanupS3Bucket', () => {
         throw new Error(`Unexpected S3 command ${command.constructor.name}`);
       }
     }
-    const cleanupS3Bucket = proxyquire(
+    const cleanupS3BucketWithFakeS3 = proxyquire(
       '../../../../../../../lib/plugins/aws/deploy/lib/cleanup-s3-bucket',
       {
         '@aws-sdk/client-s3': {
@@ -120,7 +132,7 @@ describe('cleanupS3Bucket', () => {
         },
       }
     );
-    Object.assign(awsDeploy, cleanupS3Bucket);
+    Object.assign(awsDeploy, cleanupS3BucketWithFakeS3);
 
     const objectsToRemove = await awsDeploy.getObjectsToRemove();
     await awsDeploy.removeObjects(objectsToRemove);

--- a/test/unit/lib/plugins/aws/deploy/lib/extended-validate.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/extended-validate.test.js
@@ -2,20 +2,17 @@
 
 const chai = require('chai');
 const sinon = require('sinon');
-const path = require('path');
-const AwsProvider = require('../../../../../../../lib/plugins/aws/provider');
-const AwsDeploy = require('../../../../../../../lib/plugins/aws/deploy/index');
-const Serverless = require('../../../../../../../lib/serverless');
-const { getTmpDirPath } = require('../../../../../../utils/fs');
+const extendedValidate = require('../../../../../../../lib/plugins/aws/deploy/lib/extended-validate');
 
 const expect = chai.expect;
 
 describe('extendedValidate', () => {
   let awsDeploy;
-  const tmpDirPath = getTmpDirPath();
+  let fileExistsSyncStub;
+  let readFileSyncStub;
+  let stateFileMock;
 
-  const serverlessYmlPath = path.join(tmpDirPath, 'serverless.yml');
-  const serverlessYml = {
+  const createServiceConfig = () => ({
     service: 'first-service',
     provider: 'aws',
     functions: {
@@ -23,47 +20,66 @@ describe('extendedValidate', () => {
         handler: 'sample.handler',
       },
     },
-  };
-  const stateFileMock = {
-    service: serverlessYml,
+  });
+
+  const createStateFile = () => ({
+    service: createServiceConfig(),
     package: {
       individually: true,
       artifactDirectoryName: 'some/path',
       artifact: '',
     },
+  });
+
+  const createAwsDeploy = () => {
+    const service = {
+      service: 'first-service',
+      provider: {},
+      package: {
+        individually: false,
+      },
+      functions: {
+        first: {
+          handler: 'sample.handler',
+        },
+      },
+      getAllFunctions() {
+        return Object.keys(this.functions);
+      },
+      getFunction(functionName) {
+        return this.functions[functionName];
+      },
+    };
+
+    return {
+      ...extendedValidate,
+      packagePath: 'package-path',
+      provider: {
+        naming: {
+          getServiceStateFileName: () => 'service-state.json',
+          getServiceArtifactName: () => 'service.zip',
+          getFunctionArtifactName: (functionName) => `${functionName}.zip`,
+        },
+      },
+      serverless: {
+        serviceDir: 'service-dir',
+        service,
+        utils: {
+          fileExistsSync: sinon.stub(),
+          readFileSync: sinon.stub(),
+        },
+      },
+    };
   };
 
   beforeEach(() => {
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    serverless.utils.writeFileSync(serverlessYmlPath, serverlessYml);
-    serverless.serviceDir = tmpDirPath;
-    awsDeploy = new AwsDeploy(serverless, options);
-    awsDeploy.serverless.service.service = `service-${new Date().getTime().toString()}`;
-    awsDeploy.serverless.cli = {
-      log: sinon.spy(),
-    };
+    awsDeploy = createAwsDeploy();
+    stateFileMock = createStateFile();
+    fileExistsSyncStub = awsDeploy.serverless.utils.fileExistsSync;
+    readFileSyncStub = awsDeploy.serverless.utils.readFileSync;
   });
 
   describe('extendedValidate()', () => {
-    let fileExistsSyncStub;
-    let readFileSyncStub;
-
-    beforeEach(() => {
-      fileExistsSyncStub = sinon.stub(awsDeploy.serverless.utils, 'fileExistsSync');
-      readFileSyncStub = sinon.stub(awsDeploy.serverless.utils, 'readFileSync');
-      awsDeploy.serverless.service.package.individually = false;
-    });
-
-    afterEach(() => {
-      fileExistsSyncStub.restore();
-      readFileSyncStub.restore();
-    });
-
     it('should throw error if state file does not exist', async () => {
       fileExistsSyncStub.returns(false);
 
@@ -142,27 +158,23 @@ describe('extendedValidate', () => {
     });
 
     it('should throw error if specified package artifact does not exist', async () => {
-      // const fileExistsSyncStub = sinon.stub(awsDeploy.serverless.utils, 'fileExistsSync');
       fileExistsSyncStub.onCall(0).returns(true);
       fileExistsSyncStub.onCall(1).returns(false);
       readFileSyncStub.returns(stateFileMock);
       awsDeploy.serverless.service.package.artifact = 'some/file.zip';
       await expect(awsDeploy.extendedValidate()).to.eventually.be.rejectedWith(Error);
-      delete awsDeploy.serverless.service.package.artifact;
     });
 
     it('should not throw error if specified package artifact exists', async () => {
-      // const fileExistsSyncStub = sinon.stub(awsDeploy.serverless.utils, 'fileExistsSync');
       fileExistsSyncStub.onCall(0).returns(true);
       fileExistsSyncStub.onCall(1).returns(true);
       readFileSyncStub.returns(stateFileMock);
       awsDeploy.serverless.service.package.artifact = 'some/file.zip';
       await awsDeploy.extendedValidate();
-      delete awsDeploy.serverless.service.package.artifact;
     });
 
     it('restores persisted service state without mutating the service prototype', async () => {
-      const restoredService = JSON.parse(JSON.stringify(serverlessYml));
+      const restoredService = createServiceConfig();
       restoredService.functions = {};
       Object.defineProperty(restoredService, '__proto__', {
         value: { polluted: true },

--- a/test/unit/lib/plugins/aws/deploy/lib/validate-template.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/validate-template.test.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const sinon = require('sinon');
-const AwsProvider = require('../../../../../../../lib/plugins/aws/provider');
-const AwsDeploy = require('../../../../../../../lib/plugins/aws/deploy/index');
-const Serverless = require('../../../../../../../lib/serverless');
+const validateTemplate = require('../../../../../../../lib/plugins/aws/deploy/lib/validate-template');
 const { CloudFormationClient, ValidateTemplateCommand } = require('@aws-sdk/client-cloudformation');
 
 // Configure chai
@@ -11,30 +9,34 @@ const expect = require('chai').expect;
 
 describe('validateTemplate', () => {
   let awsDeploy;
-  let serverless;
   let validateTemplateStub;
+  let sandbox;
 
   beforeEach(() => {
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-    };
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.serviceDir = 'foo';
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    awsDeploy = new AwsDeploy(serverless, options);
-    awsDeploy.bucketName = 'deployment-bucket';
-    awsDeploy.serverless.service.package.artifactDirectoryName = 'somedir';
-    awsDeploy.serverless.service.functions = {
-      first: {
-        handler: 'foo',
+    sandbox = sinon.createSandbox();
+    awsDeploy = {
+      ...validateTemplate,
+      bucketName: 'deployment-bucket',
+      provider: {
+        getAwsSdkV3Config: async () => ({ region: 'us-east-1' }),
+        getRegion: () => 'us-east-1',
+        naming: {
+          getCompiledTemplateS3Suffix: () => 'compiled-cloudformation-template.json',
+        },
+      },
+      serverless: {
+        service: {
+          package: {
+            artifactDirectoryName: 'somedir',
+          },
+        },
       },
     };
-    validateTemplateStub = sinon.stub(CloudFormationClient.prototype, 'send');
+    validateTemplateStub = sandbox.stub(CloudFormationClient.prototype, 'send');
   });
 
   afterEach(() => {
-    CloudFormationClient.prototype.send.restore();
+    sandbox.restore();
   });
 
   describe('#validateTemplate()', () => {
@@ -52,24 +54,20 @@ describe('validateTemplate', () => {
 
     it('uses an existing CloudFormation client promise from the plugin context', async () => {
       const send = sinon.stub().resolves();
-      sinon
+      const getAwsSdkV3ConfigStub = sandbox
         .stub(awsDeploy.provider, 'getAwsSdkV3Config')
         .throws(new Error('Expected existing CloudFormation client to be reused'));
       awsDeploy.cloudFormationClientPromise = Promise.resolve({ send });
 
-      try {
-        await awsDeploy.validateTemplate();
+      await awsDeploy.validateTemplate();
 
-        expect(awsDeploy.provider.getAwsSdkV3Config).to.not.have.been.called;
-        expect(send).to.have.been.calledOnce;
-        expect(send.firstCall.args[0]).to.be.instanceOf(ValidateTemplateCommand);
-        expect(send.firstCall.args[0].input).to.deep.equal({
-          TemplateURL:
-            'https://s3.amazonaws.com/deployment-bucket/somedir/compiled-cloudformation-template.json',
-        });
-      } finally {
-        awsDeploy.provider.getAwsSdkV3Config.restore();
-      }
+      expect(getAwsSdkV3ConfigStub).to.not.have.been.called;
+      expect(send).to.have.been.calledOnce;
+      expect(send.firstCall.args[0]).to.be.instanceOf(ValidateTemplateCommand);
+      expect(send.firstCall.args[0].input).to.deep.equal({
+        TemplateURL:
+          'https://s3.amazonaws.com/deployment-bucket/somedir/compiled-cloudformation-template.json',
+      });
     });
 
     it('should throw an error if the CloudFormation template is invalid', async () => {

--- a/test/unit/lib/plugins/aws/package/index.test.js
+++ b/test/unit/lib/plugins/aws/package/index.test.js
@@ -1,9 +1,6 @@
 'use strict';
 
-const AwsProvider = require('../../../../../../lib/plugins/aws/provider');
 const AwsPackage = require('../../../../../../lib/plugins/aws/package/index');
-const Serverless = require('../../../../../../lib/serverless');
-const CLI = require('../../../../../../lib/classes/cli');
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const path = require('path');
@@ -12,16 +9,38 @@ describe('AwsPackage', () => {
   let awsPackage;
   let serverless;
   let options;
+  let provider;
+
+  const createProvider = () => ({
+    getDeploymentPrefix: () => 'serverless',
+    getStage: () => 'dev',
+    getRegion: () => 'us-east-1',
+  });
+
+  const createServerless = () => ({
+    serviceDir: 'foo',
+    service: {
+      service: 'service',
+      provider: {},
+      package: {},
+    },
+    processedInput: {
+      commands: [],
+    },
+    pluginManager: {
+      commandRunStartTime: Date.now(),
+      spawn() {},
+    },
+    getProvider: sinon.stub().withArgs('aws').returns(provider),
+  });
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
     options = {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    serverless.serviceDir = 'foo';
-    serverless.cli = new CLI(serverless);
+    provider = createProvider();
+    serverless = createServerless();
     awsPackage = new AwsPackage(serverless, options);
   });
 
@@ -67,8 +86,10 @@ describe('AwsPackage', () => {
       expect(awsPackage.packagePath).to.equal(path.join('foo', '.serverless'));
     });
 
-    it('should set the provider variable to an instance of AwsProvider', () =>
-      expect(awsPackage.provider).to.be.instanceof(AwsProvider));
+    it('should set the provider variable to the AWS provider', () => {
+      expect(awsPackage.provider).to.equal(provider);
+      expect(serverless.getProvider).to.have.been.calledWithExactly('aws');
+    });
 
     it('should have commands', () => expect(awsPackage.commands).to.be.not.empty);
 

--- a/test/unit/lib/plugins/aws/package/lib/generate-artifact-directory-name.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/generate-artifact-directory-name.test.js
@@ -1,27 +1,31 @@
 'use strict';
 
 const expect = require('chai').expect;
-const AwsPackage = require('../../../../../../../lib/plugins/aws/package/index');
-const AwsProvider = require('../../../../../../../lib/plugins/aws/provider');
-const Serverless = require('../../../../../../../lib/serverless');
+const generateArtifactDirectoryName = require('../../../../../../../lib/plugins/aws/package/lib/generate-artifact-directory-name');
 
 describe('#generateArtifactDirectoryName()', () => {
-  let serverless;
   let awsPackage;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
+    awsPackage = {
+      ...generateArtifactDirectoryName,
+      provider: {
+        getDeploymentPrefix: () => 'serverless',
+        getStage: () => 'dev',
+      },
+      serverless: {
+        service: {
+          service: 'service',
+          package: {},
+        },
+      },
     };
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    awsPackage = new AwsPackage(serverless, options);
-    awsPackage.serverless.cli = new serverless.classes.CLI();
   });
 
   it('should generate a name for the artifact directory based on the current time', () => {
     awsPackage.generateArtifactDirectoryName();
-    expect(awsPackage.serverless.service.package.artifactDirectoryName).to.match(/[0-9]+-.+/);
+    expect(awsPackage.serverless.service.package.artifactDirectoryName).to.match(
+      /^serverless\/service\/dev\/[0-9]+-.+/
+    );
   });
 });

--- a/test/unit/lib/plugins/aws/package/lib/merge-custom-provider-resources.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/merge-custom-provider-resources.test.js
@@ -1,30 +1,28 @@
 'use strict';
 
-const path = require('path');
 const expect = require('chai').expect;
-const AwsPackage = require('../../../../../../../lib/plugins/aws/package/index');
-const Serverless = require('../../../../../../../lib/serverless');
+const mergeCustomProviderResources = require('../../../../../../../lib/plugins/aws/package/lib/merge-custom-provider-resources');
+const coreCloudFormationTemplateSource = require('../../../../../../../lib/plugins/aws/package/lib/core-cloudformation-template.json');
 const ServerlessError = require('../../../../../../../lib/serverless-error');
 const runServerless = require('../../../../../../utils/run-serverless');
 
 describe('mergeCustomProviderResources', () => {
-  let serverless;
   let awsPackage;
   let coreCloudFormationTemplate;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    awsPackage = new AwsPackage(serverless, {});
-
-    coreCloudFormationTemplate = awsPackage.serverless.utils.readFileSync(
-      path.resolve(
-        __dirname,
-        '../../../../../../../lib/plugins/aws/package/lib/core-cloudformation-template.json'
-      )
-    );
-
-    awsPackage.serverless.service.provider.compiledCloudFormationTemplate =
-      coreCloudFormationTemplate;
+    coreCloudFormationTemplate = JSON.parse(JSON.stringify(coreCloudFormationTemplateSource));
+    awsPackage = {
+      ...mergeCustomProviderResources,
+      serverless: {
+        service: {
+          provider: {
+            compiledCloudFormationTemplate: coreCloudFormationTemplate,
+          },
+          resources: {},
+        },
+      },
+    };
   });
 
   describe('#mergeCustomProviderResources()', () => {

--- a/test/unit/lib/plugins/aws/package/lib/save-service-state.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/save-service-state.test.js
@@ -3,41 +3,40 @@
 const expect = require('chai').expect;
 const sinon = require('sinon');
 const path = require('path');
-const AwsPackage = require('../../../../../../../lib/plugins/aws/package/index');
-const Serverless = require('../../../../../../../lib/serverless');
-const AwsProvider = require('../../../../../../../lib/plugins/aws/provider');
+const saveServiceState = require('../../../../../../../lib/plugins/aws/package/lib/save-service-state');
 
 describe('#saveServiceState()', () => {
-  let serverless;
   let awsPackage;
   let getServiceStateFileNameStub;
   let writeFileSyncStub;
 
   beforeEach(() => {
-    const options = {};
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.setProvider('aws', new AwsProvider(serverless, options));
-    awsPackage = new AwsPackage(serverless, options);
-    serverless.serviceDir = 'my-service';
-    serverless.service = {
+    getServiceStateFileNameStub = sinon.stub().returns('service-state.json');
+    writeFileSyncStub = sinon.stub();
+    awsPackage = {
+      ...saveServiceState,
       provider: {
-        compiledCloudFormationTemplate: 'compiled content',
+        naming: {
+          getServiceStateFileName: getServiceStateFileNameStub,
+        },
       },
-      package: {
-        individually: false,
-        artifactDirectoryName: 'artifact-directory',
-        artifact: 'service.zip',
+      serverless: {
+        serviceDir: 'my-service',
+        service: {
+          provider: {
+            compiledCloudFormationTemplate: 'compiled content',
+          },
+          package: {
+            individually: false,
+            artifactDirectoryName: 'artifact-directory',
+            artifact: 'service.zip',
+          },
+        },
+        utils: {
+          writeFileSync: writeFileSyncStub,
+        },
       },
     };
-    getServiceStateFileNameStub = sinon
-      .stub(awsPackage.provider.naming, 'getServiceStateFileName')
-      .returns('service-state.json');
-    writeFileSyncStub = sinon.stub(awsPackage.serverless.utils, 'writeFileSync').returns();
-  });
-
-  afterEach(() => {
-    awsPackage.provider.naming.getServiceStateFileName.restore();
-    awsPackage.serverless.utils.writeFileSync.restore();
   });
 
   it('should write the service state file template to disk', async () => {


### PR DESCRIPTION
This refactors AWS package and deploy helper coverage away from unnecessary framework construction. It uses focused provider and service fakes for helper behavior while preserving the package-visible custom resource integration.