### PR TITLE
Only replace S3 notification configs owned by the function

### DIFF
--- a/lib/plugins/aws/custom-resources/resources/s3/lib/bucket.js
+++ b/lib/plugins/aws/custom-resources/resources/s3/lib/bucket.js
@@ -15,6 +15,13 @@ function generateId(functionName, bucketConfig) {
   return `${functionName}-${md5}`;
 }
 
+function isOwnedConfiguration(config, functionName) {
+  if (!config.Id) return false;
+  const prefix = `${functionName}-`;
+  if (!config.Id.startsWith(prefix)) return false;
+  return /^[a-f0-9]{32}$/.test(config.Id.slice(prefix.length));
+}
+
 function createFilter(config) {
   const rules = config.Rules;
   if (rules && rules.length) {
@@ -64,7 +71,7 @@ async function updateConfiguration(config) {
     ) {
       NotificationConfiguration.LambdaFunctionConfigurations =
         NotificationConfiguration.LambdaFunctionConfigurations.filter(
-          (conf) => !conf.Id.startsWith(functionName)
+          (conf) => !isOwnedConfiguration(conf, functionName)
         );
     }
 
@@ -116,7 +123,7 @@ async function removeConfiguration(config) {
     ) {
       NotificationConfiguration.LambdaFunctionConfigurations =
         NotificationConfiguration.LambdaFunctionConfigurations.filter(
-          (conf) => !conf.Id.startsWith(functionName)
+          (conf) => !isOwnedConfiguration(conf, functionName)
         );
     }
 

--- a/test/unit/lib/plugins/aws/custom-resources/test/s3-bucket.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/test/s3-bucket.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const { expect } = require('chai');
+const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
+
+describe('Custom resource S3 bucket configuration', () => {
+  let sentCommands;
+  let updateConfiguration;
+  let removeConfiguration;
+
+  beforeEach(() => {
+    sentCommands = [];
+
+    class S3Client {
+      constructor() {
+        this.config = {};
+      }
+
+      send(command) {
+        sentCommands.push(command);
+        if (command.constructor.name === 'GetBucketNotificationConfigurationCommand') {
+          return Promise.resolve({
+            $metadata: {},
+            LambdaFunctionConfigurations: [
+              {
+                Id: `orders-${'a'.repeat(32)}`,
+                LambdaFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders',
+              },
+              {
+                Id: `orders-api-${'b'.repeat(32)}`,
+                LambdaFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders-api',
+              },
+              {
+                Id: 'orders-manual',
+                LambdaFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:manual',
+              },
+              {
+                LambdaFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:external',
+              },
+            ],
+          });
+        }
+        return Promise.resolve();
+      }
+    }
+
+    class GetBucketNotificationConfigurationCommand {
+      constructor(input) {
+        this.input = input;
+      }
+    }
+
+    class PutBucketNotificationConfigurationCommand {
+      constructor(input) {
+        this.input = input;
+      }
+    }
+
+    ({ updateConfiguration, removeConfiguration } = proxyquire(
+      '../../../../../../../lib/plugins/aws/custom-resources/resources/s3/lib/bucket',
+      {
+        '@aws-sdk/client-s3': {
+          S3Client,
+          GetBucketNotificationConfigurationCommand,
+          PutBucketNotificationConfigurationCommand,
+        },
+      }
+    ));
+  });
+
+  it('should only replace owned notification configurations on update', async () => {
+    await updateConfiguration({
+      lambdaArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders',
+      functionName: 'orders',
+      bucketName: 'orders-bucket',
+      bucketConfigs: [{ Event: 's3:ObjectCreated:*', Rules: [] }],
+      region: 'us-east-1',
+    });
+
+    const putInput = sentCommands[1].input;
+    const configs = putInput.NotificationConfiguration.LambdaFunctionConfigurations;
+
+    expect(configs.map((config) => config.LambdaFunctionArn)).to.deep.equal([
+      'arn:aws:lambda:us-east-1:123456789012:function:orders-api',
+      'arn:aws:lambda:us-east-1:123456789012:function:manual',
+      'arn:aws:lambda:us-east-1:123456789012:function:external',
+      'arn:aws:lambda:us-east-1:123456789012:function:orders',
+    ]);
+  });
+
+  it('should only remove owned notification configurations', async () => {
+    await removeConfiguration({
+      functionName: 'orders',
+      bucketName: 'orders-bucket',
+      region: 'us-east-1',
+    });
+
+    const putInput = sentCommands[1].input;
+    const configs = putInput.NotificationConfiguration.LambdaFunctionConfigurations;
+
+    expect(configs.map((config) => config.LambdaFunctionArn)).to.deep.equal([
+      'arn:aws:lambda:us-east-1:123456789012:function:orders-api',
+      'arn:aws:lambda:us-east-1:123456789012:function:manual',
+      'arn:aws:lambda:us-east-1:123456789012:function:external',
+    ]);
+  });
+});


### PR DESCRIPTION
Backports the S3 notification ownership fix from #333 to 3.x. The existing custom resource previously removed bucket notification entries with Id.startsWith(functionName), which could delete another function's notification when names shared a prefix and could throw on entries without an Id. The new predicate only matches the framework-generated ${functionName}-${md5} shape.