### PR TITLE
Propagate function conditions to generated resources

### DIFF
--- a/docs/guides/serverless.yml.md
+++ b/docs/guides/serverless.yml.md
@@ -719,7 +719,9 @@ functions:
       - arn:aws:lambda:region:XXXXXX:layer:LayerName:Y
     # Overrides the provider setting. Can be 'Active' or 'PassThrough'
     tracing: Active
-    # Conditionally deploy the function
+    # Conditionally deploy the function and generated function-owned companion resources.
+    # Define the CloudFormation condition under resources.Conditions.
+    # Shared event resources may not inherit this condition directly.
     condition: SomeCondition
     # CloudFormation 'DependsOn' option
     dependsOn:

--- a/docs/guides/serverless.yml.md
+++ b/docs/guides/serverless.yml.md
@@ -721,7 +721,7 @@ functions:
     tracing: Active
     # Conditionally deploy the function and generated function-owned companion resources.
     # Define the CloudFormation condition under resources.Conditions.
-    # Shared event resources may not inherit this condition directly.
+    # Shared event resources do not inherit this condition directly.
     condition: SomeCondition
     # CloudFormation 'DependsOn' option
     dependsOn:

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -48,6 +48,13 @@ const normalizeDependsOn = (items) => {
   return dependencies.length === 1 ? dependencies[0] : dependencies;
 };
 
+const applyFunctionCondition = (resource, functionObject) => {
+  if (functionObject.condition) {
+    resource.Condition = functionObject.condition;
+  }
+  return resource;
+};
+
 const getTargetAliasLogicalId = (functionObject) =>
   functionObject.targetAlias && functionObject.targetAlias.logicalId;
 
@@ -277,9 +284,7 @@ class AwsCompileFunctions {
       };
     }
 
