### PR TITLE
Replace utility and class Serverless fakes

### DIFF
--- a/test/unit/lib/classes/utils.test.js
+++ b/test/unit/lib/classes/utils.test.js
@@ -3,18 +3,25 @@
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
-const Serverless = require('../../../../lib/serverless');
 const Utils = require('../../../../lib/classes/utils');
+const YamlParser = require('../../../../lib/classes/yaml-parser');
 const { expect } = require('chai');
 const { getTmpFilePath, getTmpDirPath, removeSync } = require('../../../utils/fs');
+
+const createHarness = () => {
+  const serverlessLike = {};
+  serverlessLike.utils = new Utils(serverlessLike);
+  serverlessLike.yamlParser = new YamlParser(serverlessLike);
+  return serverlessLike;
+};
 
 describe('Utils', () => {
   let utils;
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
-    utils = new Utils(serverless);
+    serverless = createHarness();
+    utils = serverless.utils;
   });
 
   describe('#getTmpDirPath()', () => {

--- a/test/unit/lib/classes/yaml-parser.test.js
+++ b/test/unit/lib/classes/yaml-parser.test.js
@@ -8,13 +8,21 @@ const http = require('http');
 const yaml = require('js-yaml');
 const path = require('path');
 const { pathToFileURL } = require('url');
-const Serverless = require('../../../../lib/serverless');
+const Utils = require('../../../../lib/classes/utils');
+const YamlParser = require('../../../../lib/classes/yaml-parser');
 const { getTmpFilePath, getTmpDirPath } = require('../../../utils/fs');
 
 // Configure chai
 const expect = require('chai').expect;
 
-const serverless = new Serverless({ commands: [], options: {} });
+const createHarness = () => {
+  const serverlessLike = {};
+  serverlessLike.utils = new Utils(serverlessLike);
+  serverlessLike.yamlParser = new YamlParser(serverlessLike);
+  return serverlessLike;
+};
+
+const serverless = createHarness();
 
 describe('YamlParser', () => {
   describe('#parse()', () => {

--- a/test/unit/lib/utils/fs/write-file-sync.test.js
+++ b/test/unit/lib/utils/fs/write-file-sync.test.js
@@ -2,17 +2,25 @@
 
 const fsp = require('fs').promises;
 const path = require('path');
-const Serverless = require('../../../../../lib/serverless');
+const Utils = require('../../../../../lib/classes/utils');
+const YamlParser = require('../../../../../lib/classes/yaml-parser');
 const writeFileSync = require('../../../../../lib/utils/fs/write-file-sync');
 const readFileSync = require('../../../../../lib/utils/fs/read-file-sync');
 const { expect } = require('chai');
 const { getTmpFilePath } = require('../../../../utils/fs');
 
+const createHarness = () => {
+  const serverlessLike = {};
+  serverlessLike.utils = new Utils(serverlessLike);
+  serverlessLike.yamlParser = new YamlParser(serverlessLike);
+  return serverlessLike;
+};
+
 describe('#writeFileSync()', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = createHarness();
   });
 
   it('should write a .json file synchronously', () => {

--- a/test/unit/lib/utils/fs/write-file.test.js
+++ b/test/unit/lib/utils/fs/write-file.test.js
@@ -2,7 +2,8 @@
 
 const fsp = require('fs').promises;
 const path = require('path');
-const Serverless = require('../../../../../lib/serverless');
+const Utils = require('../../../../../lib/classes/utils');
+const YamlParser = require('../../../../../lib/classes/yaml-parser');
 const writeFile = require('../../../../../lib/utils/fs/write-file');
 const readFile = require('../../../../../lib/utils/fs/read-file');
 const { getTmpFilePath } = require('../../../../utils/fs');
@@ -10,12 +11,19 @@ const { getTmpFilePath } = require('../../../../utils/fs');
 // Configure chai
 const expect = require('chai').expect;
 
+const createHarness = () => {
+  const serverlessLike = {};
+  serverlessLike.utils = new Utils(serverlessLike);
+  serverlessLike.yamlParser = new YamlParser(serverlessLike);
+  return serverlessLike;
+};
+
 describe('#writeFile()', function () {
   let serverless;
   this.timeout(0);
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = createHarness();
   });
 
   it('should write a .json file asynchronously', async () => {

--- a/test/unit/lib/utils/rename-service.test.js
+++ b/test/unit/lib/utils/rename-service.test.js
@@ -1,12 +1,20 @@
 'use strict';
 
-const Serverless = require('../../../../lib/serverless');
+const Utils = require('../../../../lib/classes/utils');
+const YamlParser = require('../../../../lib/classes/yaml-parser');
 const fs = require('fs');
 const path = require('path');
 const { expect } = require('chai');
 const { ensureDirSync, getTmpDirPath } = require('../../../utils/fs');
 
 const { renameService } = require('../../../../lib/utils/rename-service');
+
+const createHarness = () => {
+  const serverlessLike = {};
+  serverlessLike.utils = new Utils(serverlessLike);
+  serverlessLike.yamlParser = new YamlParser(serverlessLike);
+  return serverlessLike;
+};
 
 describe('renameService', () => {
   let serverless;
@@ -23,8 +31,7 @@ describe('renameService', () => {
 
     serviceDir = tmpDir;
 
-    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
-    return serverless.init();
+    serverless = createHarness();
   });
 
   afterEach(() => {


### PR DESCRIPTION
This replaces direct Serverless construction in utility and class unit specs with minimal Utils and YamlParser harnesses. It removes framework initialization from pure utility coverage while preserving the existing filesystem helper, service renaming, and YAML parser assertions.