### PR TITLE
Replace small core Serverless fakes

### DIFF
--- a/test/unit/lib/classes/config-schema-handler/index.test.js
+++ b/test/unit/lib/classes/config-schema-handler/index.test.js
@@ -2,14 +2,19 @@
 
 const chai = require('chai');
 const runServerless = require('../../../../utils/run-serverless');
-const Serverless = require('../../../../../lib/serverless');
-const {
-  getConfigurationValidationResult,
-} = require('../../../../../lib/classes/config-schema-handler');
+const ConfigSchemaHandler = require('../../../../../lib/classes/config-schema-handler');
+
+const { getConfigurationValidationResult } = ConfigSchemaHandler;
 
 const expect = chai.expect;
 const FUNCTION_NAME_PATTERN = '^[a-zA-Z0-9-_]+$';
 const STAGE_NAME_PATTERN = require('../../../../../lib/utils/stage-pattern');
+
+const createConfigSchemaHandler = (configurationInput) =>
+  new ConfigSchemaHandler({
+    configurationInput,
+    service: { configValidationMode: 'error' },
+  });
 
 describe('test/unit/lib/classes/ConfigSchemaHandler/index.test.js', () => {
   describe('#constructor', () => {
@@ -81,13 +86,12 @@ describe('test/unit/lib/classes/ConfigSchemaHandler/index.test.js', () => {
     });
 
     it('restores safe null paths and skips unsafe null paths without mutating prototypes', async () => {
-      const serverless = new Serverless({ commands: [], options: {} });
       const userConfig = JSON.parse(
         '{"service":"service","frameworkVersion":"*","provider":{"name":"aws"},"custom":{"safe":{"keptNull":null},"__proto__":null,"constructor":{"prototype":{"blockedNull":null}}}}'
       );
-      serverless.configurationInput = userConfig;
+      const configSchemaHandler = createConfigSchemaHandler(userConfig);
 
-      await serverless.configSchemaHandler.validateConfig(userConfig);
+      await configSchemaHandler.validateConfig(userConfig);
 
       expect(userConfig.custom.safe.keptNull).to.equal(null);
       expect(Object.getPrototypeOf(userConfig.custom)).to.equal(Object.prototype);
@@ -98,23 +102,21 @@ describe('test/unit/lib/classes/ConfigSchemaHandler/index.test.js', () => {
     });
 
     it('resolves schema references through own definition keys named constructor', async () => {
-      const serverless = new Serverless({ commands: [], options: {} });
-      const customProperties = serverless.configSchemaHandler.schema.properties.custom.properties;
-
-      serverless.configSchemaHandler.schema.definitions.constructor = { type: 'string' };
-      customProperties.someConstructorBackedValue = {
-        $ref: '#/definitions/constructor',
-      };
-
       const userConfig = {
         service: 'service',
         frameworkVersion: '*',
         provider: { name: 'aws' },
         custom: { someConstructorBackedValue: 'ok' },
       };
-      serverless.configurationInput = userConfig;
+      const configSchemaHandler = createConfigSchemaHandler(userConfig);
+      const customProperties = configSchemaHandler.schema.properties.custom.properties;
 
-      await serverless.configSchemaHandler.validateConfig(userConfig);
+      configSchemaHandler.schema.definitions.constructor = { type: 'string' };
+      customProperties.someConstructorBackedValue = {
+        $ref: '#/definitions/constructor',
+      };
+
+      await configSchemaHandler.validateConfig(userConfig);
 
       expect(customProperties.someConstructorBackedValue).to.deep.equal({ type: 'string' });
     });

--- a/test/unit/lib/plugins/print.test.js
+++ b/test/unit/lib/plugins/print.test.js
@@ -3,7 +3,6 @@
 const chai = require('chai');
 const proxyquire = require('proxyquire').noCallThru();
 const sinon = require('sinon');
-const Serverless = require('../../../../lib/serverless');
 
 const runServerless = require('../../../utils/run-serverless');
 
@@ -24,10 +23,11 @@ describe('test/unit/lib/plugins/print.test.js', () => {
     const Print = proxyquire('../../../../lib/plugins/print', {
       '../utils/serverless-utils/log': { writeText },
     });
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.configurationInput = {
-      custom: {
-        enabled: false,
+    const serverless = {
+      configurationInput: {
+        custom: {
+          enabled: false,
+        },
       },
     };
     Object.defineProperty(serverless.configurationInput.custom, '__proto__', {
@@ -50,10 +50,11 @@ describe('test/unit/lib/plugins/print.test.js', () => {
     const Print = proxyquire('../../../../lib/plugins/print', {
       '../utils/serverless-utils/log': { writeText },
     });
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.configurationInput = {
-      custom: {
-        items: ['one', 'two', 'three'],
+    const serverless = {
+      configurationInput: {
+        custom: {
+          items: ['one', 'two', 'three'],
+        },
       },
     };
 
@@ -67,8 +68,7 @@ describe('test/unit/lib/plugins/print.test.js', () => {
     const Print = proxyquire('../../../../lib/plugins/print', {
       '../utils/serverless-utils/log': { writeText },
     });
-    const serverless = new Serverless({ commands: [], options: {} });
-    serverless.configurationInput = { custom: {} };
+    const serverless = { configurationInput: { custom: {} } };
 
     try {
       await new Print(serverless, { path: 'custom.constructor.name', format: 'text' }).print();


### PR DESCRIPTION
This replaces isolated direct Serverless construction in the config-schema-handler tests with a minimal ConfigSchemaHandler-backed fake. It also updates print path resolver tests to use plain configurationInput fakes while preserving the existing command-level coverage.