### PR TITLE
Modernize AWS stub-map test callers

### DIFF
--- a/test/unit/lib/plugins/aws/package/lib/generate-core-template.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/generate-core-template.test.js
@@ -4,6 +4,17 @@ const runServerless = require('../../../../../../utils/run-serverless');
 const expect = require('chai').expect;
 
 describe('#generateCoreTemplate()', () => {
+  const awsSdkV3StubMap = {
+    STS: {
+      getCallerIdentity: {
+        ResponseMetadata: { RequestId: 'ffffffff-ffff-ffff-ffff-ffffffffffff' },
+        UserId: 'XXXXXXXXXXXXXXXXXXXXX',
+        Account: '1234567890',
+        Arn: 'arn:aws:iam::1234567890:user/test',
+      },
+    },
+  };
+
   it('should reject non-HTTPS requests to the deployment bucket', async () =>
     runServerless({
       config: { service: 'irrelevant', provider: 'aws' },
@@ -144,17 +155,7 @@ describe('#generateCoreTemplate()', () => {
             deploymentBucket: bucketName,
           },
         },
-        awsRequestStubMap: {
-          S3: { getBucketLocation: { LocationConstraint: '' } },
-          STS: {
-            getCallerIdentity: {
-              ResponseMetadata: { RequestId: 'ffffffff-ffff-ffff-ffff-ffffffffffff' },
-              UserId: 'XXXXXXXXXXXXXXXXXXXXX',
-              Account: '1234567890',
-              Arn: 'arn:aws:iam::1234567890:user/test',
-            },
-          },
-        },
+        awsSdkV3StubMap,
         command: 'deploy',
         options: { 'aws-s3-accelerate': true },
         lastLifecycleHookName: 'before:deploy:deploy',
@@ -192,16 +193,7 @@ describe('#generateCoreTemplate()', () => {
       command: 'deploy',
       options: { 'aws-s3-accelerate': true },
       lastLifecycleHookName: 'before:deploy:deploy',
-      awsRequestStubMap: {
-        STS: {
-          getCallerIdentity: {
-            ResponseMetadata: { RequestId: 'ffffffff-ffff-ffff-ffff-ffffffffffff' },
-            UserId: 'XXXXXXXXXXXXXXXXXXXXX',
-            Account: '1234567890',
-            Arn: 'arn:aws:iam::1234567890:user/test',
-          },
-        },
-      },
+      awsSdkV3StubMap,
     }).then(({ cfTemplate: template }) => {
       expect(template.Outputs.ServerlessDeploymentBucketAccelerated).to.not.equal(null);
       expect(template.Outputs.ServerlessDeploymentBucketAccelerated.Value).to.equal(true);
@@ -213,16 +205,7 @@ describe('#generateCoreTemplate()', () => {
       command: 'deploy',
       options: { 'aws-s3-accelerate': false },
       lastLifecycleHookName: 'before:deploy:deploy',
-      awsRequestStubMap: {
-        STS: {
-          getCallerIdentity: {
-            ResponseMetadata: { RequestId: 'ffffffff-ffff-ffff-ffff-ffffffffffff' },
-            UserId: 'XXXXXXXXXXXXXXXXXXXXX',
-            Account: '1234567890',
-            Arn: 'arn:aws:iam::1234567890:user/test',
-          },
-        },
-      },
+      awsSdkV3StubMap,
     }).then(({ cfTemplate: template }) => {
       expect(template.Resources.ServerlessDeploymentBucket).to.be.deep.equal({
         Type: 'AWS::S3::Bucket',
@@ -247,16 +230,7 @@ describe('#generateCoreTemplate()', () => {
     runServerless({
       config: { service: 'irrelevant', provider: { name: 'aws', region: 'us-gov-west-1' } },
       command: 'deploy',
-      awsRequestStubMap: {
-        STS: {
-          getCallerIdentity: {
-            ResponseMetadata: { RequestId: 'ffffffff-ffff-ffff-ffff-ffffffffffff' },
-            UserId: 'XXXXXXXXXXXXXXXXXXXXX',
-            Account: '1234567890',
-            Arn: 'arn:aws:iam::1234567890:user/test',
-          },
-        },
-      },
+      awsSdkV3StubMap,
       options: { 'aws-s3-accelerate': false },
       lastLifecycleHookName: 'before:deploy:deploy',
     }).then(({ cfTemplate: template }) => {

--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -1425,7 +1425,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
       const describeImagesStub = sinon
         .stub()
         .resolves({ imageDetails: [{ imageDigest: imageDigestFromECR }] });
-      const awsRequestStubMap = {
+      const awsSdkV3StubMap = {
         ECR: {
           describeImages: describeImagesStub,
         },
@@ -1470,7 +1470,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
               },
             },
           },
-          awsRequestStubMap,
+          awsSdkV3StubMap,
         });
         cfResources = cfTemplate.Resources;
         naming = awsNaming;
@@ -1618,7 +1618,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
                 },
               },
             },
-            awsRequestStubMap: {
+            awsSdkV3StubMap: {
               ECR: {
                 describeImages: () => {
                   throw imageNotFoundError;
@@ -1659,7 +1659,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
           fixture: 'function',
           command: 'package',
           configExt: { functions },
-          awsRequestStubMap: {
+          awsSdkV3StubMap: {
             ECR: {
               describeImages: imageLookupStub,
             },
@@ -1720,7 +1720,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
       const createRepositoryStub = sinon.stub();
       const createRepositoryStubScanOnPush = sinon.stub();
       const putLifecyclePolicyStub = sinon.stub();
-      const baseAwsRequestStubMap = {
+      const baseAwsSdkV3StubMap = {
         STS: {
           getCallerIdentity: {
             ResponseMetadata: { RequestId: 'ffffffff-ffff-ffff-ffff-ffffffffffff' },
@@ -1768,10 +1768,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
       });
 
       it('should work correctly when repository exists beforehand', async () => {
-        const awsRequestStubMap = {
-          ...baseAwsRequestStubMap,
+        const awsSdkV3StubMap = {
+          ...baseAwsSdkV3StubMap,
           ECR: {
-            ...baseAwsRequestStubMap.ECR,
+            ...baseAwsSdkV3StubMap.ECR,
             describeRepositories: describeRepositoriesStub.resolves({
               repositories: [{ repositoryUri }],
             }),
@@ -1787,7 +1787,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
         } = await runServerless({
           fixture: 'ecr',
           command: 'package',
-          awsRequestStubMap,
+          awsSdkV3StubMap,
           modulesCacheStub,
         });
 
@@ -1838,10 +1838,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
       });
 
       it('should work correctly when repository does not exist beforehand and scanOnPush is set', async () => {
-        const awsRequestStubMap = {
-          ...baseAwsRequestStubMap,
+        const awsSdkV3StubMap = {
+          ...baseAwsSdkV3StubMap,
           ECR: {
-            ...baseAwsRequestStubMap.ECR,
+            ...baseAwsSdkV3StubMap.ECR,
             describeRepositories: describeRepositoriesStub.throws({
               providerError: { code: 'RepositoryNotFoundException' },
             }),
@@ -1854,7 +1854,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
         const { awsNaming, awsSdkV3Stub, cfTemplate, serverless } = await runServerless({
           fixture: 'ecr',
           command: 'package',
-          awsRequestStubMap,
+          awsSdkV3StubMap,
           modulesCacheStub,
           configExt: {
             provider: {
@@ -1889,10 +1889,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
       });
 
       it('should work correctly when repository does not exist beforehand', async () => {
-        const awsRequestStubMap = {
-          ...baseAwsRequestStubMap,
+        const awsSdkV3StubMap = {
+          ...baseAwsSdkV3StubMap,
           ECR: {
-            ...baseAwsRequestStubMap.ECR,
+            ...baseAwsSdkV3StubMap.ECR,
             describeRepositories: describeRepositoriesStub.throws({
               providerError: { code: 'RepositoryNotFoundException' },
             }),
@@ -1903,7 +1903,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
         const { awsNaming, awsSdkV3Stub, cfTemplate, serverless } = await runServerless({
           fixture: 'ecr',
           command: 'package',
-          awsRequestStubMap,
+          awsSdkV3StubMap,
           modulesCacheStub,
         });
 
@@ -1926,10 +1926,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
       });
 
       it('should create repository for native SDK v3 repository not found errors', async () => {
-        const awsRequestStubMap = {
-          ...baseAwsRequestStubMap,
+        const awsSdkV3StubMap = {
+          ...baseAwsSdkV3StubMap,
           ECR: {
-            ...baseAwsRequestStubMap.ECR,
+            ...baseAwsSdkV3StubMap.ECR,
             describeRepositories: describeRepositoriesStub.throws(
               Object.assign(new Error('Repository not found'), {
                 name: 'RepositoryNotFoundException',
@@ -1942,7 +1942,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
         const { awsNaming, awsSdkV3Stub, cfTemplate, serverless } = await runServerless({
           fixture: 'ecr',
           command: 'package',
-          awsRequestStubMap,
+          awsSdkV3StubMap,
           modulesCacheStub,
         });
 
@@ -1964,10 +1964,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
       });
 
       it('should set ECR lifecycle policy correctly', async () => {
-        const awsRequestStubMap = {
-          ...baseAwsRequestStubMap,
+        const awsSdkV3StubMap = {
+          ...baseAwsSdkV3StubMap,
           ECR: {
-            ...baseAwsRequestStubMap.ECR,
+            ...baseAwsSdkV3StubMap.ECR,
             describeRepositories: describeRepositoriesStub.throws({
               providerError: { code: 'RepositoryNotFoundException' },
             }),
@@ -1979,7 +1979,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
         const { awsNaming, awsSdkV3Stub, serverless } = await runServerless({
           fixture: 'ecr',
           command: 'package',
-          awsRequestStubMap,
+          awsSdkV3StubMap,
           modulesCacheStub,
           configExt: {
             provider: {
@@ -2017,10 +2017,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
       });
 
       it('should login and retry when docker push fails with no basic auth credentials error', async () => {
-        const awsRequestStubMap = {
-          ...baseAwsRequestStubMap,
+        const awsSdkV3StubMap = {
+          ...baseAwsSdkV3StubMap,
           ECR: {
-            ...baseAwsRequestStubMap.ECR,
+            ...baseAwsSdkV3StubMap.ECR,
             describeRepositories: describeRepositoriesStub.resolves({
               repositories: [{ repositoryUri }],
             }),
@@ -2043,7 +2043,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
         } = await runServerless({
           fixture: 'ecr',
           command: 'package',
-          awsRequestStubMap,
+          awsSdkV3StubMap,
           modulesCacheStub: {
             ...modulesCacheStub,
             [spawnModulePath]: innerSpawnExtStub,
@@ -2095,10 +2095,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
       });
 
       it('should login and retry when docker push fails with token has expired error', async () => {
-        const awsRequestStubMap = {
-          ...baseAwsRequestStubMap,
+        const awsSdkV3StubMap = {
+          ...baseAwsSdkV3StubMap,
           ECR: {
-            ...baseAwsRequestStubMap.ECR,
+            ...baseAwsSdkV3StubMap.ECR,
             describeRepositories: describeRepositoriesStub.resolves({
               repositories: [{ repositoryUri }],
             }),
@@ -2115,7 +2115,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
         const { awsSdkV3Stub, serverless } = await runServerless({
           fixture: 'ecr',
           command: 'package',
-          awsRequestStubMap,
+          awsSdkV3StubMap,
           modulesCacheStub: {
             ...modulesCacheStub,
             [spawnModulePath]: innerSpawnExtStub,
@@ -2145,10 +2145,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
       });
 
       it('should work correctly when image is defined with implicit path in provider', async () => {
-        const awsRequestStubMap = {
-          ...baseAwsRequestStubMap,
+        const awsSdkV3StubMap = {
+          ...baseAwsSdkV3StubMap,
           ECR: {
-            ...baseAwsRequestStubMap.ECR,
+            ...baseAwsSdkV3StubMap.ECR,
             describeRepositories: describeRepositoriesStub.resolves({
               repositories: [{ repositoryUri }],
             }),
@@ -2158,7 +2158,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
         const { awsNaming, cfTemplate } = await runServerless({
           fixture: 'ecr',
           command: 'package',
-          awsRequestStubMap,
+          awsSdkV3StubMap,
           modulesCacheStub,
           configExt: {
             provider: {
@@ -2186,10 +2186,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
       });
 
       it('should work correctly when image is defined with `file` set', async () => {
-        const awsRequestStubMap = {
-          ...baseAwsRequestStubMap,
+        const awsSdkV3StubMap = {
+          ...baseAwsSdkV3StubMap,
           ECR: {
-            ...baseAwsRequestStubMap.ECR,
+            ...baseAwsSdkV3StubMap.ECR,
             describeRepositories: describeRepositoriesStub.resolves({
               repositories: [{ repositoryUri }],
             }),
@@ -2203,7 +2203,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
         } = await runServerless({
           fixture: 'ecr',
           command: 'package',
-          awsRequestStubMap,
+          awsSdkV3StubMap,
           modulesCacheStub,
           configExt: {
             provider: {
@@ -2242,10 +2242,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
       });
 
       it('should work correctly when image is defined with `cacheFrom` set', async () => {
-        const awsRequestStubMap = {
-          ...baseAwsRequestStubMap,
+        const awsSdkV3StubMap = {
+          ...baseAwsSdkV3StubMap,
           ECR: {
-            ...baseAwsRequestStubMap.ECR,
+            ...baseAwsSdkV3StubMap.ECR,
             describeRepositories: describeRepositoriesStub.resolves({
               repositories: [{ repositoryUri }],
             }),
@@ -2259,7 +2259,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
         } = await runServerless({
           fixture: 'ecr',
           command: 'package',
-          awsRequestStubMap,
+          awsSdkV3StubMap,
           modulesCacheStub,
           configExt: {
             provider: {
@@ -2301,10 +2301,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
       });
 
       it('should work correctly when image is defined with `buildOptions` set', async () => {
-        const awsRequestStubMap = {
-          ...baseAwsRequestStubMap,
+        const awsSdkV3StubMap = {
+          ...baseAwsSdkV3StubMap,
           ECR: {
-            ...baseAwsRequestStubMap.ECR,
+            ...baseAwsSdkV3StubMap.ECR,
             describeRepositories: describeRepositoriesStub.resolves({
               repositories: [{ repositoryUri }],
             }),
@@ -2318,7 +2318,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
         } = await runServerless({
           fixture: 'ecr',
           command: 'package',
-          awsRequestStubMap,
+          awsSdkV3StubMap,
           modulesCacheStub,
           configExt: {
             provider: {
@@ -2360,10 +2360,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
       });
 
       it('should work correctly when image is defined with `buildArgs` set', async () => {
-        const awsRequestStubMap = {
-          ...baseAwsRequestStubMap,
+        const awsSdkV3StubMap = {
+          ...baseAwsSdkV3StubMap,
           ECR: {
-            ...baseAwsRequestStubMap.ECR,
+            ...baseAwsSdkV3StubMap.ECR,
             describeRepositories: describeRepositoriesStub.resolves({
               repositories: [{ repositoryUri }],
             }),
@@ -2377,7 +2377,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
         } = await runServerless({
           fixture: 'ecr',
           command: 'package',
-          awsRequestStubMap,
+          awsSdkV3StubMap,
           modulesCacheStub,
           configExt: {
             provider: {
@@ -2421,10 +2421,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
       });
 
       it('should work correctly when image is defined with `platform` set', async () => {
-        const awsRequestStubMap = {
-          ...baseAwsRequestStubMap,
+        const awsSdkV3StubMap = {
+          ...baseAwsSdkV3StubMap,
           ECR: {
-            ...baseAwsRequestStubMap.ECR,
+            ...baseAwsSdkV3StubMap.ECR,
             describeRepositories: describeRepositoriesStub.resolves({
               repositories: [{ repositoryUri }],
             }),
@@ -2438,7 +2438,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
         } = await runServerless({
           fixture: 'ecr',
           command: 'package',
-          awsRequestStubMap,
+          awsSdkV3StubMap,
           modulesCacheStub,
           configExt: {
             provider: {
@@ -2479,10 +2479,10 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
       });
 
       it('should work correctly when `functions[].image` is defined with explicit name', async () => {
-        const awsRequestStubMap = {
-          ...baseAwsRequestStubMap,
+        const awsSdkV3StubMap = {
+          ...baseAwsSdkV3StubMap,
           ECR: {
-            ...baseAwsRequestStubMap.ECR,
+            ...baseAwsSdkV3StubMap.ECR,
             describeRepositories: describeRepositoriesStub.resolves({
               repositories: [{ repositoryUri }],
             }),
@@ -2492,7 +2492,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
         const { awsNaming, cfTemplate } = await runServerless({
           fixture: 'ecr',
           command: 'package',
-          awsRequestStubMap,
+          awsSdkV3StubMap,
           modulesCacheStub,
           configExt: {
             provider: {
@@ -2524,7 +2524,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
           runServerless({
             fixture: 'ecr',
             command: 'package',
-            awsRequestStubMap: baseAwsRequestStubMap,
+            awsSdkV3StubMap: baseAwsSdkV3StubMap,
             modulesCacheStub: {
               [spawnModulePath]: sinon.stub().throws(),
             },
@@ -2537,7 +2537,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
           runServerless({
             fixture: 'ecr',
             command: 'package',
-            awsRequestStubMap: baseAwsRequestStubMap,
+            awsSdkV3StubMap: baseAwsSdkV3StubMap,
             modulesCacheStub: {
               ...modulesCacheStub,
               [spawnModulePath]: sinon.stub().returns({}).onSecondCall().throws(),
@@ -2551,7 +2551,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
           runServerless({
             fixture: 'ecr',
             command: 'package',
-            awsRequestStubMap: baseAwsRequestStubMap,
+            awsSdkV3StubMap: baseAwsSdkV3StubMap,
             modulesCacheStub: {
               ...modulesCacheStub,
               [spawnModulePath]: sinon.stub().returns({}).onCall(2).throws(),
@@ -2565,7 +2565,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
           runServerless({
             fixture: 'ecr',
             command: 'package',
-            awsRequestStubMap: baseAwsRequestStubMap,
+            awsSdkV3StubMap: baseAwsSdkV3StubMap,
             modulesCacheStub: {
               ...modulesCacheStub,
               [spawnModulePath]: sinon.stub().returns({}).onCall(3).throws(),
@@ -2579,7 +2579,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
           runServerless({
             fixture: 'ecr',
             command: 'package',
-            awsRequestStubMap: baseAwsRequestStubMap,
+            awsSdkV3StubMap: baseAwsSdkV3StubMap,
             modulesCacheStub: {
               ...modulesCacheStub,
               [spawnModulePath]: sinon

--- a/test/unit/lib/plugins/package/lib/package-service.test.js
+++ b/test/unit/lib/plugins/package/lib/package-service.test.js
@@ -14,7 +14,7 @@ const packageService = require('../../../../../../lib/plugins/package/lib/packag
 const { expect } = require('chai');
 
 describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
-  const awsRequestStubMap = {
+  const awsSdkV3StubMap = {
     S3: {
       headBucket: {},
     },
@@ -78,7 +78,7 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
       } = await runServerless({
         fixture: 'packaging',
         command: 'package',
-        awsRequestStubMap,
+        awsSdkV3StubMap,
         configExt: {
           package: {
             patterns: [
@@ -178,7 +178,7 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
       } = await runServerless({
         fixture: 'packaging',
         command: 'package',
-        awsRequestStubMap,
+        awsSdkV3StubMap,
         configExt: {
           useDotenv: true,
         },
@@ -243,7 +243,7 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
       } = await runServerless({
         fixture: 'packaging',
         command: 'package',
-        awsRequestStubMap,
+        awsSdkV3StubMap,
         configExt: {
           package: {
             individually: true,
@@ -305,7 +305,7 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
       const { serverless: serverlessInstance } = await runServerless({
         fixture: 'packaging',
         command: 'package',
-        awsRequestStubMap,
+        awsSdkV3StubMap,
         configExt: {
           package: {
             artifact: 'artifact.zip',
@@ -345,7 +345,7 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
   describe('pre-prepared artifact with absolute artifact path', () => {
     describe('while deploying whole service', () => {
       const s3UploadStub = sinon.stub();
-      const innerAwsRequestStubMap = {
+      const innerAwsSdkV3StubMap = {
         Lambda: {
           getFunction: {
             Configuration: {
@@ -394,7 +394,7 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
           cwd: serviceDir,
           command: 'deploy',
           lastLifecycleHookName: 'aws:deploy:deploy:uploadArtifacts',
-          awsRequestStubMap: innerAwsRequestStubMap,
+          awsSdkV3StubMap: innerAwsSdkV3StubMap,
         });
 
         const callArgs = s3UploadStub.args.find((item) =>
@@ -416,7 +416,7 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
           cwd: serviceDir,
           command: 'deploy',
           lastLifecycleHookName: 'aws:deploy:deploy:uploadArtifacts',
-          awsRequestStubMap: innerAwsRequestStubMap,
+          awsSdkV3StubMap: innerAwsSdkV3StubMap,
         });
 
         const callArgs = s3UploadStub.args.find((item) =>
@@ -428,7 +428,7 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
 
     describe('while deploying specific function', () => {
       const updateFunctionCodeStub = sinon.stub();
-      const innerAwsRequestStubMap = {
+      const innerAwsSdkV3StubMap = {
         Lambda: {
           getFunction: {
             Configuration: {
@@ -464,7 +464,7 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
           cwd: serviceDir,
           command: 'deploy function',
           options: { function: 'other' },
-          awsRequestStubMap: innerAwsRequestStubMap,
+          awsSdkV3StubMap: innerAwsSdkV3StubMap,
         });
         expect(updateFunctionCodeStub).to.have.been.calledOnce;
         expect(updateFunctionCodeStub.args[0][0].ZipFile).to.deep.equal(Buffer.from(zipContent));
@@ -484,7 +484,7 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
           cwd: serviceDir,
           command: 'deploy function',
           options: { function: 'foo' },
-          awsRequestStubMap: innerAwsRequestStubMap,
+          awsSdkV3StubMap: innerAwsSdkV3StubMap,
         });
         expect(updateFunctionCodeStub).to.have.been.calledOnce;
         expect(updateFunctionCodeStub.args[0][0].ZipFile).to.deep.equal(Buffer.from(zipContent));


### PR DESCRIPTION
This modernizes the remaining AWS test callers to use the SDK v3 stub map directly. It keeps the runServerless compatibility alias in place while removing legacy caller usage from the affected AWS provider, core template, and package service coverage.