### PR TITLE
Support qualified existing event targets

### DIFF
--- a/lib/plugins/aws/custom-resources/resources/cognito-user-pool/handler.js
+++ b/lib/plugins/aws/custom-resources/resources/cognito-user-pool/handler.js
@@ -30,14 +30,16 @@ async function create(event, context) {
         region: Region,
         accountId: AccountId,
         userPoolId: userPool.Id,
-      }).then(() =>
-        updateConfiguration({
-          lambdaArn: target.lambdaArn,
-          userPoolName: target.userPoolName,
-          userPoolConfigs: target.userPoolConfigs,
-          region: Region,
-        })
-      )
+      })
+        .catch(ignoreExistingPermission)
+        .then(() =>
+          updateConfiguration({
+            lambdaArn: target.lambdaArn,
+            userPoolName: target.userPoolName,
+            userPoolConfigs: target.userPoolConfigs,
+            region: Region,
+          })
+        )
   );
 }
 
@@ -61,12 +63,13 @@ async function update(event, context) {
       region: Region,
       accountId: AccountId,
       userPoolId: userPool.Id,
-    });
+    }).catch(ignoreExistingPermission);
   }
 
   await updateConfiguration({
     lambdaArn: target.lambdaArn,
-    previousLambdaArn: oldTarget && oldTarget.lambdaArn,
+    previousLambdaArn:
+      oldTarget && oldTarget.userPoolName === target.userPoolName ? oldTarget.lambdaArn : undefined,
     userPoolName: target.userPoolName,
     userPoolConfigs: target.userPoolConfigs,
     region: Region,
@@ -100,13 +103,15 @@ async function remove(event, context) {
     functionQualifier: target.functionQualifier,
     userPoolName: target.userPoolName,
     region: Region,
-  }).then(() =>
-    removeConfiguration({
-      lambdaArn: target.lambdaArn,
-      userPoolName: target.userPoolName,
-      region: Region,
-    })
-  );
+  })
+    .catch(ignoreMissingPermission)
+    .then(() =>
+      removeConfiguration({
+        lambdaArn: target.lambdaArn,
+        userPoolName: target.userPoolName,
+        region: Region,
+      })
+    );
 }
 
 function resolveTarget(properties, environment) {
@@ -138,6 +143,13 @@ function isSameTarget(target, oldTarget) {
 
 function ignoreMissingPermission(error) {
   if (error && [error.name, error.Code, error.code].includes('ResourceNotFoundException')) {
+    return;
+  }
+  throw error;
+}
+
+function ignoreExistingPermission(error) {
+  if (error && [error.name, error.Code, error.code].includes('ResourceConflictException')) {
     return;
   }
   throw error;

--- a/lib/plugins/aws/custom-resources/resources/cognito-user-pool/handler.js
+++ b/lib/plugins/aws/custom-resources/resources/cognito-user-pool/handler.js
@@ -16,61 +16,131 @@ async function handler(event, context) {
 }
 
 async function create(event, context) {
-  const { FunctionName, UserPoolName, UserPoolConfigs } = event.ResourceProperties;
-  const { Partition, Region, AccountId } = getEnvironment(context);
+  const environment = getEnvironment(context);
+  const { Partition, Region, AccountId } = environment;
+  const target = resolveTarget(event.ResourceProperties, environment);
 
-  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
-
-  return findUserPoolByName({ userPoolName: UserPoolName, region: Region }).then((userPool) =>
-    addPermission({
-      functionName: FunctionName,
-      userPoolName: UserPoolName,
-      partition: Partition,
-      region: Region,
-      accountId: AccountId,
-      userPoolId: userPool.Id,
-    }).then(() =>
-      updateConfiguration({
-        lambdaArn,
-        userPoolName: UserPoolName,
-        userPoolConfigs: UserPoolConfigs,
+  return findUserPoolByName({ userPoolName: target.userPoolName, region: Region }).then(
+    (userPool) =>
+      addPermission({
+        functionName: target.functionName,
+        functionQualifier: target.functionQualifier,
+        userPoolName: target.userPoolName,
+        partition: Partition,
         region: Region,
-      })
-    )
+        accountId: AccountId,
+        userPoolId: userPool.Id,
+      }).then(() =>
+        updateConfiguration({
+          lambdaArn: target.lambdaArn,
+          userPoolName: target.userPoolName,
+          userPoolConfigs: target.userPoolConfigs,
+          region: Region,
+        })
+      )
   );
 }
 
 async function update(event, context) {
-  const { Partition, Region, AccountId } = getEnvironment(context);
-  const { FunctionName, UserPoolName, UserPoolConfigs } = event.ResourceProperties;
+  const environment = getEnvironment(context);
+  const { Partition, Region, AccountId } = environment;
+  const target = resolveTarget(event.ResourceProperties, environment);
+  const oldTarget =
+    event.OldResourceProperties && resolveTarget(event.OldResourceProperties, environment);
 
-  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
+  if (!isSameTarget(target, oldTarget)) {
+    const userPool = await findUserPoolByName({
+      userPoolName: target.userPoolName,
+      region: Region,
+    });
+    await addPermission({
+      functionName: target.functionName,
+      functionQualifier: target.functionQualifier,
+      userPoolName: target.userPoolName,
+      partition: Partition,
+      region: Region,
+      accountId: AccountId,
+      userPoolId: userPool.Id,
+    });
+  }
 
-  return updateConfiguration({
-    lambdaArn,
-    userPoolName: UserPoolName,
-    userPoolConfigs: UserPoolConfigs,
+  await updateConfiguration({
+    lambdaArn: target.lambdaArn,
+    previousLambdaArn: oldTarget && oldTarget.lambdaArn,
+    userPoolName: target.userPoolName,
+    userPoolConfigs: target.userPoolConfigs,
     region: Region,
   });
+
+  if (oldTarget && oldTarget.userPoolName !== target.userPoolName) {
+    await removeConfiguration({
+      lambdaArn: oldTarget.lambdaArn,
+      userPoolName: oldTarget.userPoolName,
+      region: Region,
+    });
+  }
+
+  if (oldTarget && !isSameTarget(target, oldTarget)) {
+    await removePermission({
+      functionName: oldTarget.functionName,
+      functionQualifier: oldTarget.functionQualifier,
+      userPoolName: oldTarget.userPoolName,
+      region: Region,
+    }).catch(ignoreMissingPermission);
+  }
 }
 
 async function remove(event, context) {
-  const { Partition, Region, AccountId } = getEnvironment(context);
-  const { FunctionName, UserPoolName } = event.ResourceProperties;
-
-  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
+  const environment = getEnvironment(context);
+  const { Region } = environment;
+  const target = resolveTarget(event.ResourceProperties, environment);
 
   return removePermission({
-    functionName: FunctionName,
-    userPoolName: UserPoolName,
+    functionName: target.functionName,
+    functionQualifier: target.functionQualifier,
+    userPoolName: target.userPoolName,
     region: Region,
   }).then(() =>
     removeConfiguration({
-      lambdaArn,
-      userPoolName: UserPoolName,
+      lambdaArn: target.lambdaArn,
+      userPoolName: target.userPoolName,
       region: Region,
     })
   );
+}
+
+function resolveTarget(properties, environment) {
+  const { FunctionName, FunctionQualifier, UserPoolName, UserPoolConfigs } = properties;
+
+  return {
+    functionName: FunctionName,
+    functionQualifier: FunctionQualifier,
+    userPoolName: UserPoolName,
+    userPoolConfigs: UserPoolConfigs,
+    lambdaArn: getLambdaArn(
+      environment.Partition,
+      environment.Region,
+      environment.AccountId,
+      FunctionName,
+      FunctionQualifier
+    ),
+  };
+}
+
+function isSameTarget(target, oldTarget) {
+  return (
+    oldTarget &&
+    target.functionName === oldTarget.functionName &&
+    target.functionQualifier === oldTarget.functionQualifier &&
+    target.userPoolName === oldTarget.userPoolName
+  );
+}
+
+function ignoreMissingPermission(error) {
+  if (error && [error.name, error.Code, error.code].includes('ResourceNotFoundException')) {
+    return;
+  }
+  throw error;
 }
 
 module.exports = {

--- a/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/permissions.js
+++ b/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/permissions.js
@@ -19,12 +19,21 @@ function getStatementId(functionName, userPoolName) {
 }
 
 async function addPermission(config) {
-  const { functionName, userPoolName, partition, region, accountId, userPoolId } = config;
+  const {
+    functionName,
+    functionQualifier,
+    userPoolName,
+    partition,
+    region,
+    accountId,
+    userPoolId,
+  } = config;
   lambda.config.region = () => region;
 
   const payload = {
     Action: 'lambda:InvokeFunction',
     FunctionName: functionName,
+    ...(functionQualifier && { Qualifier: functionQualifier }),
     Principal: 'cognito-idp.amazonaws.com',
     StatementId: getStatementId(functionName, userPoolName),
     SourceArn: `arn:${partition}:cognito-idp:${region}:${accountId}:userpool/${userPoolId}`,
@@ -33,10 +42,11 @@ async function addPermission(config) {
 }
 
 async function removePermission(config) {
-  const { functionName, userPoolName, region } = config;
+  const { functionName, functionQualifier, userPoolName, region } = config;
   lambda.config.region = () => region;
   const payload = {
     FunctionName: functionName,
+    ...(functionQualifier && { Qualifier: functionQualifier }),
     StatementId: getStatementId(functionName, userPoolName),
   };
   return lambda.send(new RemovePermissionCommand(payload));

--- a/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/user-pool.js
+++ b/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/user-pool.js
@@ -73,7 +73,7 @@ async function getConfiguration(config) {
 }
 
 async function updateConfiguration(config) {
-  const { lambdaArn, userPoolConfigs, region } = config;
+  const { lambdaArn, previousLambdaArn, userPoolConfigs, region } = config;
 
   cognito.config.region = () => region;
 
@@ -82,7 +82,10 @@ async function updateConfiguration(config) {
     let { LambdaConfig } = res.UserPool;
 
     // remove configurations for this specific function
-    LambdaConfig = removeExistingLambdas(LambdaConfig, lambdaArn);
+    LambdaConfig = removeExistingLambdas(
+      LambdaConfig,
+      [lambdaArn, previousLambdaArn].filter(Boolean)
+    );
 
     userPoolConfigs.forEach((poolConfig) => {
       if (customSenderSources.includes(poolConfig.Trigger)) {
@@ -133,14 +136,16 @@ async function removeConfiguration(config) {
   });
 }
 
-function removeExistingLambdas(lambdaConfig, lambdaArn) {
+function removeExistingLambdas(lambdaConfig, lambdaArns) {
+  const targets = new Set(Array.isArray(lambdaArns) ? lambdaArns : [lambdaArns]);
   const res = Object.fromEntries(
     Object.entries(lambdaConfig).filter(([key, value]) => {
-      if (key === 'PreTokenGenerationConfig' && value && value.LambdaArn === lambdaArn) {
+      if (key === 'PreTokenGenerationConfig' && value && targets.has(value.LambdaArn)) {
         return false;
       }
       return (
-        !(customSenderSources.includes(key) && value.LambdaArn === lambdaArn) && value !== lambdaArn
+        !(customSenderSources.includes(key) && value && targets.has(value.LambdaArn)) &&
+        !targets.has(value)
       );
     })
   );

--- a/lib/plugins/aws/custom-resources/resources/s3/handler.js
+++ b/lib/plugins/aws/custom-resources/resources/s3/handler.js
@@ -16,58 +16,126 @@ async function handler(event, context) {
 }
 
 async function create(event, context) {
-  const { Partition, Region, AccountId } = getEnvironment(context);
-  const { FunctionName, BucketName, BucketConfigs } = event.ResourceProperties;
-
-  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
+  const environment = getEnvironment(context);
+  const { Partition, Region, AccountId } = environment;
+  const target = resolveTarget(event.ResourceProperties, environment);
 
   return addPermission({
-    functionName: FunctionName,
-    bucketName: BucketName,
+    functionName: target.functionName,
+    functionQualifier: target.functionQualifier,
+    bucketName: target.bucketName,
     partition: Partition,
     region: Region,
     accountId: AccountId,
   }).then(() =>
     updateConfiguration({
-      lambdaArn,
+      lambdaArn: target.lambdaArn,
       region: Region,
-      functionName: FunctionName,
-      bucketName: BucketName,
-      bucketConfigs: BucketConfigs,
+      functionName: target.functionName,
+      bucketName: target.bucketName,
+      bucketConfigs: target.bucketConfigs,
     })
   );
 }
 
 async function update(event, context) {
-  const { Partition, Region, AccountId } = getEnvironment(context);
-  const { FunctionName, BucketName, BucketConfigs } = event.ResourceProperties;
+  const environment = getEnvironment(context);
+  const { Partition, Region, AccountId } = environment;
+  const target = resolveTarget(event.ResourceProperties, environment);
+  const oldTarget =
+    event.OldResourceProperties && resolveTarget(event.OldResourceProperties, environment);
 
-  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
+  if (!isSameTarget(target, oldTarget)) {
+    await addPermission({
+      functionName: target.functionName,
+      functionQualifier: target.functionQualifier,
+      bucketName: target.bucketName,
+      partition: Partition,
+      region: Region,
+      accountId: AccountId,
+    });
+  }
 
-  return updateConfiguration({
-    lambdaArn,
+  await updateConfiguration({
+    lambdaArn: target.lambdaArn,
     region: Region,
-    functionName: FunctionName,
-    bucketName: BucketName,
-    bucketConfigs: BucketConfigs,
+    functionName: target.functionName,
+    bucketName: target.bucketName,
+    bucketConfigs: target.bucketConfigs,
   });
+
+  if (
+    oldTarget &&
+    (oldTarget.bucketName !== target.bucketName || oldTarget.functionName !== target.functionName)
+  ) {
+    await removeConfiguration({
+      region: Region,
+      functionName: oldTarget.functionName,
+      bucketName: oldTarget.bucketName,
+    });
+  }
+
+  if (oldTarget && !isSameTarget(target, oldTarget)) {
+    await removePermission({
+      functionName: oldTarget.functionName,
+      functionQualifier: oldTarget.functionQualifier,
+      bucketName: oldTarget.bucketName,
+      region: Region,
+    }).catch(ignoreMissingPermission);
+  }
 }
 
 async function remove(event, context) {
-  const { Region } = getEnvironment(context);
-  const { FunctionName, BucketName } = event.ResourceProperties;
+  const environment = getEnvironment(context);
+  const { Region } = environment;
+  const target = resolveTarget(event.ResourceProperties, environment);
 
   return removePermission({
-    functionName: FunctionName,
-    bucketName: BucketName,
+    functionName: target.functionName,
+    functionQualifier: target.functionQualifier,
+    bucketName: target.bucketName,
     region: Region,
   }).then(() =>
     removeConfiguration({
       region: Region,
-      functionName: FunctionName,
-      bucketName: BucketName,
+      functionName: target.functionName,
+      bucketName: target.bucketName,
     })
   );
+}
+
+function resolveTarget(properties, environment) {
+  const { FunctionName, FunctionQualifier, BucketName, BucketConfigs } = properties;
+
+  return {
+    functionName: FunctionName,
+    functionQualifier: FunctionQualifier,
+    bucketName: BucketName,
+    bucketConfigs: BucketConfigs,
+    lambdaArn: getLambdaArn(
+      environment.Partition,
+      environment.Region,
+      environment.AccountId,
+      FunctionName,
+      FunctionQualifier
+    ),
+  };
+}
+
+function isSameTarget(target, oldTarget) {
+  return (
+    oldTarget &&
+    target.functionName === oldTarget.functionName &&
+    target.functionQualifier === oldTarget.functionQualifier &&
+    target.bucketName === oldTarget.bucketName
+  );
+}
+
+function ignoreMissingPermission(error) {
+  if (error && [error.name, error.Code, error.code].includes('ResourceNotFoundException')) {
+    return;
+  }
+  throw error;
 }
 
 module.exports = {

--- a/lib/plugins/aws/custom-resources/resources/s3/handler.js
+++ b/lib/plugins/aws/custom-resources/resources/s3/handler.js
@@ -27,15 +27,17 @@ async function create(event, context) {
     partition: Partition,
     region: Region,
     accountId: AccountId,
-  }).then(() =>
-    updateConfiguration({
-      lambdaArn: target.lambdaArn,
-      region: Region,
-      functionName: target.functionName,
-      bucketName: target.bucketName,
-      bucketConfigs: target.bucketConfigs,
-    })
-  );
+  })
+    .catch(ignoreExistingPermission)
+    .then(() =>
+      updateConfiguration({
+        lambdaArn: target.lambdaArn,
+        region: Region,
+        functionName: target.functionName,
+        bucketName: target.bucketName,
+        bucketConfigs: target.bucketConfigs,
+      })
+    );
 }
 
 async function update(event, context) {
@@ -53,7 +55,7 @@ async function update(event, context) {
       partition: Partition,
       region: Region,
       accountId: AccountId,
-    });
+    }).catch(ignoreExistingPermission);
   }
 
   await updateConfiguration({
@@ -95,13 +97,15 @@ async function remove(event, context) {
     functionQualifier: target.functionQualifier,
     bucketName: target.bucketName,
     region: Region,
-  }).then(() =>
-    removeConfiguration({
-      region: Region,
-      functionName: target.functionName,
-      bucketName: target.bucketName,
-    })
-  );
+  })
+    .catch(ignoreMissingPermission)
+    .then(() =>
+      removeConfiguration({
+        region: Region,
+        functionName: target.functionName,
+        bucketName: target.bucketName,
+      })
+    );
 }
 
 function resolveTarget(properties, environment) {
@@ -133,6 +137,13 @@ function isSameTarget(target, oldTarget) {
 
 function ignoreMissingPermission(error) {
   if (error && [error.name, error.Code, error.code].includes('ResourceNotFoundException')) {
+    return;
+  }
+  throw error;
+}
+
+function ignoreExistingPermission(error) {
+  if (error && [error.name, error.Code, error.code].includes('ResourceConflictException')) {
     return;
   }
   throw error;

--- a/lib/plugins/aws/custom-resources/resources/s3/lib/bucket.js
+++ b/lib/plugins/aws/custom-resources/resources/s3/lib/bucket.js
@@ -15,6 +15,10 @@ function generateId(functionName, bucketConfig) {
   return `${functionName}-${md5}`;
 }
 
+function isOwnedConfiguration(config, functionName) {
+  return config.Id && config.Id.startsWith(`${functionName}-`);
+}
+
 function createFilter(config) {
   const rules = config.Rules;
   if (rules && rules.length) {
@@ -64,7 +68,7 @@ async function updateConfiguration(config) {
     ) {
       NotificationConfiguration.LambdaFunctionConfigurations =
         NotificationConfiguration.LambdaFunctionConfigurations.filter(
-          (conf) => !conf.Id.startsWith(functionName)
+          (conf) => !isOwnedConfiguration(conf, functionName)
         );
     }
 
@@ -116,7 +120,7 @@ async function removeConfiguration(config) {
     ) {
       NotificationConfiguration.LambdaFunctionConfigurations =
         NotificationConfiguration.LambdaFunctionConfigurations.filter(
-          (conf) => !conf.Id.startsWith(functionName)
+          (conf) => !isOwnedConfiguration(conf, functionName)
         );
     }
 

--- a/lib/plugins/aws/custom-resources/resources/s3/lib/bucket.js
+++ b/lib/plugins/aws/custom-resources/resources/s3/lib/bucket.js
@@ -16,7 +16,10 @@ function generateId(functionName, bucketConfig) {
 }
 
 function isOwnedConfiguration(config, functionName) {
-  return config.Id && config.Id.startsWith(`${functionName}-`);
+  if (!config.Id) return false;
+  const prefix = `${functionName}-`;
+  if (!config.Id.startsWith(prefix)) return false;
+  return /^[a-f0-9]{32}$/.test(config.Id.slice(prefix.length));
 }
 
 function createFilter(config) {

--- a/lib/plugins/aws/custom-resources/resources/s3/lib/permissions.js
+++ b/lib/plugins/aws/custom-resources/resources/s3/lib/permissions.js
@@ -19,13 +19,14 @@ function getStatementId(functionName, bucketName) {
 }
 
 async function addPermission(config) {
-  const { functionName, bucketName, partition, region, accountId } = config;
+  const { functionName, functionQualifier, bucketName, partition, region, accountId } = config;
 
   lambda.config.region = () => region;
 
   const payload = {
     Action: 'lambda:InvokeFunction',
     FunctionName: functionName,
+    ...(functionQualifier && { Qualifier: functionQualifier }),
     Principal: 's3.amazonaws.com',
     StatementId: getStatementId(functionName, bucketName),
     SourceArn: `arn:${partition}:s3:::${bucketName}`,
@@ -36,12 +37,13 @@ async function addPermission(config) {
 }
 
 async function removePermission(config) {
-  const { functionName, bucketName, region } = config;
+  const { functionName, functionQualifier, bucketName, region } = config;
 
   lambda.config.region = () => region;
 
   const payload = {
     FunctionName: functionName,
+    ...(functionQualifier && { Qualifier: functionQualifier }),
     StatementId: getStatementId(functionName, bucketName),
   };
   return lambda.send(new RemovePermissionCommand(payload));

--- a/lib/plugins/aws/custom-resources/resources/utils.js
+++ b/lib/plugins/aws/custom-resources/resources/utils.js
@@ -55,8 +55,9 @@ async function response(event, context, status, data = {}, err) {
   });
 }
 
-function getLambdaArn(partition, region, accountId, functionName) {
-  return `arn:${partition}:lambda:${region}:${accountId}:function:${functionName}`;
+function getLambdaArn(partition, region, accountId, functionName, functionQualifier) {
+  const arn = `arn:${partition}:lambda:${region}:${accountId}:function:${functionName}`;
+  return functionQualifier ? `${arn}:${functionQualifier}` : arn;
 }
 
 function getEnvironment(context) {

--- a/lib/plugins/aws/package/compile/events/cognito-user-pool.js
+++ b/lib/plugins/aws/package/compile/events/cognito-user-pool.js
@@ -276,6 +276,18 @@ class AwsCompileCognitoUserPoolEvents {
     if (usesExistingCognitoUserPool) {
       iamRoleStatements.push({
         Effect: 'Allow',
+        Resource: [
+          {
+            'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:*',
+          },
+          {
+            'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:*:*',
+          },
+        ],
+        Action: ['lambda:RemovePermission'],
+      });
+      iamRoleStatements.push({
+        Effect: 'Allow',
         Resource: {
           'Fn::Sub': 'arn:${AWS::Partition}:iam::*:role/*',
         },

--- a/lib/plugins/aws/package/compile/events/cognito-user-pool.js
+++ b/lib/plugins/aws/package/compile/events/cognito-user-pool.js
@@ -147,6 +147,8 @@ class AwsCompileCognitoUserPoolEvents {
       let funcUsesExistingCognitoUserPool = false;
       const functionObj = service.getFunction(functionName);
       const FunctionName = functionObj.name;
+      const functionQualifier = functionObj.targetAlias && functionObj.targetAlias.name;
+      const targetAliasLogicalId = functionObj.targetAlias && functionObj.targetAlias.logicalId;
 
       if (functionObj.events) {
         functionObj.events.forEach((event) => {
@@ -215,12 +217,17 @@ class AwsCompileCognitoUserPoolEvents {
                 [customPoolResourceLogicalId]: {
                   Type: 'Custom::CognitoUserPool',
                   Version: 1.0,
-                  DependsOn: [eventFunctionLogicalId, customResourceFunctionLogicalId],
+                  DependsOn: [
+                    eventFunctionLogicalId,
+                    targetAliasLogicalId,
+                    customResourceFunctionLogicalId,
+                  ].filter(Boolean),
                   Properties: {
                     ServiceToken: {
                       'Fn::GetAtt': [customResourceFunctionLogicalId, 'Arn'],
                     },
                     FunctionName,
+                    ...(functionQualifier && { FunctionQualifier: functionQualifier }),
                     UserPoolName: pool,
                     UserPoolConfigs: [userPoolConfig],
                     ForceDeploy: forceDeployProperty,
@@ -253,9 +260,14 @@ class AwsCompileCognitoUserPoolEvents {
       if (funcUsesExistingCognitoUserPool) {
         iamRoleStatements.push({
           Effect: 'Allow',
-          Resource: {
-            'Fn::Sub': `arn:\${AWS::Partition}:lambda:*:*:function:${FunctionName}`,
-          },
+          Resource: [
+            {
+              'Fn::Sub': `arn:\${AWS::Partition}:lambda:*:*:function:${FunctionName}`,
+            },
+            {
+              'Fn::Sub': `arn:\${AWS::Partition}:lambda:*:*:function:${FunctionName}:*`,
+            },
+          ],
           Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
         });
       }

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -314,6 +314,8 @@ class AwsCompileS3Events {
               };
             });
 
+            const targetAliasLogicalId =
+              functionObj.targetAlias && functionObj.targetAlias.logicalId;
             const eventFunctionLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
             const customResourceFunctionLogicalId =
               this.provider.naming.getCustomResourceS3HandlerFunctionLogicalId();
@@ -338,12 +340,19 @@ class AwsCompileS3Events {
                 [customS3ResourceLogicalId]: {
                   Type: 'Custom::S3',
                   Version: 1.0,
-                  DependsOn: [eventFunctionLogicalId, customResourceFunctionLogicalId],
+                  DependsOn: [
+                    eventFunctionLogicalId,
+                    targetAliasLogicalId,
+                    customResourceFunctionLogicalId,
+                  ].filter(Boolean),
                   Properties: {
                     ServiceToken: {
                       'Fn::GetAtt': [customResourceFunctionLogicalId, 'Arn'],
                     },
                     FunctionName,
+                    ...(functionObj.targetAlias && {
+                      FunctionQualifier: functionObj.targetAlias.name,
+                    }),
                     BucketName: bucket,
                     BucketConfigs: [
                       {

--- a/test/unit/lib/plugins/aws/custom-resources/test/cognito-user-pool.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/test/cognito-user-pool.test.js
@@ -158,4 +158,154 @@ describe('Custom resource Cognito user pool handler', () => {
       'removePermission',
     ]);
   });
+
+  it('should continue migration when qualified permission already exists', async () => {
+    const findUserPoolByName = sinon.stub().resolves({ Id: 'us-east-1_abc123' });
+    const addPermission = sinon.stub().rejects({ name: 'ResourceConflictException' });
+    const updateConfiguration = sinon.stub().resolves();
+    const removePermission = sinon.stub().resolves();
+    const removeConfiguration = sinon.stub().resolves();
+
+    const { handler } = proxyquire(
+      '../../../../../../../lib/plugins/aws/custom-resources/resources/cognito-user-pool/handler',
+      {
+        '../utils': {
+          ...utils,
+          getEnvironment: () => ({
+            Partition: 'aws',
+            Region: 'us-east-1',
+            AccountId: '123456789012',
+          }),
+          handlerWrapper: (wrappedHandler) => wrappedHandler,
+        },
+        './lib/permissions': { addPermission, removePermission },
+        './lib/user-pool': {
+          findUserPoolByName,
+          updateConfiguration,
+          removeConfiguration,
+        },
+      }
+    );
+
+    await handler(
+      {
+        RequestType: 'Update',
+        ResourceProperties: {
+          FunctionName: 'orders',
+          FunctionQualifier: 'provisioned',
+          UserPoolName: 'orders-pool',
+          UserPoolConfigs: [{ Trigger: 'PreSignUp' }],
+        },
+        OldResourceProperties: {
+          FunctionName: 'orders',
+          UserPoolName: 'orders-pool',
+          UserPoolConfigs: [{ Trigger: 'PreSignUp' }],
+        },
+      },
+      {}
+    );
+
+    expect(updateConfiguration).to.have.been.calledOnce;
+    expect(removePermission).to.have.been.calledOnce;
+  });
+
+  it('should not remove previous Lambda arn from a new user pool', async () => {
+    const findUserPoolByName = sinon.stub().resolves({ Id: 'us-east-1_abc123' });
+    const addPermission = sinon.stub().resolves();
+    const updateConfiguration = sinon.stub().resolves();
+    const removePermission = sinon.stub().resolves();
+    const removeConfiguration = sinon.stub().resolves();
+
+    const { handler } = proxyquire(
+      '../../../../../../../lib/plugins/aws/custom-resources/resources/cognito-user-pool/handler',
+      {
+        '../utils': {
+          ...utils,
+          getEnvironment: () => ({
+            Partition: 'aws',
+            Region: 'us-east-1',
+            AccountId: '123456789012',
+          }),
+          handlerWrapper: (wrappedHandler) => wrappedHandler,
+        },
+        './lib/permissions': { addPermission, removePermission },
+        './lib/user-pool': {
+          findUserPoolByName,
+          updateConfiguration,
+          removeConfiguration,
+        },
+      }
+    );
+
+    await handler(
+      {
+        RequestType: 'Update',
+        ResourceProperties: {
+          FunctionName: 'orders',
+          FunctionQualifier: 'provisioned',
+          UserPoolName: 'new-orders-pool',
+          UserPoolConfigs: [{ Trigger: 'PreSignUp' }],
+        },
+        OldResourceProperties: {
+          FunctionName: 'orders',
+          UserPoolName: 'old-orders-pool',
+          UserPoolConfigs: [{ Trigger: 'PreSignUp' }],
+        },
+      },
+      {}
+    );
+
+    expect(updateConfiguration.args[0][0]).to.include({
+      lambdaArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders:provisioned',
+      previousLambdaArn: undefined,
+      userPoolName: 'new-orders-pool',
+    });
+    expect(removeConfiguration.args[0][0]).to.include({
+      lambdaArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders',
+      userPoolName: 'old-orders-pool',
+    });
+  });
+
+  it('should remove trigger configuration when Lambda permission is already missing', async () => {
+    const findUserPoolByName = sinon.stub().resolves({ Id: 'us-east-1_abc123' });
+    const addPermission = sinon.stub().resolves();
+    const updateConfiguration = sinon.stub().resolves();
+    const removePermission = sinon.stub().rejects({ name: 'ResourceNotFoundException' });
+    const removeConfiguration = sinon.stub().resolves();
+
+    const { handler } = proxyquire(
+      '../../../../../../../lib/plugins/aws/custom-resources/resources/cognito-user-pool/handler',
+      {
+        '../utils': {
+          ...utils,
+          getEnvironment: () => ({
+            Partition: 'aws',
+            Region: 'us-east-1',
+            AccountId: '123456789012',
+          }),
+          handlerWrapper: (wrappedHandler) => wrappedHandler,
+        },
+        './lib/permissions': { addPermission, removePermission },
+        './lib/user-pool': {
+          findUserPoolByName,
+          updateConfiguration,
+          removeConfiguration,
+        },
+      }
+    );
+
+    await handler(
+      {
+        RequestType: 'Delete',
+        ResourceProperties: {
+          FunctionName: 'orders',
+          FunctionQualifier: 'provisioned',
+          UserPoolName: 'orders-pool',
+        },
+      },
+      {}
+    );
+
+    expect(removeConfiguration).to.have.been.calledOnce;
+  });
 });

--- a/test/unit/lib/plugins/aws/custom-resources/test/cognito-user-pool.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/test/cognito-user-pool.test.js
@@ -1,0 +1,161 @@
+'use strict';
+
+const { expect } = require('chai');
+const proxyquire = require('proxyquire').noCallThru();
+const sinon = require('sinon');
+const utils = require('../../../../../../../lib/plugins/aws/custom-resources/resources/utils');
+
+describe('Custom resource Cognito user pool permissions', () => {
+  let sentCommands;
+  let addPermission;
+  let removePermission;
+
+  beforeEach(() => {
+    sentCommands = [];
+
+    class LambdaClient {
+      constructor() {
+        this.config = {};
+      }
+
+      send(command) {
+        sentCommands.push(command);
+        return Promise.resolve();
+      }
+    }
+
+    class AddPermissionCommand {
+      constructor(input) {
+        this.input = input;
+      }
+    }
+
+    class RemovePermissionCommand {
+      constructor(input) {
+        this.input = input;
+      }
+    }
+
+    ({ addPermission, removePermission } = proxyquire(
+      '../../../../../../../lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/permissions',
+      {
+        '@aws-sdk/client-lambda': {
+          LambdaClient,
+          AddPermissionCommand,
+          RemovePermissionCommand,
+        },
+      }
+    ));
+  });
+
+  it('should pass qualifier when adding Lambda permission', async () => {
+    await addPermission({
+      functionName: 'orders',
+      functionQualifier: 'provisioned',
+      userPoolName: 'orders-pool',
+      partition: 'aws',
+      region: 'us-east-1',
+      accountId: '123456789012',
+      userPoolId: 'us-east-1_abc123',
+    });
+
+    expect(sentCommands[0].input).to.include({
+      FunctionName: 'orders',
+      Qualifier: 'provisioned',
+    });
+  });
+
+  it('should pass qualifier when removing Lambda permission', async () => {
+    await removePermission({
+      functionName: 'orders',
+      functionQualifier: 'provisioned',
+      userPoolName: 'orders-pool',
+      region: 'us-east-1',
+    });
+
+    expect(sentCommands[0].input).to.include({
+      FunctionName: 'orders',
+      Qualifier: 'provisioned',
+    });
+  });
+});
+
+describe('Custom resource Cognito user pool handler', () => {
+  it('should add qualified permission before migrating existing trigger target', async () => {
+    const calls = [];
+    const findUserPoolByName = sinon.stub().resolves({ Id: 'us-east-1_abc123' });
+    const addPermission = sinon.stub().callsFake(async (input) => {
+      calls.push(['addPermission', input]);
+    });
+    const updateConfiguration = sinon.stub().callsFake(async (input) => {
+      calls.push(['updateConfiguration', input]);
+    });
+    const removePermission = sinon.stub().callsFake(async (input) => {
+      calls.push(['removePermission', input]);
+    });
+    const removeConfiguration = sinon.stub().resolves();
+
+    const { handler } = proxyquire(
+      '../../../../../../../lib/plugins/aws/custom-resources/resources/cognito-user-pool/handler',
+      {
+        '../utils': {
+          ...utils,
+          getEnvironment: () => ({
+            Partition: 'aws',
+            Region: 'us-east-1',
+            AccountId: '123456789012',
+          }),
+          handlerWrapper: (wrappedHandler) => wrappedHandler,
+        },
+        './lib/permissions': { addPermission, removePermission },
+        './lib/user-pool': {
+          findUserPoolByName,
+          updateConfiguration,
+          removeConfiguration,
+        },
+      }
+    );
+
+    await handler(
+      {
+        RequestType: 'Update',
+        ResourceProperties: {
+          FunctionName: 'orders',
+          FunctionQualifier: 'provisioned',
+          UserPoolName: 'orders-pool',
+          UserPoolConfigs: [{ Trigger: 'PreSignUp' }],
+        },
+        OldResourceProperties: {
+          FunctionName: 'orders',
+          UserPoolName: 'orders-pool',
+          UserPoolConfigs: [{ Trigger: 'PreSignUp' }],
+        },
+      },
+      {}
+    );
+
+    expect(addPermission).to.have.been.calledOnce;
+    expect(addPermission.args[0][0]).to.include({
+      functionName: 'orders',
+      functionQualifier: 'provisioned',
+      userPoolName: 'orders-pool',
+      userPoolId: 'us-east-1_abc123',
+    });
+    expect(updateConfiguration.args[0][0]).to.include({
+      lambdaArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders:provisioned',
+      previousLambdaArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders',
+      userPoolName: 'orders-pool',
+    });
+    expect(removePermission.args[0][0]).to.include({
+      functionName: 'orders',
+      userPoolName: 'orders-pool',
+    });
+    expect(removePermission.args[0][0]).to.have.property('functionQualifier', undefined);
+    expect(removeConfiguration).to.not.have.been.called;
+    expect(calls.map(([name]) => name)).to.deep.equal([
+      'addPermission',
+      'updateConfiguration',
+      'removePermission',
+    ]);
+  });
+});

--- a/test/unit/lib/plugins/aws/custom-resources/test/s3.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/test/s3.test.js
@@ -151,6 +151,89 @@ describe('Custom resource S3 handler', () => {
       'removePermission',
     ]);
   });
+
+  it('should continue migration when qualified permission already exists', async () => {
+    const addPermission = sinon.stub().rejects({ name: 'ResourceConflictException' });
+    const updateConfiguration = sinon.stub().resolves();
+    const removePermission = sinon.stub().resolves();
+    const removeConfiguration = sinon.stub().resolves();
+
+    const { handler } = proxyquire(
+      '../../../../../../../lib/plugins/aws/custom-resources/resources/s3/handler',
+      {
+        '../utils': {
+          ...utils,
+          getEnvironment: () => ({
+            Partition: 'aws',
+            Region: 'us-east-1',
+            AccountId: '123456789012',
+          }),
+          handlerWrapper: (wrappedHandler) => wrappedHandler,
+        },
+        './lib/permissions': { addPermission, removePermission },
+        './lib/bucket': { updateConfiguration, removeConfiguration },
+      }
+    );
+
+    await handler(
+      {
+        RequestType: 'Update',
+        ResourceProperties: {
+          FunctionName: 'orders',
+          FunctionQualifier: 'provisioned',
+          BucketName: 'orders-bucket',
+          BucketConfigs: [],
+        },
+        OldResourceProperties: {
+          FunctionName: 'orders',
+          BucketName: 'orders-bucket',
+          BucketConfigs: [],
+        },
+      },
+      {}
+    );
+
+    expect(updateConfiguration).to.have.been.calledOnce;
+    expect(removePermission).to.have.been.calledOnce;
+  });
+
+  it('should remove notification configuration when Lambda permission is already missing', async () => {
+    const addPermission = sinon.stub().resolves();
+    const updateConfiguration = sinon.stub().resolves();
+    const removePermission = sinon.stub().rejects({ name: 'ResourceNotFoundException' });
+    const removeConfiguration = sinon.stub().resolves();
+
+    const { handler } = proxyquire(
+      '../../../../../../../lib/plugins/aws/custom-resources/resources/s3/handler',
+      {
+        '../utils': {
+          ...utils,
+          getEnvironment: () => ({
+            Partition: 'aws',
+            Region: 'us-east-1',
+            AccountId: '123456789012',
+          }),
+          handlerWrapper: (wrappedHandler) => wrappedHandler,
+        },
+        './lib/permissions': { addPermission, removePermission },
+        './lib/bucket': { updateConfiguration, removeConfiguration },
+      }
+    );
+
+    await handler(
+      {
+        RequestType: 'Delete',
+        ResourceProperties: {
+          FunctionName: 'orders',
+          FunctionQualifier: 'provisioned',
+          BucketName: 'orders-bucket',
+        },
+      },
+      {}
+    );
+
+    expect(removeConfiguration).to.have.been.calledOnce;
+  });
 });
 
 describe('Custom resource S3 bucket configuration', () => {
@@ -168,12 +251,12 @@ describe('Custom resource S3 bucket configuration', () => {
           return Promise.resolve({
             LambdaFunctionConfigurations: [
               {
-                Id: 'orders-previous',
+                Id: `orders-${'a'.repeat(32)}`,
                 LambdaFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders',
               },
               {
-                Id: 'orders2-previous',
-                LambdaFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders2',
+                Id: `orders-api-${'b'.repeat(32)}`,
+                LambdaFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders-api',
               },
               {
                 LambdaFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:external',
@@ -221,7 +304,7 @@ describe('Custom resource S3 bucket configuration', () => {
 
     expect(configs).to.have.length(3);
     expect(configs.map((config) => config.LambdaFunctionArn)).to.deep.equal([
-      'arn:aws:lambda:us-east-1:123456789012:function:orders2',
+      'arn:aws:lambda:us-east-1:123456789012:function:orders-api',
       'arn:aws:lambda:us-east-1:123456789012:function:external',
       'arn:aws:lambda:us-east-1:123456789012:function:orders:provisioned',
     ]);

--- a/test/unit/lib/plugins/aws/custom-resources/test/s3.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/test/s3.test.js
@@ -1,0 +1,229 @@
+'use strict';
+
+const { expect } = require('chai');
+const proxyquire = require('proxyquire').noCallThru();
+const sinon = require('sinon');
+const utils = require('../../../../../../../lib/plugins/aws/custom-resources/resources/utils');
+
+describe('Custom resource S3 permissions', () => {
+  let sentCommands;
+  let addPermission;
+  let removePermission;
+
+  beforeEach(() => {
+    sentCommands = [];
+
+    class LambdaClient {
+      constructor() {
+        this.config = {};
+      }
+
+      send(command) {
+        sentCommands.push(command);
+        return Promise.resolve();
+      }
+    }
+
+    class AddPermissionCommand {
+      constructor(input) {
+        this.input = input;
+      }
+    }
+
+    class RemovePermissionCommand {
+      constructor(input) {
+        this.input = input;
+      }
+    }
+
+    ({ addPermission, removePermission } = proxyquire(
+      '../../../../../../../lib/plugins/aws/custom-resources/resources/s3/lib/permissions',
+      {
+        '@aws-sdk/client-lambda': {
+          LambdaClient,
+          AddPermissionCommand,
+          RemovePermissionCommand,
+        },
+      }
+    ));
+  });
+
+  it('should pass qualifier when adding Lambda permission', async () => {
+    await addPermission({
+      functionName: 'orders',
+      functionQualifier: 'provisioned',
+      bucketName: 'orders-bucket',
+      partition: 'aws',
+      region: 'us-east-1',
+      accountId: '123456789012',
+    });
+
+    expect(sentCommands[0].input).to.include({
+      FunctionName: 'orders',
+      Qualifier: 'provisioned',
+    });
+  });
+
+  it('should pass qualifier when removing Lambda permission', async () => {
+    await removePermission({
+      functionName: 'orders',
+      functionQualifier: 'provisioned',
+      bucketName: 'orders-bucket',
+      region: 'us-east-1',
+    });
+
+    expect(sentCommands[0].input).to.include({
+      FunctionName: 'orders',
+      Qualifier: 'provisioned',
+    });
+  });
+});
+
+describe('Custom resource S3 handler', () => {
+  it('should add qualified permission before migrating existing notification target', async () => {
+    const calls = [];
+    const addPermission = sinon.stub().callsFake(async (input) => {
+      calls.push(['addPermission', input]);
+    });
+    const updateConfiguration = sinon.stub().callsFake(async (input) => {
+      calls.push(['updateConfiguration', input]);
+    });
+    const removePermission = sinon.stub().callsFake(async (input) => {
+      calls.push(['removePermission', input]);
+    });
+    const removeConfiguration = sinon.stub().resolves();
+
+    const { handler } = proxyquire(
+      '../../../../../../../lib/plugins/aws/custom-resources/resources/s3/handler',
+      {
+        '../utils': {
+          ...utils,
+          getEnvironment: () => ({
+            Partition: 'aws',
+            Region: 'us-east-1',
+            AccountId: '123456789012',
+          }),
+          handlerWrapper: (wrappedHandler) => wrappedHandler,
+        },
+        './lib/permissions': { addPermission, removePermission },
+        './lib/bucket': { updateConfiguration, removeConfiguration },
+      }
+    );
+
+    await handler(
+      {
+        RequestType: 'Update',
+        ResourceProperties: {
+          FunctionName: 'orders',
+          FunctionQualifier: 'provisioned',
+          BucketName: 'orders-bucket',
+          BucketConfigs: [],
+        },
+        OldResourceProperties: {
+          FunctionName: 'orders',
+          BucketName: 'orders-bucket',
+          BucketConfigs: [],
+        },
+      },
+      {}
+    );
+
+    expect(addPermission).to.have.been.calledOnce;
+    expect(addPermission.args[0][0]).to.include({
+      functionName: 'orders',
+      functionQualifier: 'provisioned',
+      bucketName: 'orders-bucket',
+    });
+    expect(updateConfiguration.args[0][0]).to.include({
+      lambdaArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders:provisioned',
+      functionName: 'orders',
+      bucketName: 'orders-bucket',
+    });
+    expect(removePermission.args[0][0]).to.include({
+      functionName: 'orders',
+      bucketName: 'orders-bucket',
+    });
+    expect(removePermission.args[0][0]).to.have.property('functionQualifier', undefined);
+    expect(removeConfiguration).to.not.have.been.called;
+    expect(calls.map(([name]) => name)).to.deep.equal([
+      'addPermission',
+      'updateConfiguration',
+      'removePermission',
+    ]);
+  });
+});
+
+describe('Custom resource S3 bucket configuration', () => {
+  it('should only replace owned notification configurations', async () => {
+    const sentCommands = [];
+
+    class S3Client {
+      constructor() {
+        this.config = {};
+      }
+
+      send(command) {
+        sentCommands.push(command);
+        if (command.constructor.name === 'GetBucketNotificationConfigurationCommand') {
+          return Promise.resolve({
+            LambdaFunctionConfigurations: [
+              {
+                Id: 'orders-previous',
+                LambdaFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders',
+              },
+              {
+                Id: 'orders2-previous',
+                LambdaFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders2',
+              },
+              {
+                LambdaFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:external',
+              },
+            ],
+          });
+        }
+        return Promise.resolve();
+      }
+    }
+
+    class GetBucketNotificationConfigurationCommand {
+      constructor(input) {
+        this.input = input;
+      }
+    }
+
+    class PutBucketNotificationConfigurationCommand {
+      constructor(input) {
+        this.input = input;
+      }
+    }
+
+    const { updateConfiguration } = proxyquire(
+      '../../../../../../../lib/plugins/aws/custom-resources/resources/s3/lib/bucket',
+      {
+        '@aws-sdk/client-s3': {
+          S3Client,
+          GetBucketNotificationConfigurationCommand,
+          PutBucketNotificationConfigurationCommand,
+        },
+      }
+    );
+
+    await updateConfiguration({
+      lambdaArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders:provisioned',
+      functionName: 'orders',
+      bucketName: 'orders-bucket',
+      bucketConfigs: [{ Event: 's3:ObjectCreated:*', Rules: [] }],
+      region: 'us-east-1',
+    });
+
+    const putInput = sentCommands[1].input;
+    const configs = putInput.NotificationConfiguration.LambdaFunctionConfigurations;
+
+    expect(configs).to.have.length(3);
+    expect(configs.map((config) => config.LambdaFunctionArn)).to.deep.equal([
+      'arn:aws:lambda:us-east-1:123456789012:function:orders2',
+      'arn:aws:lambda:us-east-1:123456789012:function:external',
+      'arn:aws:lambda:us-east-1:123456789012:function:orders:provisioned',
+    ]);
+  });
+});

--- a/test/unit/lib/plugins/aws/custom-resources/test/utils.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/test/utils.test.js
@@ -16,6 +16,16 @@ describe('#getLambdaArn()', () => {
 
     expect(arn).to.equal('arn:aws:lambda:us-east-1:123456:function:some-function');
   });
+
+  it('should return the qualified Lambda arn', () => {
+    const partition = 'aws';
+    const region = 'us-east-1';
+    const accountId = '123456';
+    const functionName = 'some-function';
+    const arn = getLambdaArn(partition, region, accountId, functionName, 'provisioned');
+
+    expect(arn).to.equal('arn:aws:lambda:us-east-1:123456:function:some-function:provisioned');
+  });
 });
 
 describe('#getLambdaArn() govloud west', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
@@ -505,7 +505,10 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
           {
             Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
             Effect: 'Allow',
-            Resource: { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:first' },
+            Resource: [
+              { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:first' },
+              { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:first:*' },
+            ],
           },
           {
             Effect: 'Allow',
@@ -640,7 +643,10 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
           {
             Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
             Effect: 'Allow',
-            Resource: { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:first' },
+            Resource: [
+              { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:first' },
+              { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:first:*' },
+            ],
           },
           {
             Effect: 'Allow',
@@ -755,7 +761,10 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
           {
             Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
             Effect: 'Allow',
-            Resource: { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:first' },
+            Resource: [
+              { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:first' },
+              { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:first:*' },
+            ],
           },
           {
             Action: [
@@ -769,7 +778,10 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
           {
             Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
             Effect: 'Allow',
-            Resource: { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:second' },
+            Resource: [
+              { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:second' },
+              { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:second:*' },
+            ],
           },
           {
             Effect: 'Allow',
@@ -1028,6 +1040,22 @@ describe('lib/plugins/aws/package/compile/events/cognito-user-pool.test.js', () 
       fixture: 'cognito-user-pool',
       configExt: {
         ...serverlessConfigurationExtension,
+        functions: {
+          ...serverlessConfigurationExtension.functions,
+          provisionedExisting: {
+            handler: 'index.js',
+            provisionedConcurrency: 1,
+            events: [
+              {
+                cognitoUserPool: {
+                  pool: 'ProvisionedExistingPool',
+                  trigger: 'PreSignUp',
+                  existing: true,
+                },
+              },
+            ],
+          },
+        },
         resources: {
           Resources: {
             CognitoUserPoolCUPCustomEmailSender: {
@@ -1111,6 +1139,10 @@ describe('lib/plugins/aws/package/compile/events/cognito-user-pool.test.js', () 
         cfResources[
           naming.getCustomResourceCognitoUserPoolResourceLogicalId('existingCustomEmailSender')
         ];
+      const provisionedResource =
+        cfResources[
+          naming.getCustomResourceCognitoUserPoolResourceLogicalId('provisionedExisting')
+        ];
 
       expect(simpleResource).to.deep.equal({
         Type: 'Custom::CognitoUserPool',
@@ -1145,6 +1177,16 @@ describe('lib/plugins/aws/package/compile/events/cognito-user-pool.test.js', () 
           LambdaVersion: 'V1_0',
         },
       ]);
+      expect(provisionedResource.DependsOn).to.deep.equal([
+        naming.getLambdaLogicalId('provisionedExisting'),
+        naming.getLambdaProvisionedConcurrencyAliasLogicalId('provisionedExisting'),
+        naming.getCustomResourceCognitoUserPoolHandlerFunctionLogicalId(),
+      ]);
+      expect(provisionedResource.Properties).to.deep.include({
+        FunctionName: serverlessInstance.service.getFunction('provisionedExisting').name,
+        FunctionQualifier: naming.getLambdaProvisionedConcurrencyAliasName(),
+        UserPoolName: 'ProvisionedExistingPool',
+      });
     });
   });
 

--- a/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
@@ -511,6 +511,14 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
             ],
           },
           {
+            Action: ['lambda:RemovePermission'],
+            Effect: 'Allow',
+            Resource: [
+              { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:*' },
+              { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:*:*' },
+            ],
+          },
+          {
             Effect: 'Allow',
             Resource: {
               'Fn::Sub': 'arn:${AWS::Partition}:iam::*:role/*',
@@ -649,6 +657,14 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
             ],
           },
           {
+            Action: ['lambda:RemovePermission'],
+            Effect: 'Allow',
+            Resource: [
+              { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:*' },
+              { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:*:*' },
+            ],
+          },
+          {
             Effect: 'Allow',
             Resource: {
               'Fn::Sub': 'arn:${AWS::Partition}:iam::*:role/*',
@@ -781,6 +797,14 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
             Resource: [
               { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:second' },
               { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:second:*' },
+            ],
+          },
+          {
+            Action: ['lambda:RemovePermission'],
+            Effect: 'Allow',
+            Resource: [
+              { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:*' },
+              { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:*:*' },
             ],
           },
           {

--- a/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -1026,6 +1026,19 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
               },
             ],
           },
+          provisionedExisting: {
+            handler: 'core.provisioned',
+            provisionedConcurrency: 1,
+            events: [
+              {
+                s3: {
+                  bucket: 'provisioned-bucket',
+                  event: 's3:ObjectCreated:*',
+                  existing: true,
+                },
+              },
+            ],
+          },
         },
       },
       command: 'package',
@@ -1240,6 +1253,24 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
           },
         ],
       },
+    });
+  });
+
+  it('should target a generated alias for existing buckets when targetAlias is set', () => {
+    const resource =
+      cfResources[naming.getCustomResourceS3ResourceLogicalId('provisionedExisting')];
+    const aliasLogicalId =
+      naming.getLambdaProvisionedConcurrencyAliasLogicalId('provisionedExisting');
+
+    expect(resource.DependsOn).to.deep.equal([
+      naming.getLambdaLogicalId('provisionedExisting'),
+      aliasLogicalId,
+      naming.getCustomResourceS3HandlerFunctionLogicalId(),
+    ]);
+    expect(resource.Properties).to.deep.include({
+      FunctionName: serverlessInstance.service.getFunction('provisionedExisting').name,
+      FunctionQualifier: naming.getLambdaProvisionedConcurrencyAliasName(),
+      BucketName: 'provisioned-bucket',
     });
   });
 


### PR DESCRIPTION
This passes Lambda qualifiers through existing S3 and Cognito custom resources when a function uses a generated target alias. It migrates existing unqualified targets by adding the new permission before updating the event configuration and cleaning up the old permission.