### PR TITLE
Replace non-AWS plugin Serverless fakes

### DIFF
--- a/test/unit/lib/plugins/deploy.test.js
+++ b/test/unit/lib/plugins/deploy.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Deploy = require('../../../../lib/plugins/deploy');
-const Serverless = require('../../../../lib/serverless');
 const sinon = require('sinon');
 const chai = require('chai');
 
@@ -13,11 +12,21 @@ describe('Deploy', () => {
   let options;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = {
+      providers: { validProvider: true },
+      service: {
+        provider: { name: 'validProvider' },
+        package: {},
+      },
+      pluginManager: {
+        spawn: () => Promise.resolve(),
+      },
+      getProvider(name) {
+        return this.providers[name] || false;
+      },
+    };
     options = {};
     deploy = new Deploy(serverless, options);
-    deploy.serverless.providers = { validProvider: true };
-    deploy.serverless.service.provider.name = 'validProvider';
   });
 
   describe('#constructor()', () => {

--- a/test/unit/lib/plugins/info.test.js
+++ b/test/unit/lib/plugins/info.test.js
@@ -2,7 +2,6 @@
 
 const chai = require('chai');
 const Info = require('../../../../lib/plugins/info');
-const Serverless = require('../../../../lib/serverless');
 
 const expect = chai.expect;
 
@@ -11,7 +10,7 @@ describe('Info', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = {};
     info = new Info(serverless);
   });
 

--- a/test/unit/lib/plugins/install.test.js
+++ b/test/unit/lib/plugins/install.test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Serverless = require('../../../../lib/serverless');
 const Install = require('../../../../lib/plugins/install.js');
 const sinon = require('sinon');
 const download = require('../../../../lib/utils/download-template-from-repo');
@@ -16,7 +15,7 @@ describe('Install', () => {
 
   let serviceDir;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     const tmpDir = getTmpDirPath();
     cwd = process.cwd();
 
@@ -25,11 +24,8 @@ describe('Install', () => {
 
     serviceDir = tmpDir;
 
-    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
+    serverless = {};
     install = new Install(serverless);
-    return serverless.init().then(() => {
-      install.serverless.cli = new serverless.classes.CLI();
-    });
   });
 
   afterEach(() => {

--- a/test/unit/lib/plugins/invoke.test.js
+++ b/test/unit/lib/plugins/invoke.test.js
@@ -3,7 +3,6 @@
 const chai = require('chai');
 const { overrideEnv } = require('../../../utils/process');
 const Invoke = require('../../../../lib/plugins/invoke');
-const Serverless = require('../../../../lib/serverless');
 
 const expect = chai.expect;
 
@@ -14,7 +13,10 @@ describe('Invoke', () => {
 
   beforeEach(() => {
     ({ restoreEnv } = overrideEnv());
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = {
+      processedInput: { options: {} },
+      service: { provider: {} },
+    };
     invoke = new Invoke(serverless);
   });
 

--- a/test/unit/lib/plugins/metrics.test.js
+++ b/test/unit/lib/plugins/metrics.test.js
@@ -2,14 +2,13 @@
 
 const expect = require('chai').expect;
 const Metrics = require('../../../../lib/plugins/metrics');
-const Serverless = require('../../../../lib/serverless');
 
 describe('Metrics', () => {
   let metrics;
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = {};
     const options = {};
     metrics = new Metrics(serverless, options);
   });

--- a/test/unit/lib/plugins/package/package.test.js
+++ b/test/unit/lib/plugins/package/package.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Package = require('../../../../../lib/plugins/package/package');
-const Serverless = require('../../../../../lib/serverless');
 const sinon = require('sinon');
 
 // Configure chai
@@ -12,15 +11,16 @@ describe('Package', () => {
   let options;
   let pkg;
 
-  beforeEach(async () => {
-    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
-    return serverless.init().then(() => {
-      options = {
-        stage: 'dev',
-        region: 'us-east-1',
-      };
-      pkg = new Package(serverless, options);
-    });
+  beforeEach(() => {
+    serverless = {
+      serviceDir: null,
+      service: { package: {} },
+    };
+    options = {
+      stage: 'dev',
+      region: 'us-east-1',
+    };
+    pkg = new Package(serverless, options);
   });
 
   describe('#constructor()', () => {

--- a/test/unit/lib/plugins/plugin/lib/utils.test.js
+++ b/test/unit/lib/plugins/plugin/lib/utils.test.js
@@ -2,18 +2,13 @@
 
 const chai = require('chai');
 const sinon = require('sinon');
-const PluginList = require('../../../../../../lib/plugins/plugin/list');
 const pluginUtilsModule = require('../../../../../../lib/plugins/plugin/lib/utils.js');
-const Serverless = require('../../../../../../lib/serverless');
-const CLI = require('../../../../../../lib/classes/cli');
 const { log } = require('../../../../../../lib/utils/serverless-utils/log');
 const observeOutput = require('../../../../../lib/observe-output');
 
 const expect = chai.expect;
 
 describe('PluginUtils', () => {
-  let pluginUtils;
-  let serverless;
   const plugins = [
     {
       name: 'serverless-plugin-1',
@@ -31,13 +26,6 @@ describe('PluginUtils', () => {
       githubUrl: 'https://github.com/serverless/serverless-existing-plugin',
     },
   ];
-
-  beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.cli = new CLI(serverless);
-    const options = {};
-    pluginUtils = new PluginList(serverless, options);
-  });
 
   describe('#getPlugins()', () => {
     let fetchStub;
@@ -70,7 +58,7 @@ describe('PluginUtils', () => {
 
   describe('#display()', () => {
     it('should display the plugins if present', async () => {
-      const output = await observeOutput(() => pluginUtils.display(plugins));
+      const output = await observeOutput(() => pluginUtilsModule.display(plugins));
       let expectedMessage = '';
       expectedMessage += 'serverless-existing-plugin Serverless Existing plugin\n';
       expectedMessage += 'serverless-plugin-1 Serverless Plugin 1\n';
@@ -84,7 +72,7 @@ describe('PluginUtils', () => {
 
     it('should ignore malformed plugin records and still display valid plugins', async () => {
       const output = await observeOutput(() =>
-        pluginUtils.display([
+        pluginUtilsModule.display([
           {
             name: 'serverless-plugin-2',
             description: 'Serverless Plugin 2',
@@ -121,7 +109,7 @@ describe('PluginUtils', () => {
 
       try {
         const output = await observeOutput(() =>
-          pluginUtils.display([
+          pluginUtilsModule.display([
             null,
             {
               description: 'Missing name',

--- a/test/unit/lib/plugins/plugin/list.test.js
+++ b/test/unit/lib/plugins/plugin/list.test.js
@@ -3,8 +3,6 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const PluginList = require('../../../../../lib/plugins/plugin/list');
-const Serverless = require('../../../../../lib/serverless');
-const CLI = require('../../../../../lib/classes/cli');
 
 const expect = chai.expect;
 
@@ -13,8 +11,7 @@ describe('PluginList', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.cli = new CLI(serverless);
+    serverless = {};
     const options = {};
     pluginList = new PluginList(serverless, options);
   });

--- a/test/unit/lib/plugins/plugin/search.test.js
+++ b/test/unit/lib/plugins/plugin/search.test.js
@@ -2,8 +2,6 @@
 
 const sinon = require('sinon');
 const PluginSearch = require('../../../../../lib/plugins/plugin/search');
-const Serverless = require('../../../../../lib/serverless');
-const CLI = require('../../../../../lib/classes/cli');
 const expect = require('chai').expect;
 
 describe('PluginSearch', () => {
@@ -29,8 +27,7 @@ describe('PluginSearch', () => {
   ];
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    serverless.cli = new CLI(serverless);
+    serverless = {};
     const options = {};
     pluginSearch = new PluginSearch(serverless, options);
   });

--- a/test/unit/lib/plugins/remove.test.js
+++ b/test/unit/lib/plugins/remove.test.js
@@ -2,7 +2,6 @@
 
 const chai = require('chai');
 const Remove = require('../../../../lib/plugins/remove');
-const Serverless = require('../../../../lib/serverless');
 
 const expect = chai.expect;
 
@@ -11,7 +10,7 @@ describe('Remove', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = {};
     remove = new Remove(serverless);
   });
 

--- a/test/unit/lib/plugins/rollback.test.js
+++ b/test/unit/lib/plugins/rollback.test.js
@@ -2,14 +2,13 @@
 
 const expect = require('chai').expect;
 const Rollback = require('../../../../lib/plugins/rollback');
-const Serverless = require('../../../../lib/serverless');
 
 describe('Rollback', () => {
   let rollback;
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = {};
     rollback = new Rollback(serverless);
   });
 


### PR DESCRIPTION
This replaces direct Serverless construction in non-AWS plugin metadata and hook unit specs with minimal plugin-shaped fakes. It removes unused CLI and initialization scaffolding while keeping the assertions focused on command metadata, hook wiring, and utility behavior.