### PR TITLE
Clean up 4.x target alias merge

### DIFF
--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -63,6 +63,7 @@ class AwsCompileFunctions {
 
     this.seenTargetExecutionPermissionKeys = new Set();
     this.seenTargetExecutionPermissionObjects = new WeakSet();
+    this.targetAliasesInitialized = false;
     if (
       this.serverless.service.provider.name === 'aws' &&
       this.serverless.service.provider.versionFunctions == null
@@ -160,7 +161,7 @@ class AwsCompileFunctions {
     const cfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;
     const functionResource = this.cfLambdaFunctionTemplate();
     const functionObject = this.serverless.service.getFunction(functionName);
-    this.initializeTargetAliases();
+    this.ensureTargetAliasesInitialized();
     functionObject.package = functionObject.package || {};
 
     if (!functionObject.handler && !functionObject.image) {
@@ -925,9 +926,15 @@ class AwsCompileFunctions {
     }
   }
 
+  ensureTargetAliasesInitialized() {
+    if (this.targetAliasesInitialized) return;
+    this.initializeTargetAliases();
+    this.targetAliasesInitialized = true;
+  }
+
   async compileFunctions() {
     const allFunctions = this.serverless.service.getAllFunctions();
-    this.initializeTargetAliases();
+    this.ensureTargetAliasesInitialized();
     return Promise.all(allFunctions.map((functionName) => this.compileFunction(functionName)));
   }
 

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1388,6 +1388,12 @@ describe('AwsCompileFunctions', () => {
           awsProvider.naming.getLambdaEventConfigLogicalId('source')
         ];
 
+      expect(
+        awsCompileFunctions.serverless.service.getFunction('target').targetAlias
+      ).to.deep.equal({
+        name: awsProvider.naming.getLambdaProvisionedConcurrencyAliasName(),
+        logicalId: awsProvider.naming.getLambdaProvisionedConcurrencyAliasLogicalId('target'),
+      });
       expect(eventConfig.DependsOn).to.equal(
         awsProvider.naming.getLambdaProvisionedConcurrencyAliasLogicalId('target')
       );
@@ -3526,18 +3532,25 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
           },
         });
 
-        const { cfTemplate: updatedTemplate } = await runServerless({
+        const { awsNaming, cfTemplate: updatedTemplate } = await runServerless({
           cwd: serviceDir,
           command: 'package',
         });
 
         const updatedVersionArn = updatedTemplate.Outputs.BasicLambdaFunctionQualifiedArn.Value.Ref;
+        const snapStartAlias =
+          updatedTemplate.Resources[awsNaming.getLambdaSnapStartAliasLogicalId('basic')];
 
         expect(originalTemplate.Resources.BasicLambdaFunction.Properties).to.not.have.property(
           'SnapStart'
         );
         expect(updatedTemplate.Resources.BasicLambdaFunction.Properties.SnapStart).to.deep.equal({
           ApplyOn: 'PublishedVersions',
+        });
+        expect(snapStartAlias.Properties).to.deep.equal({
+          FunctionName: { Ref: awsNaming.getLambdaLogicalId('basic') },
+          FunctionVersion: { 'Fn::GetAtt': [updatedVersionArn, 'Version'] },
+          Name: awsNaming.getLambdaSnapStartEnabledAliasName(),
         });
         expect(originalVersionArn).to.not.equal(updatedVersionArn);
       });

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -3491,9 +3491,12 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
       });
 
       it('should create a different version if SnapStart changed', async () => {
-        const { servicePath: serviceDir, updateConfig } = await fixtures.setup('function', {
-          configExt,
-        });
+        const { servicePath: serviceDir, updateConfig } = await setupProgrammaticFixture(
+          'function',
+          {
+            configExt: {},
+          }
+        );
 
         await updateConfig({
           functions: {


### PR DESCRIPTION
This updates the merged SnapStart hash test to use the 4.x fixture helper. It also avoids repeated target alias initialization during package compilation while preserving single-function compilation behavior.