-    if (functionObject.condition) {
-      functionResource.Condition = functionObject.condition;
-    }
+    applyFunctionCondition(functionResource, functionObject);
 
     if (functionObject.dependsOn) {
       functionResource.DependsOn = (functionResource.DependsOn || []).concat(
@@ -502,7 +507,10 @@ class AwsCompileFunctions {
         extractLayerConfigurationsFromFunction(functionResource.Properties, cfTemplate)
       );
 
-      const versionResource = this.cfLambdaVersionTemplate();
+      const versionResource = applyFunctionCondition(
+        this.cfLambdaVersionTemplate(),
+        functionObject
+      );
 
       if (functionImageSha) {
         versionResource.Properties.CodeSha256 = functionImageSha;
@@ -565,6 +573,7 @@ class AwsCompileFunctions {
       const newVersionOutput = this.cfOutputLatestVersionTemplate();
 
       newVersionOutput.Value = { Ref: versionLogicalId };
+      applyFunctionCondition(newVersionOutput, functionObject);
 
       Object.assign(cfTemplate.Outputs, {
         [functionVersionOutputLogicalId]: newVersionOutput,
@@ -583,18 +592,21 @@ class AwsCompileFunctions {
         const aliasLogicalId = functionObject.targetAlias.logicalId;
         const aliasName = functionObject.targetAlias.name;
 
-        const aliasResource = {
-          Type: 'AWS::Lambda::Alias',
-          Properties: {
-            FunctionName: { Ref: functionLogicalId },
-            FunctionVersion: { 'Fn::GetAtt': [versionLogicalId, 'Version'] },
-            Name: aliasName,
-            ProvisionedConcurrencyConfig: {
-              ProvisionedConcurrentExecutions: functionObject.provisionedConcurrency,
+        const aliasResource = applyFunctionCondition(
+          {
+            Type: 'AWS::Lambda::Alias',
+            Properties: {
+              FunctionName: { Ref: functionLogicalId },
+              FunctionVersion: { 'Fn::GetAtt': [versionLogicalId, 'Version'] },
+              Name: aliasName,
+              ProvisionedConcurrencyConfig: {
+                ProvisionedConcurrentExecutions: functionObject.provisionedConcurrency,
+              },
             },
+            DependsOn: functionLogicalId,
           },
-          DependsOn: functionLogicalId,
-        };
+          functionObject
+        );
 
         cfTemplate.Resources[aliasLogicalId] = aliasResource;
       }
@@ -605,15 +617,18 @@ class AwsCompileFunctions {
         const aliasLogicalId = functionObject.targetAlias.logicalId;
         const aliasName = functionObject.targetAlias.name;
 
-        const aliasResource = {
-          Type: 'AWS::Lambda::Alias',
-          Properties: {
-            FunctionName: { Ref: functionLogicalId },
-            FunctionVersion: { 'Fn::GetAtt': [versionLogicalId, 'Version'] },
-            Name: aliasName,
+        const aliasResource = applyFunctionCondition(
+          {
+            Type: 'AWS::Lambda::Alias',
+            Properties: {
+              FunctionName: { Ref: functionLogicalId },
+              FunctionVersion: { 'Fn::GetAtt': [versionLogicalId, 'Version'] },
+              Name: aliasName,
+            },
+            DependsOn: functionLogicalId,
           },
-          DependsOn: functionLogicalId,
-        };
+          functionObject
+        );
 
         cfTemplate.Resources[aliasLogicalId] = aliasResource;
       }
@@ -694,14 +709,17 @@ class AwsCompileFunctions {
       cors.maxAge = url.cors.maxAge;
     }
 
-    const urlResource = {
-      Type: 'AWS::Lambda::Url',
-      Properties: {
-        AuthType: auth,
-        TargetFunctionArn: resolveLambdaTarget(functionName, functionObject),
+    const urlResource = applyFunctionCondition(
+      {
+        Type: 'AWS::Lambda::Url',
+        Properties: {
+          AuthType: auth,
+          TargetFunctionArn: resolveLambdaTarget(functionName, functionObject),
+        },
+        DependsOn: getTargetAliasLogicalId(functionObject),
       },
-      DependsOn: getTargetAliasLogicalId(functionObject),
-    };
+      functionObject
+    );
 
     if (cors) {
       urlResource.Properties.Cors = {
@@ -720,34 +738,50 @@ class AwsCompileFunctions {
 
     const logicalId = this.provider.naming.getLambdaFunctionUrlLogicalId(functionName);
     cfTemplate.Resources[logicalId] = urlResource;
-    cfTemplate.Outputs[this.provider.naming.getLambdaFunctionUrlOutputLogicalId(functionName)] = {
-      Description: 'Lambda Function URL',
-      Value: {
-        'Fn::GetAtt': [logicalId, 'FunctionUrl'],
+    const urlOutput = applyFunctionCondition(
+      {
+        Description: 'Lambda Function URL',
+        Value: {
+          'Fn::GetAtt': [logicalId, 'FunctionUrl'],
+        },
       },
-    };
+      functionObject
+    );
+    cfTemplate.Outputs[this.provider.naming.getLambdaFunctionUrlOutputLogicalId(functionName)] =
+      urlOutput;
 
     if (auth === 'NONE') {
-      cfTemplate.Resources[this.provider.naming.getLambdaFnUrlPermissionLogicalId(functionName)] = {
-        Type: 'AWS::Lambda::Permission',
-        Properties: {
-          FunctionName: resolveLambdaTarget(functionName, functionObject),
-          Action: 'lambda:InvokeFunctionUrl',
-          Principal: '*',
-          FunctionUrlAuthType: auth,
+      const urlPermissionResource = applyFunctionCondition(
+        {
+          Type: 'AWS::Lambda::Permission',
+          Properties: {
+            FunctionName: resolveLambdaTarget(functionName, functionObject),
+            Action: 'lambda:InvokeFunctionUrl',
+            Principal: '*',
+            FunctionUrlAuthType: auth,
+          },
+          DependsOn: getTargetAliasLogicalId(functionObject),
         },
-        DependsOn: getTargetAliasLogicalId(functionObject),
-      };
-      cfTemplate.Resources[this.provider.naming.getLambdaFnPermissionLogicalId(functionName)] = {
-        Type: 'AWS::Lambda::Permission',
-        Properties: {
-          FunctionName: resolveLambdaTarget(functionName, functionObject),
-          Action: 'lambda:InvokeFunction',
-          Principal: '*',
-          InvokedViaFunctionUrl: true,
+        functionObject
+      );
+      cfTemplate.Resources[this.provider.naming.getLambdaFnUrlPermissionLogicalId(functionName)] =
+        urlPermissionResource;
+
+      const invokePermissionResource = applyFunctionCondition(
+        {
+          Type: 'AWS::Lambda::Permission',
+          Properties: {
+            FunctionName: resolveLambdaTarget(functionName, functionObject),
+            Action: 'lambda:InvokeFunction',
+            Principal: '*',
+            InvokedViaFunctionUrl: true,
+          },
+          DependsOn: getTargetAliasLogicalId(functionObject),
         },
-        DependsOn: getTargetAliasLogicalId(functionObject),
-      };
+        functionObject
+      );
+      cfTemplate.Resources[this.provider.naming.getLambdaFnPermissionLogicalId(functionName)] =
+        invokePermissionResource;
     }
   }
 
@@ -789,23 +823,26 @@ class AwsCompileFunctions {
     const cfResources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
     const functionLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
 
-    const resource = {
-      Type: 'AWS::Lambda::EventInvokeConfig',
-      Properties: {
-        FunctionName: { Ref: functionLogicalId },
-        DestinationConfig: destinationConfig,
-        Qualifier: functionObject.targetAlias ? functionObject.targetAlias.name : '$LATEST',
+    const resource = applyFunctionCondition(
+      {
+        Type: 'AWS::Lambda::EventInvokeConfig',
+        Properties: {
+          FunctionName: { Ref: functionLogicalId },
+          DestinationConfig: destinationConfig,
+          Qualifier: functionObject.targetAlias ? functionObject.targetAlias.name : '$LATEST',
+        },
+        DependsOn: normalizeDependsOn([
+          getTargetAliasLogicalId(functionObject),
+          ...(destinations
+            ? [
+                this.getDestinationTargetAliasLogicalId(destinations.onSuccess),
+                this.getDestinationTargetAliasLogicalId(destinations.onFailure),
+              ]
+            : []),
+        ]),
       },
-      DependsOn: normalizeDependsOn([
-        getTargetAliasLogicalId(functionObject),
-        ...(destinations
-          ? [
-              this.getDestinationTargetAliasLogicalId(destinations.onSuccess),
-              this.getDestinationTargetAliasLogicalId(destinations.onFailure),
-            ]
-          : []),
-      ]),
-    };
+      functionObject
+    );
 
     if (maximumEventAge) {
       resource.Properties.MaximumEventAgeInSeconds = maximumEventAge;

--- a/lib/plugins/aws/package/lib/merge-iam-templates.js
+++ b/lib/plugins/aws/package/lib/merge-iam-templates.js
@@ -25,6 +25,10 @@ module.exports = {
           },
         };
 
+        if (functionObject.condition) {
+          newLogGroup[logGroupLogicalId].Condition = functionObject.condition;
+        }
+
         const logRetentionInDays =
           functionObject.logRetentionInDays || this.provider.getLogRetentionInDays();
         if (logRetentionInDays) {

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -2140,6 +2140,15 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
             fnCondition: {
               handler: 'target.handler',
               condition: 'CreateFunctionCondition',
+              maximumRetryAttempts: 0,
+              provisionedConcurrency: 1,
+              url: true,
+            },
+            fnConditionSnapStart: {
+              handler: 'target.handler',
+              runtime: 'java17',
+              condition: 'CreateFunctionCondition',
+              snapStart: true,
             },
             fnDependsOn: {
               handler: 'target.handler',
@@ -2540,9 +2549,38 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
     });
 
     it('should support `functions[].conditions`', () => {
-      expect(getFunctionResource('fnCondition').Condition).to.equal(
-        serviceConfig.functions.fnCondition.condition
+      const condition = serviceConfig.functions.fnCondition.condition;
+      const [versionLogicalId, versionResource] = getVersionResourceEntry('fnCondition');
+
+      expect(getFunctionResource('fnCondition').Condition).to.equal(condition);
+      expect(versionResource.Condition).to.equal(condition);
+      expect(cfOutputs[naming.getLambdaVersionOutputLogicalId('fnCondition')]).to.deep.include({
+        Condition: condition,
+      });
+      expect(cfOutputs[naming.getLambdaVersionOutputLogicalId('fnCondition')].Value).to.deep.equal({
+        Ref: versionLogicalId,
+      });
+      expect(
+        cfResources[naming.getLambdaProvisionedConcurrencyAliasLogicalId('fnCondition')].Condition
+      ).to.equal(condition);
+      expect(cfResources[naming.getLambdaFunctionUrlLogicalId('fnCondition')].Condition).to.equal(
+        condition
       );
+      expect(
+        cfOutputs[naming.getLambdaFunctionUrlOutputLogicalId('fnCondition')].Condition
+      ).to.equal(condition);
+      expect(
+        cfResources[naming.getLambdaFnUrlPermissionLogicalId('fnCondition')].Condition
+      ).to.equal(condition);
+      expect(cfResources[naming.getLambdaFnPermissionLogicalId('fnCondition')].Condition).to.equal(
+        condition
+      );
+      expect(cfResources[naming.getLambdaEventConfigLogicalId('fnCondition')].Condition).to.equal(
+        condition
+      );
+      expect(
+        cfResources[naming.getLambdaSnapStartAliasLogicalId('fnConditionSnapStart')].Condition
+      ).to.equal(serviceConfig.functions.fnConditionSnapStart.condition);
     });
 
     it('should support `functions[].dependsOn`', () => {

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -2548,7 +2548,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
       ).to.deep.equal([{ Ref: 'ExternalLambdaLayer' }]);
     });
 
-    it('should support `functions[].conditions`', () => {
+    it('should support `functions[].condition`', () => {
       const condition = serviceConfig.functions.fnCondition.condition;
       const [versionLogicalId, versionResource] = getVersionResourceEntry('fnCondition');
 

--- a/test/unit/lib/plugins/aws/package/lib/merge-iam-templates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/merge-iam-templates.test.js
@@ -93,6 +93,17 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
                 handler: 'index.handler',
                 role: 'myCustRole0',
               },
+              fnCondition: {
+                handler: 'index.handler',
+                condition: 'CreateFunctionCondition',
+              },
+            },
+            resources: {
+              Conditions: {
+                CreateFunctionCondition: {
+                  'Fn::Equals': ['true', 'true'],
+                },
+              },
             },
           },
         });
@@ -168,6 +179,12 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
         expect(myFunctionResource.Properties.LogGroupName).to.be.equal(
           `/aws/lambda/${service}-dev-myFunction`
         );
+
+        const conditionFunctionName = naming.getLogGroupLogicalId('fnCondition');
+        const conditionFunctionResource = cfResources[conditionFunctionName];
+
+        expect(conditionFunctionResource.Type).to.be.equal('AWS::Logs::LogGroup');
+        expect(conditionFunctionResource.Condition).to.be.equal('CreateFunctionCondition');
       });
     });
 


### PR DESCRIPTION
This applies functions[].condition to generated Lambda-owned companion resources. It covers log groups, versions and outputs, aliases, Function URLs and URL permissions, and async event invoke configs without changing shared event resources.