### PR TITLE
Include SnapStart in Lambda version hashes

### DIFF
--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -275,6 +275,12 @@ class AwsCompileFunctions {
       functionResource.Properties.Description = functionObject.description;
     }
 
+    if (functionObject.snapStart) {
+      functionResource.Properties.SnapStart = {
+        ApplyOn: 'PublishedVersions',
+      };
+    }
+
     if (functionObject.condition) {
       functionResource.Condition = functionObject.condition;
     }
@@ -624,10 +630,6 @@ class AwsCompileFunctions {
 
       if (functionObject.snapStart) {
         if (!shouldVersionFunction) delete versionResource.DeletionPolicy;
-
-        functionResource.Properties.SnapStart = {
-          ApplyOn: 'PublishedVersions',
-        };
 
         const aliasLogicalId = this.provider.naming.getLambdaSnapStartAliasLogicalId(functionName);
         const aliasName = this.provider.naming.getLambdaSnapStartEnabledAliasName();

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -3026,6 +3026,36 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
         expect(originalVersionArn).to.equal(updatedVersionArn);
       });
 
+      it('should create a different version if SnapStart changed', async () => {
+        const packageService = async (snapStart) => {
+          const { servicePath: serviceDir, updateConfig } = await fixtures.setup('function', {
+            configExt,
+          });
+
+          await updateConfig({
+            functions: {
+              basic: {
+                runtime: 'java17',
+                versionFunction: true,
+                snapStart,
+              },
+            },
+          });
+
+          const { cfTemplate } = await runServerless({
+            cwd: serviceDir,
+            command: 'package',
+          });
+
+          return cfTemplate.Outputs.BasicLambdaFunctionQualifiedArn.Value.Ref;
+        };
+
+        const versionWithoutSnapStart = await packageService(false);
+        const versionWithSnapStart = await packageService(true);
+
+        expect(versionWithoutSnapStart).to.not.equal(versionWithSnapStart);
+      });
+
       describe('with layers', () => {
         let firstCfTemplate;
         let serviceDir;

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -3027,33 +3027,52 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
       });
 
       it('should create a different version if SnapStart changed', async () => {
-        const packageService = async (snapStart) => {
-          const { servicePath: serviceDir, updateConfig } = await fixtures.setup('function', {
-            configExt,
-          });
+        const { servicePath: serviceDir, updateConfig } = await fixtures.setup('function', {
+          configExt,
+        });
 
-          await updateConfig({
-            functions: {
-              basic: {
-                runtime: 'java17',
-                versionFunction: true,
-                snapStart,
-              },
+        await updateConfig({
+          functions: {
+            basic: {
+              runtime: 'java17',
+              versionFunction: true,
+              snapStart: false,
             },
-          });
+          },
+        });
 
-          const { cfTemplate } = await runServerless({
-            cwd: serviceDir,
-            command: 'package',
-          });
+        const { cfTemplate: originalTemplate } = await runServerless({
+          cwd: serviceDir,
+          command: 'package',
+        });
 
-          return cfTemplate.Outputs.BasicLambdaFunctionQualifiedArn.Value.Ref;
-        };
+        const originalVersionArn =
+          originalTemplate.Outputs.BasicLambdaFunctionQualifiedArn.Value.Ref;
 
-        const versionWithoutSnapStart = await packageService(false);
-        const versionWithSnapStart = await packageService(true);
+        await updateConfig({
+          functions: {
+            basic: {
+              runtime: 'java17',
+              versionFunction: true,
+              snapStart: true,
+            },
+          },
+        });
 
-        expect(versionWithoutSnapStart).to.not.equal(versionWithSnapStart);
+        const { cfTemplate: updatedTemplate } = await runServerless({
+          cwd: serviceDir,
+          command: 'package',
+        });
+
+        const updatedVersionArn = updatedTemplate.Outputs.BasicLambdaFunctionQualifiedArn.Value.Ref;
+
+        expect(originalTemplate.Resources.BasicLambdaFunction.Properties).to.not.have.property(
+          'SnapStart'
+        );
+        expect(updatedTemplate.Resources.BasicLambdaFunction.Properties.SnapStart).to.deep.equal({
+          ApplyOn: 'PublishedVersions',
+        });
+        expect(originalVersionArn).to.not.equal(updatedVersionArn);
       });
 
       describe('with layers', () => {


### PR DESCRIPTION
This moves the SnapStart property into the Lambda function resource before version hashes are calculated. This ensures changing SnapStart publishes a new Lambda version.