### PR TITLE
Replace core fixture wrappers

### DIFF
--- a/test/unit/lib/classes/plugin-manager.test.js
+++ b/test/unit/lib/classes/plugin-manager.test.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 const { overrideEnv, overrideArgv } = require('../../../utils/process');
 const runServerless = require('../../../utils/run-serverless');
-const fixtures = require('../../../fixtures/programmatic');
+const setupProgrammaticFixture = require('../../../utils/setup-programmatic-fixture');
 const Serverless = require('../../../../lib/serverless');
 const CLI = require('../../../../lib/classes/cli');
 const resolveInput = require('../../../../lib/cli/resolve-input');
@@ -1613,7 +1613,7 @@ describe('PluginManager', () => {
 
 describe('test/unit/lib/classes/PluginManager.test.js', () => {
   it('should load plugins relatively to the working directory', async () => {
-    const { servicePath: serviceDir } = await fixtures.setup('aws');
+    const { servicePath: serviceDir } = await setupProgrammaticFixture('aws');
     const localPluginDir = path.join(serviceDir, 'node_modules', 'local-plugin');
     const parentPluginDir = path.join(serviceDir, '..', 'node_modules', 'parent-plugin');
     installPlugin(localPluginDir, SynchronousPluginMock);

--- a/test/unit/lib/serverless.test.js
+++ b/test/unit/lib/serverless.test.js
@@ -17,7 +17,7 @@ const CLI = require('../../../lib/classes/cli');
 const ServerlessError = require('../../../lib/serverless-error');
 const runServerless = require('../../utils/run-serverless');
 const spawn = require('../../../lib/utils/spawn');
-const programmaticFixturesEngine = require('../../fixtures/programmatic');
+const setupProgrammaticFixture = require('../../utils/setup-programmatic-fixture');
 const path = require('path');
 const yaml = require('js-yaml');
 
@@ -274,7 +274,7 @@ describe('test/unit/lib/serverless.test.js', () => {
       };
       setByPath(customExt, pluginConfig.overwriteValuePath, 'test_value');
 
-      const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('plugin', {
+      const { servicePath: serviceDir } = await setupProgrammaticFixture('plugin', {
         configExt,
       });
       const serverlessProcess = await spawn('node', [serverlessPath, 'print'], {


### PR DESCRIPTION
This replaces the remaining direct programmatic fixture setup in the core Serverless and plugin-manager unit tests with the shared setupProgrammaticFixture helper. It preserves the existing constructor coverage, plugin-manager internals, and mutable copied-service behavior.