### PR TITLE
Cache custom-resource artifacts by content

### DIFF
--- a/lib/plugins/aws/custom-resources/generate-zip.js
+++ b/lib/plugins/aws/custom-resources/generate-zip.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const path = require('path');
+const crypto = require('crypto');
+const fs = require('fs');
 const getTmpDirPath = require('../../../utils/fs/get-tmp-dir-path');
 const createZipFile = require('../../../utils/fs/create-zip-file');
 const ensureArtifact = require('../../../utils/ensure-artifact');
@@ -11,15 +13,42 @@ const srcDirPath = path.join(__dirname, 'resources');
 
 const artifactName = 'custom-resources.zip';
 
+const listFilesSorted = (dir) => {
+  const result = [];
+  for (const entry of fs
+    .readdirSync(dir, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name))) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) result.push(...listFilesSorted(fullPath));
+    else result.push(fullPath);
+  }
+  return result;
+};
+
+const resolveSourcesHash = () => {
+  const hash = crypto.createHash('md5');
+  for (const filePath of listFilesSorted(srcDirPath)) {
+    hash.update(path.relative(srcDirPath, filePath));
+    hash.update('\0');
+    hash.update(fs.readFileSync(filePath));
+    hash.update('\0');
+  }
+  return hash.digest('hex');
+};
+
 module.exports = async () => {
-  const resultPath = await ensureArtifact(artifactName, async (cachePath) => {
-    const tmpDirPath = getTmpDirPath();
-    const tmpInstalledLambdaPath = path.resolve(tmpDirPath, 'resource-lambda');
-    const tmpZipFilePath = path.resolve(tmpDirPath, 'resource-lambda.zip');
-    const cachedZipFilePath = path.resolve(cachePath, artifactName);
-    await copy(srcDirPath, tmpInstalledLambdaPath);
-    await createZipFile(tmpInstalledLambdaPath, tmpZipFilePath);
-    await safeMoveFile(tmpZipFilePath, cachedZipFilePath);
-  });
+  const resultPath = await ensureArtifact(
+    artifactName,
+    async (cachePath) => {
+      const tmpDirPath = getTmpDirPath();
+      const tmpInstalledLambdaPath = path.resolve(tmpDirPath, 'resource-lambda');
+      const tmpZipFilePath = path.resolve(tmpDirPath, 'resource-lambda.zip');
+      const cachedZipFilePath = path.resolve(cachePath, artifactName);
+      await copy(srcDirPath, tmpInstalledLambdaPath);
+      await createZipFile(tmpInstalledLambdaPath, tmpZipFilePath);
+      await safeMoveFile(tmpZipFilePath, cachedZipFilePath);
+    },
+    { artifactVersion: `custom-resources-${resolveSourcesHash()}` }
+  );
   return path.resolve(resultPath, artifactName);
 };

--- a/test/unit/lib/plugins/aws/custom-resources/generate-zip.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/generate-zip.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
 const glob = require('../../../../../../lib/utils/glob');
 const requireUncached = require('../../../../../utils/require-uncached');
 const { listZipFiles } = require('../../../../../utils/fs');
@@ -11,6 +12,8 @@ const resourcesDir = path.resolve(
   __dirname,
   '../../../../../../lib/plugins/aws/custom-resources/resources/'
 );
+const generateZipPath = '../../../../../../lib/plugins/aws/custom-resources/generate-zip';
+const escapedPathSep = path.sep.replace(/\\/g, '\\\\');
 
 describe('test/unit/lib/plugins/aws/customResources/generateZip.test.js', () => {
   describe('when generating a zip file', () => {
@@ -24,6 +27,53 @@ describe('test/unit/lib/plugins/aws/customResources/generateZip.test.js', () => 
 
       const filesInResourceDir = await glob('**', { cwd: resourcesDir });
       expect(filesInZip).to.have.all.members(filesInResourceDir);
+    });
+
+    it('should store the zip in a content-addressed cache directory', async () => {
+      const zipFilePath = await requireUncached(async () => require(generateZipPath)());
+
+      expect(zipFilePath).to.match(
+        new RegExp(
+          `${escapedPathSep}\\.serverless${escapedPathSep}artifacts${escapedPathSep}` +
+            `custom-resources-[a-f0-9]{32}${escapedPathSep}custom-resources\\.zip$`
+        )
+      );
+    });
+
+    it('should return the same content-addressed path on repeated calls', async () => {
+      const [firstPath, secondPath] = await requireUncached(async () => {
+        const generateZip = require(generateZipPath);
+        return [await generateZip(), await generateZip()];
+      });
+
+      expect(secondPath).to.equal(firstPath);
+    });
+
+    it('should change the cache directory when resource content changes', async () => {
+      const artifactVersions = [];
+      const makeGenerateZip = (content) =>
+        proxyquire(generateZipPath, {
+          'fs': {
+            readdirSync: () => [
+              {
+                name: 'handler.js',
+                isDirectory: () => false,
+              },
+            ],
+            readFileSync: () => Buffer.from(content),
+          },
+          '../../../utils/ensure-artifact': async (artifactName, generate, options) => {
+            artifactVersions.push(options.artifactVersion);
+            return path.resolve('/tmp/cache', options.artifactVersion);
+          },
+        });
+
+      await makeGenerateZip('first')();
+      await makeGenerateZip('second')();
+
+      expect(artifactVersions[0]).to.match(/^custom-resources-[a-f0-9]{32}$/);
+      expect(artifactVersions[1]).to.match(/^custom-resources-[a-f0-9]{32}$/);
+      expect(artifactVersions[1]).to.not.equal(artifactVersions[0]);
     });
   });
 });


### PR DESCRIPTION
Caches the custom-resource zip under a content-addressed artifact version while keeping the deployed filename as custom-resources.zip. Published npm releases already get a fresh package-version cache path during packaging, so this mainly prevents stale same-version artifacts in source checkouts, git and tarball installs, local CI, and repeated development builds.