### PR TITLE
Harden target alias dependencies

### DIFF
--- a/lib/plugins/aws/package/compile/events/event-bridge/index.js
+++ b/lib/plugins/aws/package/compile/events/event-bridge/index.js
@@ -444,8 +444,11 @@ class AwsCompileEventBridgeEvents {
     };
     // If this stack is creating the event bus the rule must depend on it to ensure stack can be removed
     if (shouldCreateEventBus) {
-      eventRuleResource.DependsOn =
-        this.provider.naming.getEventBridgeEventBusLogicalId(eventBusName);
+      const dependsOn = [
+        eventRuleResource.DependsOn,
+        this.provider.naming.getEventBridgeEventBusLogicalId(eventBusName),
+      ].filter(Boolean);
+      eventRuleResource.DependsOn = dependsOn.length === 1 ? dependsOn[0] : dependsOn;
     }
 
     const ruleNameLogicalIdStub = makeRuleName({

--- a/lib/plugins/aws/package/compile/events/sns.js
+++ b/lib/plugins/aws/package/compile/events/sns.js
@@ -3,6 +3,20 @@
 const ServerlessError = require('../../../../../serverless-error');
 const resolveLambdaTarget = require('../../../utils/resolve-lambda-target');
 
+const mergeDependsOn = (resource, dependency) => {
+  if (!dependency) return;
+  if (!resource.DependsOn) {
+    resource.DependsOn = dependency;
+    return;
+  }
+
+  const dependencies = Array.isArray(resource.DependsOn)
+    ? resource.DependsOn
+    : [resource.DependsOn];
+  if (!dependencies.includes(dependency)) dependencies.push(dependency);
+  resource.DependsOn = dependencies.length === 1 ? dependencies[0] : dependencies;
+};
+
 class AwsCompileSNSEvents {
   constructor(serverless, options) {
     this.serverless = serverless;
@@ -171,6 +185,8 @@ class AwsCompileSNSEvents {
             }
 
             const endpoint = resolveLambdaTarget(functionName, functionObj);
+            const targetAliasLogicalId =
+              functionObj.targetAlias && functionObj.targetAlias.logicalId;
 
             const subscriptionLogicalId = this.provider.naming.getLambdaSnsSubscriptionLogicalId(
               functionName,
@@ -180,7 +196,7 @@ class AwsCompileSNSEvents {
             if (topicArn) {
               template.Resources[subscriptionLogicalId] = {
                 Type: 'AWS::SNS::Subscription',
-                DependsOn: functionObj.targetAlias && functionObj.targetAlias.logicalId,
+                DependsOn: targetAliasLogicalId,
                 Properties: {
                   TopicArn: topicArn,
                   Protocol: 'lambda',
@@ -222,14 +238,16 @@ class AwsCompileSNSEvents {
                 }
                 template.Resources[topicLogicalId] = {
                   Type: 'AWS::SNS::Topic',
-                  DependsOn: functionObj.targetAlias && functionObj.targetAlias.logicalId,
+                  DependsOn: targetAliasLogicalId,
                   Properties: topicResourceProperties,
                 };
               }
+              mergeDependsOn(template.Resources[topicLogicalId], targetAliasLogicalId);
 
               if (event.sns.filterPolicy || redrivePolicy) {
                 template.Resources[subscriptionLogicalId] = {
                   Type: 'AWS::SNS::Subscription',
+                  DependsOn: targetAliasLogicalId,
                   Properties: Object.assign({}, subscription, {
                     TopicArn: {
                       Ref: topicLogicalId,
@@ -254,7 +272,7 @@ class AwsCompileSNSEvents {
 
             template.Resources[lambdaPermissionLogicalId] = {
               Type: 'AWS::Lambda::Permission',
-              DependsOn: functionObj.targetAlias && functionObj.targetAlias.logicalId,
+              DependsOn: targetAliasLogicalId,
               Properties: {
                 FunctionName: endpoint,
                 Action: 'lambda:InvokeFunction',

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -171,7 +171,7 @@ class AwsCompileFunctions {
     const cfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;
     const functionResource = this.cfLambdaFunctionTemplate();
     const functionObject = this.serverless.service.getFunction(functionName);
-    this.initializeTargetAlias(functionName, functionObject);
+    this.initializeTargetAliases();
     functionObject.package = functionObject.package || {};
     const enforceHashUpdate = this.options['enforce-hash-update'];
 

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -40,6 +40,12 @@ const appendIfMissing = (items, item) => {
 
 const uniq = (items) => Array.from(new Set(items));
 
+const normalizeDependsOn = (items) => {
+  const dependencies = uniq(items.filter(Boolean));
+  if (!dependencies.length) return undefined;
+  return dependencies.length === 1 ? dependencies[0] : dependencies;
+};
+
 const getTargetAliasLogicalId = (functionObject) =>
   functionObject.targetAlias && functionObject.targetAlias.logicalId;
 
@@ -165,6 +171,7 @@ class AwsCompileFunctions {
     const cfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;
     const functionResource = this.cfLambdaFunctionTemplate();
     const functionObject = this.serverless.service.getFunction(functionName);
+    this.initializeTargetAlias(functionName, functionObject);
     functionObject.package = functionObject.package || {};
     const enforceHashUpdate = this.options['enforce-hash-update'];
 
@@ -606,11 +613,8 @@ class AwsCompileFunctions {
       if (functionObject.provisionedConcurrency) {
         if (!shouldVersionFunction) delete versionResource.DeletionPolicy;
 
-        const aliasLogicalId =
-          this.provider.naming.getLambdaProvisionedConcurrencyAliasLogicalId(functionName);
-        const aliasName = this.provider.naming.getLambdaProvisionedConcurrencyAliasName();
-
-        functionObject.targetAlias = { name: aliasName, logicalId: aliasLogicalId };
+        const aliasLogicalId = functionObject.targetAlias.logicalId;
+        const aliasName = functionObject.targetAlias.name;
 
         const aliasResource = {
           Type: 'AWS::Lambda::Alias',
@@ -631,10 +635,8 @@ class AwsCompileFunctions {
       if (functionObject.snapStart) {
         if (!shouldVersionFunction) delete versionResource.DeletionPolicy;
 
-        const aliasLogicalId = this.provider.naming.getLambdaSnapStartAliasLogicalId(functionName);
-        const aliasName = this.provider.naming.getLambdaSnapStartEnabledAliasName();
-
-        functionObject.targetAlias = { name: aliasName, logicalId: aliasLogicalId };
+        const aliasLogicalId = functionObject.targetAlias.logicalId;
+        const aliasName = functionObject.targetAlias.name;
 
         const aliasResource = {
           Type: 'AWS::Lambda::Alias',
@@ -827,7 +829,15 @@ class AwsCompileFunctions {
         DestinationConfig: destinationConfig,
         Qualifier: functionObject.targetAlias ? functionObject.targetAlias.name : '$LATEST',
       },
-      DependsOn: getTargetAliasLogicalId(functionObject),
+      DependsOn: normalizeDependsOn([
+        getTargetAliasLogicalId(functionObject),
+        ...(destinations
+          ? [
+              this.getDestinationTargetAliasLogicalId(destinations.onSuccess),
+              this.getDestinationTargetAliasLogicalId(destinations.onFailure),
+            ]
+          : []),
+      ]),
     };
 
     if (maximumEventAge) {
@@ -848,6 +858,14 @@ class AwsCompileFunctions {
     return destinationsProperty.startsWith('arn:')
       ? destinationsProperty
       : this.provider.resolveFunctionArn(destinationsProperty);
+  }
+
+  getDestinationTargetAliasLogicalId(destinationsProperty) {
+    if (typeof destinationsProperty !== 'string' || destinationsProperty.startsWith('arn:')) {
+      return undefined;
+    }
+
+    return getTargetAliasLogicalId(this.serverless.service.getFunction(destinationsProperty));
   }
 
   // Memoized in a constructor
@@ -897,13 +915,18 @@ class AwsCompileFunctions {
       // Note: Cannot address function via { 'Fn::GetAtt': [targetLogicalId, 'Arn'] }
       // as same IAM settings are used for target function and that will introduce
       // circular dependency error. Relying on Fn::Sub as a workaround
-      ResourceArn = destinationsProperty.startsWith('arn:')
-        ? destinationsProperty
-        : {
-            'Fn::Sub': `arn:\${AWS::Partition}:lambda:\${AWS::Region}:\${AWS::AccountId}:function:${
-              this.serverless.service.getFunction(destinationsProperty).name
-            }`,
-          };
+      if (destinationsProperty.startsWith('arn:')) {
+        ResourceArn = destinationsProperty;
+      } else {
+        const targetFunctionObject = this.serverless.service.getFunction(destinationsProperty);
+        const targetAliasName =
+          targetFunctionObject.targetAlias && targetFunctionObject.targetAlias.name;
+        ResourceArn = {
+          'Fn::Sub': `arn:\${AWS::Partition}:lambda:\${AWS::Region}:\${AWS::AccountId}:function:${
+            targetFunctionObject.name
+          }${targetAliasName ? `:${targetAliasName}` : ''}`,
+        };
+      }
     }
     iamPolicyStatements.push({ Effect: 'Allow', Action: action, Resource: ResourceArn });
   }
@@ -916,8 +939,29 @@ class AwsCompileFunctions {
     }
   }
 
+  initializeTargetAlias(functionName, functionObject) {
+    if (functionObject.provisionedConcurrency) {
+      functionObject.targetAlias = {
+        name: this.provider.naming.getLambdaProvisionedConcurrencyAliasName(),
+        logicalId: this.provider.naming.getLambdaProvisionedConcurrencyAliasLogicalId(functionName),
+      };
+    } else if (functionObject.snapStart) {
+      functionObject.targetAlias = {
+        name: this.provider.naming.getLambdaSnapStartEnabledAliasName(),
+        logicalId: this.provider.naming.getLambdaSnapStartAliasLogicalId(functionName),
+      };
+    }
+  }
+
+  initializeTargetAliases() {
+    for (const functionName of this.serverless.service.getAllFunctions()) {
+      this.initializeTargetAlias(functionName, this.serverless.service.getFunction(functionName));
+    }
+  }
+
   async compileFunctions() {
     const allFunctions = this.serverless.service.getAllFunctions();
+    this.initializeTargetAliases();
     return Promise.all(allFunctions.map((functionName) => this.compileFunction(functionName)));
   }
 

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -25,6 +25,7 @@ const { methodDescriptor } = require('../../utils/property-descriptors');
 const { hasOwn } = require('../../utils/safe-object');
 const { progress, log } = require('../../utils/serverless-utils/log');
 const validateStage = require('../../utils/validate-stage');
+const resolveLambdaTarget = require('./utils/resolve-lambda-target');
 
 const isLambdaArn = RegExp.prototype.test.bind(/^arn:[^:]+:lambda:/);
 const isEcrUri = RegExp.prototype.test.bind(
@@ -1997,13 +1998,7 @@ class AwsProvider {
   resolveFunctionArn(functionAddress) {
     if (isLambdaArn(functionAddress)) return functionAddress;
     const functionData = this.serverless.service.getFunction(functionAddress);
-    if (functionData) {
-      const logicalId = this.naming.getLambdaLogicalId(functionAddress);
-      const alias = functionData.targetAlias;
-      const arnGetter = { 'Fn::GetAtt': [logicalId, 'Arn'] };
-      if (!alias) return arnGetter;
-      return { 'Fn::Join': [':', [arnGetter, alias.name]] };
-    }
+    if (functionData) return resolveLambdaTarget(functionAddress, functionData);
     throw new ServerlessError(
       `Unrecognized function address ${functionAddress}`,
       'UNRECOGNIZED_FUNCTION_ADDRESS'

--- a/lib/plugins/aws/utils/resolve-lambda-target.js
+++ b/lib/plugins/aws/utils/resolve-lambda-target.js
@@ -1,13 +1,12 @@
 'use strict';
 
-const memoizee = require('memoizee');
 const naming = require('../lib/naming');
 
-const resolveLambdaTarget = memoizee((functionName, functionObject) => {
+const resolveLambdaTarget = (functionName, functionObject) => {
   const lambdaLogicalId = naming.getLambdaLogicalId(functionName);
   const functionArnGetter = { 'Fn::GetAtt': [lambdaLogicalId, 'Arn'] };
   if (!functionObject.targetAlias) return functionArnGetter;
   return { 'Fn::Join': [':', [functionArnGetter, functionObject.targetAlias.name]] };
-});
+};
 
 module.exports = resolveLambdaTarget;

--- a/test/unit/lib/plugins/aws/package/compile/events/event-bridge/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/event-bridge/index.test.js
@@ -607,6 +607,52 @@ describe('EventBridgeEvents', () => {
         expect(ruleTarget.Arn['Fn::GetAtt'][0]).to.equal(naming.getLambdaLogicalId('basic'));
       });
 
+      it('should merge created EventBus and target alias dependencies', async () => {
+        const { cfTemplate, awsNaming } = await runServerless({
+          fixture: 'function',
+          configExt: {
+            functions: {
+              basic: {
+                provisionedConcurrency: 1,
+                events: [
+                  {
+                    eventBridge: {
+                      eventBus: eventBusName,
+                      schedule,
+                    },
+                  },
+                ],
+              },
+            },
+          },
+          command: 'package',
+        });
+        const resources = cfTemplate.Resources;
+        const createdRuleResource = Object.values(resources).find(
+          (resource) => resource.Type === 'AWS::Events::Rule'
+        );
+        const aliasLogicalId = awsNaming.getLambdaProvisionedConcurrencyAliasLogicalId('basic');
+
+        expect(createdRuleResource.DependsOn).to.have.members([
+          aliasLogicalId,
+          awsNaming.getEventBridgeEventBusLogicalId(eventBusName),
+        ]);
+        expect(createdRuleResource.Properties.Targets[0].Arn).to.deep.equal({
+          'Fn::Join': [
+            ':',
+            [
+              {
+                'Fn::GetAtt': [awsNaming.getLambdaLogicalId('basic'), 'Arn'],
+              },
+              'provisioned',
+            ],
+          ],
+        });
+        expect(
+          resources[awsNaming.getEventBridgeLambdaPermissionLogicalId('basic', 1)].DependsOn
+        ).to.equal(aliasLogicalId);
+      });
+
       it('should create a lambda permission resource that correctly references event bus in SourceArn', () => {
         const lambdaPermissionResource =
           cfResources[naming.getEventBridgeLambdaPermissionLogicalId('basic', 1)];

--- a/test/unit/lib/plugins/aws/package/compile/events/sns.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/sns.test.js
@@ -208,6 +208,69 @@ describe('AwsCompileSNSEvents', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
 
+    it('should merge generated topic dependencies for aliased inline subscriptions', () => {
+      awsCompileSNSEvents.serverless.service.functions = {
+        first: {
+          targetAlias: { name: 'provisioned', logicalId: 'FirstAlias' },
+          events: [{ sns: 'SharedTopic' }],
+        },
+        second: {
+          targetAlias: { name: 'provisioned', logicalId: 'SecondAlias' },
+          events: [{ sns: 'SharedTopic' }],
+        },
+      };
+
+      awsCompileSNSEvents.compileSNSEvents();
+
+      const resources =
+        awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+      expect(resources.SNSTopicSharedTopic.DependsOn).to.have.members([
+        'FirstAlias',
+        'SecondAlias',
+      ]);
+      expect(resources.SNSTopicSharedTopic.Properties.Subscription).to.deep.equal([
+        {
+          Endpoint: {
+            'Fn::Join': [':', [{ 'Fn::GetAtt': ['FirstLambdaFunction', 'Arn'] }, 'provisioned']],
+          },
+          Protocol: 'lambda',
+        },
+        {
+          Endpoint: {
+            'Fn::Join': [':', [{ 'Fn::GetAtt': ['SecondLambdaFunction', 'Arn'] }, 'provisioned']],
+          },
+          Protocol: 'lambda',
+        },
+      ]);
+    });
+
+    it('should make generated subscriptions depend on target aliases', () => {
+      awsCompileSNSEvents.serverless.service.functions = {
+        first: {
+          targetAlias: { name: 'provisioned', logicalId: 'FirstAlias' },
+          events: [
+            {
+              sns: {
+                topicName: 'Topic 1',
+                filterPolicy: { pet: ['dog'] },
+              },
+            },
+          ],
+        },
+      };
+
+      awsCompileSNSEvents.compileSNSEvents();
+
+      const resources =
+        awsCompileSNSEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+      expect(resources.SNSTopicTopic1.DependsOn).to.equal('FirstAlias');
+      expect(resources.FirstSnsSubscriptionTopic1.DependsOn).to.equal('FirstAlias');
+      expect(resources.FirstSnsSubscriptionTopic1.Properties.Endpoint).to.deep.equal({
+        'Fn::Join': [':', [{ 'Fn::GetAtt': ['FirstLambdaFunction', 'Arn'] }, 'provisioned']],
+      });
+      expect(resources.FirstLambdaPermissionTopic1SNS.DependsOn).to.equal('FirstAlias');
+    });
+
     it('should throw an error when the event an object and the displayName is not given', () => {
       awsCompileSNSEvents.serverless.service.functions = {
         first: {

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1135,6 +1135,46 @@ describe('AwsCompileFunctions', () => {
         ).to.deep.equal(['FuncLogGroup', 'MyThing', 'MyOtherThing']);
       });
     });
+
+    it('should initialize target aliases when compiling one function', async () => {
+      awsCompileFunctions.serverless.service.functions = {
+        source: {
+          handler: 'source.handler',
+          name: 'source',
+          role: 'arn:aws:iam::123456789012:role/source-role',
+          destinations: { onSuccess: 'target' },
+        },
+        target: {
+          handler: 'target.handler',
+          name: 'target',
+          provisionedConcurrency: 1,
+        },
+      };
+
+      await awsCompileFunctions.compileFunction('source');
+
+      const eventConfig =
+        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate.Resources[
+          awsProvider.naming.getLambdaEventConfigLogicalId('source')
+        ];
+
+      expect(eventConfig.DependsOn).to.equal(
+        awsProvider.naming.getLambdaProvisionedConcurrencyAliasLogicalId('target')
+      );
+      expect(eventConfig.Properties.DestinationConfig).to.deep.equal({
+        OnSuccess: {
+          Destination: {
+            'Fn::Join': [
+              ':',
+              [
+                { 'Fn::GetAtt': [awsProvider.naming.getLambdaLogicalId('target'), 'Arn'] },
+                'provisioned',
+              ],
+            ],
+          },
+        },
+      });
+    });
   });
 });
 

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1816,6 +1816,15 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
             fnTargetFailure: {
               handler: 'target.handler',
             },
+            fnProvisionedDestinationTarget: {
+              handler: 'target.handler',
+              provisionedConcurrency: 1,
+            },
+            fnProvisionedDestinationSource: {
+              handler: 'trigger.handler',
+              provisionedConcurrency: 1,
+              destinations: { onSuccess: 'fnProvisionedDestinationTarget' },
+            },
             fnDestinationsOnFailure: {
               handler: 'trigger.handler',
               destinations: { onFailure: 'fnTargetFailure' },
@@ -2169,21 +2178,23 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
     });
 
     it('should support `functions[].url` set to `true` with provisionedConcurrency set', () => {
+      const provisionedTarget = {
+        'Fn::Join': [
+          ':',
+          [
+            {
+              'Fn::GetAtt': ['FnUrlWithProvisionedLambdaFunction', 'Arn'],
+            },
+            'provisioned',
+          ],
+        ],
+      };
+
       expect(
         cfResources[naming.getLambdaFunctionUrlLogicalId('fnUrlWithProvisioned')].Properties
       ).to.deep.equal({
         AuthType: 'NONE',
-        TargetFunctionArn: {
-          'Fn::Join': [
-            ':',
-            [
-              {
-                'Fn::GetAtt': ['FnUrlWithProvisionedLambdaFunction', 'Arn'],
-              },
-              'provisioned',
-            ],
-          ],
-        },
+        TargetFunctionArn: provisionedTarget,
       });
       expect(
         cfResources[naming.getLambdaFunctionUrlLogicalId('fnUrlWithProvisioned')].DependsOn
@@ -2201,6 +2212,25 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
       });
       expect(
         cfResources[naming.getLambdaFnUrlPermissionLogicalId('fnUrlWithProvisioned')].DependsOn
+      ).to.equal('FnUrlWithProvisionedProvConcLambdaAlias');
+      expect(
+        cfResources[naming.getLambdaFnUrlPermissionLogicalId('fnUrlWithProvisioned')].Properties
+      ).to.deep.equal({
+        Action: 'lambda:InvokeFunctionUrl',
+        FunctionName: provisionedTarget,
+        FunctionUrlAuthType: 'NONE',
+        Principal: '*',
+      });
+      expect(
+        cfResources[naming.getLambdaFnPermissionLogicalId('fnUrlWithProvisioned')].Properties
+      ).to.deep.equal({
+        Action: 'lambda:InvokeFunction',
+        FunctionName: provisionedTarget,
+        InvokedViaFunctionUrl: true,
+        Principal: '*',
+      });
+      expect(
+        cfResources[naming.getLambdaFnPermissionLogicalId('fnUrlWithProvisioned')].DependsOn
       ).to.equal('FnUrlWithProvisionedProvConcLambdaAlias');
     });
 
@@ -2323,6 +2353,41 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
           'Fn::Sub': `arn:\${AWS::Partition}:lambda:\${AWS::Region}:\${AWS::AccountId}:function:${
             serverless.service.getFunction('fnTargetFailure').name
           }`,
+        },
+      });
+    });
+
+    it('should support `functions[].destinations` referencing a provisioned function in same stack', () => {
+      const target = {
+        'Fn::Join': [
+          ':',
+          [
+            {
+              'Fn::GetAtt': [naming.getLambdaLogicalId('fnProvisionedDestinationTarget'), 'Arn'],
+            },
+            'provisioned',
+          ],
+        ],
+      };
+      const eventConfig =
+        cfResources[naming.getLambdaEventConfigLogicalId('fnProvisionedDestinationSource')];
+
+      expect(eventConfig.Properties.Qualifier).to.equal('provisioned');
+      expect(eventConfig.Properties.DestinationConfig).to.deep.equal({
+        OnSuccess: { Destination: target },
+      });
+      expect(eventConfig.DependsOn).to.have.members([
+        naming.getLambdaProvisionedConcurrencyAliasLogicalId('fnProvisionedDestinationSource'),
+        naming.getLambdaProvisionedConcurrencyAliasLogicalId('fnProvisionedDestinationTarget'),
+      ]);
+
+      expect(iamRolePolicyStatements).to.deep.include({
+        Effect: 'Allow',
+        Action: 'lambda:InvokeFunction',
+        Resource: {
+          'Fn::Sub': `arn:\${AWS::Partition}:lambda:\${AWS::Region}:\${AWS::AccountId}:function:${
+            serverless.service.getFunction('fnProvisionedDestinationTarget').name
+          }:provisioned`,
         },
       });
     });

--- a/test/unit/lib/plugins/aws/utils/resolve-lambda-target.test.js
+++ b/test/unit/lib/plugins/aws/utils/resolve-lambda-target.test.js
@@ -19,4 +19,19 @@ describe('#resolveLambdaTarget', () => {
       'Fn::Join': [':', [{ 'Fn::GetAtt': ['FooLambdaFunction', 'Arn'] }, 'provisioned']],
     });
   });
+
+  it('should reflect a target alias added after an earlier unqualified resolution', () => {
+    const functionObj = {};
+    const functionName = 'foo';
+
+    expect(resolveLambdaTarget(functionName, functionObj)).to.deep.equal({
+      'Fn::GetAtt': ['FooLambdaFunction', 'Arn'],
+    });
+
+    functionObj.targetAlias = { name: 'provisioned' };
+
+    expect(resolveLambdaTarget(functionName, functionObj)).to.deep.equal({
+      'Fn::Join': [':', [{ 'Fn::GetAtt': ['FooLambdaFunction', 'Arn'] }, 'provisioned']],
+    });
+  });
 });


### PR DESCRIPTION
This initializes Lambda target aliases before function compilation and removes stale target resolution caching. It preserves alias dependencies for EventBridge, SNS, Function URLs, and async destinations.