### PR TITLE
Replace variable source Serverless fakes

### DIFF
--- a/test/unit/lib/configuration/variables/sources/instance-dependent/get-aws.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/get-aws.test.js
@@ -8,7 +8,6 @@ const resolveMeta = require('../../../../../../../lib/configuration/variables/re
 const resolve = require('../../../../../../../lib/configuration/variables/resolve');
 const selfSource = require('../../../../../../../lib/configuration/variables/sources/self');
 const mergePlainObjects = require('../../../../../../../lib/utils/merge-plain-objects');
-const Serverless = require('../../../../../../../lib/serverless');
 
 describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-aws.test.js', () => {
   let configuration;
@@ -52,6 +51,13 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-a
       });
   }
 
+  const createServerlessInstance = () => ({
+    getProvider: () => ({
+      getRegion: () => 'us-east-1',
+      getAwsSdkV3Config,
+    }),
+  });
+
   const initializeServerless = async ({ configExt, options, custom, handler } = {}) => {
     configuration = {
       service: 'foo',
@@ -70,21 +76,7 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-a
     };
     if (configExt) configuration = mergePlainObjects(configuration, configExt);
     variablesMeta = resolveMeta(configuration);
-    const serverlessInstance = new Serverless({
-      configuration,
-      serviceDir: process.cwd(),
-      configurationFilename: 'serverless.yml',
-      commands: ['package'],
-      options: {},
-    });
-    serverlessInstance.init();
-    serverlessInstance.getProvider = () => ({
-      constructor: {
-        getProviderName: () => 'aws',
-      },
-      getRegion: () => 'us-east-1',
-      getAwsSdkV3Config,
-    });
+    const serverlessInstance = createServerlessInstance();
     const getAwsSource = loadSource(handler || (() => ({ Account: '1234567890' })));
 
     await resolve({
@@ -179,15 +171,7 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-a
 
   it('should ignore inherited region from options', async () => {
     const getAwsSource = loadSource(() => ({ Account: '1234567890' }));
-    const source = getAwsSource({
-      getProvider: () => ({
-        constructor: {
-          getProviderName: () => 'aws',
-        },
-        getRegion: () => 'us-east-1',
-        getAwsSdkV3Config,
-      }),
-    });
+    const source = getAwsSource(createServerlessInstance());
     const result = await source.resolve({
       address: 'region',
       options: Object.create({ region: 'eu-central-1' }),

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/get-sls.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/get-sls.test.js
@@ -7,12 +7,15 @@ const resolve = require('../../../../../../../lib/configuration/variables/resolv
 const selfSource = require('../../../../../../../lib/configuration/variables/sources/self');
 const getSlsSource = require('../../../../../../../lib/configuration/variables/sources/instance-dependent/get-sls');
 const mergePlainObjects = require('../../../../../../../lib/utils/merge-plain-objects');
-const Serverless = require('../../../../../../../lib/serverless');
 
 describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-sls.test.js', () => {
   let configuration;
   let variablesMeta;
   let serverlessInstance;
+
+  const createServerlessInstance = () => ({
+    instanceId: 'test-instance-id',
+  });
 
   const initializeServerless = async ({ configExt, options, setupOptions = {} } = {}) => {
     configuration = {
@@ -33,14 +36,7 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-s
       configuration = mergePlainObjects(configuration, configExt);
     }
     variablesMeta = resolveMeta(configuration);
-    serverlessInstance = new Serverless({
-      configuration,
-      serviceDir: process.cwd(),
-      configurationFilename: 'serverless.yml',
-      commands: ['package'],
-      options: {},
-    });
-    serverlessInstance.init();
+    serverlessInstance = createServerlessInstance();
     await resolve({
       serviceDir: process.cwd(),
       configuration,

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/param.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/param.test.js
@@ -6,9 +6,17 @@ const resolveMeta = require('../../../../../../../lib/configuration/variables/re
 const resolve = require('../../../../../../../lib/configuration/variables/resolve');
 const selfSource = require('../../../../../../../lib/configuration/variables/sources/self');
 const getParamSource = require('../../../../../../../lib/configuration/variables/sources/instance-dependent/param');
-const Serverless = require('../../../../../../../lib/serverless');
 
 describe('test/unit/lib/configuration/variables/sources/instance-dependent/param.test.js', () => {
+  const createServerlessInstance = ({ configuration, cliParameters }) => ({
+    configurationInput: configuration,
+    processedInput: {
+      options: {
+        param: cliParameters,
+      },
+    },
+  });
+
   const runServerless = async ({
     cliParameters = [],
     stageParameters = {},
@@ -37,17 +45,10 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/param
 
     const variablesMeta = resolveMeta(configuration);
 
-    const serverlessInstance = new Serverless({
+    const serverlessInstance = createServerlessInstance({
       configuration,
-      options: {
-        param: cliParameters,
-      },
-      serviceDir: process.cwd(),
-      configurationFilename: 'serverless.yml',
-      commands: ['package'],
+      cliParameters,
     });
-
-    serverlessInstance.init();
 
     await resolve({
       serviceDir: process.cwd(),


### PR DESCRIPTION
This replaces direct Serverless construction in the instance-dependent variable source specs with minimal instance-shaped fakes. It leaves the AWS SDK module seams unchanged while preserving variable source behavior.