### PR TITLE
Replace commands fixture wrappers

### DIFF
--- a/test/unit/commands/doctor.test.js
+++ b/test/unit/commands/doctor.test.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const spawn = require('../../../lib/utils/spawn');
 const { expect } = require('chai');
-const fixturesEngine = require('../../fixtures/programmatic');
+const setupProgrammaticFixture = require('../../utils/setup-programmatic-fixture');
 
 const serverlessPath = path.resolve(__dirname, '../../../scripts/serverless.js');
 
@@ -13,7 +13,7 @@ describe('test/unit/commands/doctor.test.js', async () => {
   });
 
   it('should print health status after command which triggered deprecation', async () => {
-    const { servicePath: serviceDir } = await fixturesEngine.setup('http-api', {
+    const { servicePath: serviceDir } = await setupProgrammaticFixture('http-api', {
       configExt: {
         provider: {
           httpApi: {

--- a/test/unit/commands/plugin-install.test.js
+++ b/test/unit/commands/plugin-install.test.js
@@ -5,7 +5,7 @@ const fsp = require('fs').promises;
 const sinon = require('sinon');
 const yaml = require('js-yaml');
 const proxyquire = require('proxyquire');
-const fixturesEngine = require('../../fixtures/programmatic');
+const setupProgrammaticFixture = require('../../utils/setup-programmatic-fixture');
 const resolveConfigurationPath = require('../../../lib/cli/resolve-configuration-path');
 const cloudformationSchema = require('../../../lib/utils/serverless-utils/cloudformation-schema');
 const { expect } = require('chai');
@@ -57,7 +57,7 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
     let serviceDir;
     let configurationFilePath;
     before(async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const configuration = fixture.serviceConfig;
       serviceDir = fixture.servicePath;
       configurationFilePath = await resolveConfigurationPath({
@@ -93,7 +93,7 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
 
   describe('with plugins in configuration', () => {
     it('should not add plugin to serverless file if it is already present in configuration but configured behind a variable', async () => {
-      const fixture = await fixturesEngine.setup('function', {
+      const fixture = await setupProgrammaticFixture('function', {
         configExt: {
           plugins: ['${self:custom.pluginName}'],
           custom: {
@@ -130,7 +130,7 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
 
   describe('with invalid plugin name', () => {
     it('rejects before installing or updating the configuration file', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const configuration = fixture.serviceConfig;
       const serviceDir = fixture.servicePath;
       const configurationFilePath = await resolveConfigurationPath({
@@ -157,7 +157,7 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
 
   describe('with JSON configuration', () => {
     it('adds a plugin to array-form plugins', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const { configurationFilePath, configuration, configurationFilename } =
         await writeJsonConfiguration(fixture.servicePath, {
           service: 'json-service',
@@ -177,7 +177,7 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
     });
 
     it('adds a plugin to object-form plugins.modules', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const { configurationFilePath, configuration, configurationFilename } =
         await writeJsonConfiguration(fixture.servicePath, {
           service: 'json-service',
@@ -197,7 +197,7 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
     });
 
     it('strips a UTF-8 BOM from JSON input', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const configuration = { service: 'json-service', plugins: [] };
       const { configurationFilePath, configurationFilename } = await writeJsonConfiguration(
         fixture.servicePath,
@@ -218,7 +218,7 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
     });
 
     it('includes the JSON filename in invalid JSON errors', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const { configurationFilePath, configuration, configurationFilename } =
         await writeJsonConfiguration(fixture.servicePath, { service: 'json-service' }, '{invalid');
 
@@ -233,7 +233,7 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
     });
 
     it('writes compact JSON with a final newline', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const { configurationFilePath, configuration, configurationFilename } =
         await writeJsonConfiguration(fixture.servicePath, {
           service: 'json-service',
@@ -255,7 +255,7 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
 
   describe('with intrinsic-tagged yaml', () => {
     it('preserves shorthand intrinsic tags when adding a plugin to array-form yaml', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const serviceDir = fixture.servicePath;
       const rawYaml = [
         'service: raw-plugin-yaml',
@@ -304,7 +304,7 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
     });
 
     it('preserves sibling shorthand tags when adding a plugin to object-form plugins.modules', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const serviceDir = fixture.servicePath;
       const rawYaml = [
         'service: raw-plugin-yaml',
@@ -351,7 +351,7 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
     });
 
     it('updates a quoted top level plugins array without duplicating the section', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const serviceDir = fixture.servicePath;
       const rawYaml = [
         'service: raw-plugin-yaml',

--- a/test/unit/commands/plugin-uninstall.test.js
+++ b/test/unit/commands/plugin-uninstall.test.js
@@ -5,7 +5,7 @@ const fsp = require('fs').promises;
 const sinon = require('sinon');
 const yaml = require('js-yaml');
 const proxyquire = require('proxyquire');
-const fixturesEngine = require('../../fixtures/programmatic');
+const setupProgrammaticFixture = require('../../utils/setup-programmatic-fixture');
 const resolveConfigurationPath = require('../../../lib/cli/resolve-configuration-path');
 const cloudformationSchema = require('../../../lib/utils/serverless-utils/cloudformation-schema');
 const { expect } = require('chai');
@@ -52,7 +52,7 @@ describe('test/unit/commands/plugin-uninstall.test.js', async () => {
   let configurationFilePath;
 
   before(async () => {
-    const fixture = await fixturesEngine.setup('function', {
+    const fixture = await setupProgrammaticFixture('function', {
       configExt: {
         plugins: [pluginName],
       },
@@ -96,7 +96,7 @@ describe('test/unit/commands/plugin-uninstall.test.js', async () => {
 
   describe('with invalid plugin name', () => {
     it('rejects before uninstalling or updating the configuration file', async () => {
-      const fixture = await fixturesEngine.setup('function', {
+      const fixture = await setupProgrammaticFixture('function', {
         configExt: {
           plugins: [pluginName],
         },
@@ -130,7 +130,7 @@ describe('test/unit/commands/plugin-uninstall.test.js', async () => {
 
   describe('with JSON configuration', () => {
     it('removes a plugin from array-form plugins', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const { configurationFilePath, configuration, configurationFilename } =
         await writeJsonConfiguration(fixture.servicePath, {
           service: 'json-service',
@@ -150,7 +150,7 @@ describe('test/unit/commands/plugin-uninstall.test.js', async () => {
     });
 
     it('removes all duplicate plugin entries', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const { configurationFilePath, configuration, configurationFilename } =
         await writeJsonConfiguration(fixture.servicePath, {
           service: 'json-service',
@@ -170,7 +170,7 @@ describe('test/unit/commands/plugin-uninstall.test.js', async () => {
     });
 
     it('deletes an empty top-level plugins array', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const { configurationFilePath, configuration, configurationFilename } =
         await writeJsonConfiguration(fixture.servicePath, {
           service: 'json-service',
@@ -190,7 +190,7 @@ describe('test/unit/commands/plugin-uninstall.test.js', async () => {
     });
 
     it('deletes an empty object-form plugins.modules array', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const { configurationFilePath, configuration, configurationFilename } =
         await writeJsonConfiguration(fixture.servicePath, {
           service: 'json-service',
@@ -211,7 +211,7 @@ describe('test/unit/commands/plugin-uninstall.test.js', async () => {
     });
 
     it('includes the JSON filename in invalid JSON errors', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const { configurationFilePath, configuration, configurationFilename } =
         await writeJsonConfiguration(fixture.servicePath, { service: 'json-service' }, '{invalid');
 
@@ -226,7 +226,7 @@ describe('test/unit/commands/plugin-uninstall.test.js', async () => {
     });
 
     it('writes compact JSON with a final newline', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const { configurationFilePath, configuration, configurationFilename } =
         await writeJsonConfiguration(fixture.servicePath, {
           service: 'json-service',
@@ -248,7 +248,7 @@ describe('test/unit/commands/plugin-uninstall.test.js', async () => {
 
   describe('with intrinsic-tagged yaml', () => {
     it('preserves shorthand intrinsic tags when removing a plugin from array-form yaml', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const fixtureServiceDir = fixture.servicePath;
       const rawYaml = [
         'service: raw-plugin-yaml',
@@ -291,7 +291,7 @@ describe('test/unit/commands/plugin-uninstall.test.js', async () => {
     });
 
     it('preserves sibling shorthand tags when removing a plugin from object-form plugins.modules', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const fixtureServiceDir = fixture.servicePath;
       const rawYaml = [
         'service: raw-plugin-yaml',
@@ -337,7 +337,7 @@ describe('test/unit/commands/plugin-uninstall.test.js', async () => {
     });
 
     it('preserves later plugins siblings when removing the last object-form plugin entry', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const fixtureServiceDir = fixture.servicePath;
       const rawYaml = [
         'service: raw-plugin-yaml',
@@ -384,7 +384,7 @@ describe('test/unit/commands/plugin-uninstall.test.js', async () => {
     });
 
     it('removes plugins from a quoted top level plugins array without leaving a duplicate section', async () => {
-      const fixture = await fixturesEngine.setup('function');
+      const fixture = await setupProgrammaticFixture('function');
       const fixtureServiceDir = fixture.servicePath;
       const rawYaml = [
         'service: raw-plugin-yaml',

--- a/test/unit/scripts/serverless.test.js
+++ b/test/unit/scripts/serverless.test.js
@@ -3,11 +3,10 @@
 const { expect } = require('chai');
 
 const path = require('path');
-const fsp = require('fs').promises;
 const spawn = require('../../../lib/utils/spawn');
 const { stripVTControlCharacters: stripAnsi } = require('node:util');
 const { version } = require('../../../package');
-const programmaticFixturesEngine = require('../../fixtures/programmatic');
+const setupProgrammaticFixture = require('../../utils/setup-programmatic-fixture');
 
 const serverlessPath = path.resolve(__dirname, '../../../scripts/serverless.js');
 const programmaticFixturesPath = path.resolve(__dirname, '../../fixtures/programmatic');
@@ -143,7 +142,7 @@ describe('test/unit/scripts/serverless.test.js', () => {
     try {
       await spawn('node', [serverlessPath, 'print'], {
         cwd: (
-          await programmaticFixturesEngine.setup('aws', {
+          await setupProgrammaticFixture('aws', {
             configExt: { provider: '${foo:bar}' },
           })
         ).servicePath,
@@ -159,7 +158,7 @@ describe('test/unit/scripts/serverless.test.js', () => {
     try {
       await spawn('node', [serverlessPath, 'print'], {
         cwd: (
-          await programmaticFixturesEngine.setup('aws', {
+          await setupProgrammaticFixture('aws', {
             configExt: { provider: { stage: '${foo:bar}' } },
           })
         ).servicePath,
@@ -172,15 +171,15 @@ describe('test/unit/scripts/serverless.test.js', () => {
   });
 
   it('should load env variables from dotenv files', async () => {
-    const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('aws', {
+    const { servicePath: serviceDir } = await setupProgrammaticFixture('aws', {
       configExt: {
         useDotenv: true,
         custom: {
           fromDefaultEnv: '${env:DEFAULT_ENV_VARIABLE}',
         },
       },
+      files: [{ to: '.env', contents: 'DEFAULT_ENV_VARIABLE=valuefromdefault' }],
     });
-    await fsp.writeFile(path.resolve(serviceDir, '.env'), 'DEFAULT_ENV_VARIABLE=valuefromdefault');
     const printOut = String(
       (await spawn('node', [serverlessPath, 'print'], { cwd: serviceDir })).stdoutBuffer
     );
@@ -189,7 +188,7 @@ describe('test/unit/scripts/serverless.test.js', () => {
   });
 
   it('should allow not defined environment variables in provider.stage`', async () => {
-    const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('aws', {
+    const { servicePath: serviceDir } = await setupProgrammaticFixture('aws', {
       configExt: {
         useDotenv: true,
         provider: {
@@ -199,8 +198,8 @@ describe('test/unit/scripts/serverless.test.js', () => {
           fromDefaultEnv: '${env:DEFAULT_ENV_VARIABLE}',
         },
       },
+      files: [{ to: '.env', contents: 'DEFAULT_ENV_VARIABLE=valuefromdefault' }],
     });
-    await fsp.writeFile(path.resolve(serviceDir, '.env'), 'DEFAULT_ENV_VARIABLE=valuefromdefault');
     const printOut = String(
       (await spawn('node', [serverlessPath, 'print'], { cwd: serviceDir })).stdoutBuffer
     );
@@ -209,15 +208,15 @@ describe('test/unit/scripts/serverless.test.js', () => {
   });
 
   it('should report "env" variables resolution conflicts with exception', async () => {
-    const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('aws', {
+    const { servicePath: serviceDir } = await setupProgrammaticFixture('aws', {
       configExt: {
         useDotenv: true,
         provider: {
           stage: "${env:FOO, 'dev'}",
         },
       },
+      files: [{ to: '.env', contents: 'FOO=test' }],
     });
-    await fsp.writeFile(path.resolve(serviceDir, '.env'), 'FOO=test');
     try {
       await spawn('node', [serverlessPath, 'print'], { cwd: serviceDir });
       throw new Error('Unexpected');
@@ -228,7 +227,7 @@ describe('test/unit/scripts/serverless.test.js', () => {
   });
 
   it('should support custom variable soruces', async () => {
-    const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('plugin', {
+    const { servicePath: serviceDir } = await setupProgrammaticFixture('plugin', {
       configExt: {
         custom: {
           otherVar: '${other:addressValue}',
@@ -245,7 +244,7 @@ describe('test/unit/scripts/serverless.test.js', () => {
     try {
       await spawn('node', [serverlessPath, 'print'], {
         cwd: (
-          await programmaticFixturesEngine.setup('aws', {
+          await setupProgrammaticFixture('aws', {
             configExt: { plugins: '${foo:bar}' },
           })
         ).servicePath,
@@ -260,7 +259,7 @@ describe('test/unit/scripts/serverless.test.js', () => {
   it('should throw meaningful error on unrecognized command for custom provider', async () => {
     try {
       await spawn('node', [serverlessPath, 'foo'], {
-        cwd: (await programmaticFixturesEngine.setup('custom-provider')).servicePath,
+        cwd: (await setupProgrammaticFixture('custom-provider')).servicePath,
       });
       throw new Error('Unexpected');
     } catch (error) {
@@ -293,7 +292,7 @@ describe('test/unit/scripts/serverless.test.js', () => {
   });
 
   it('should include plugin commands in service help output', async () => {
-    const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('plugin');
+    const { servicePath: serviceDir } = await setupProgrammaticFixture('plugin');
 
     const output = stripAnsi(
       String(
@@ -311,7 +310,7 @@ describe('test/unit/scripts/serverless.test.js', () => {
   });
 
   it('should print plugin command help to stdout', async () => {
-    const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('plugin');
+    const { servicePath: serviceDir } = await setupProgrammaticFixture('plugin');
 
     const output = stripAnsi(
       String(
@@ -329,7 +328,7 @@ describe('test/unit/scripts/serverless.test.js', () => {
   });
 
   it('should dispatch plugin command', async () => {
-    const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('plugin');
+    const { servicePath: serviceDir } = await setupProgrammaticFixture('plugin');
 
     const output = stripAnsi(
       String(
@@ -345,7 +344,7 @@ describe('test/unit/scripts/serverless.test.js', () => {
   });
 
   it('should parse plugin command options from final plugin schema', async () => {
-    const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('plugin');
+    const { servicePath: serviceDir } = await setupProgrammaticFixture('plugin');
 
     const output = stripAnsi(
       String(


### PR DESCRIPTION
This replaces direct programmatic fixture engine usage in command and script tests with the shared mutable fixture helper. It preserves static fixture path handling for entrypoint behavior and keeps plugin install and uninstall configuration mutation assertions in place.