### PR TITLE
Read deprecation environment at call time

### DIFF
--- a/lib/utils/log-deprecation.js
+++ b/lib/utils/log-deprecation.js
@@ -9,10 +9,6 @@ const safeMoveFile = require('./fs/safe-move-file');
 const { style, log } = require('./serverless-utils/log');
 const healthStatusFilename = require('./health-status-filename');
 
-const disabledDeprecationCodesByEnv = extractCodes(process.env.SLS_DEPRECATION_DISABLE);
-
-const notificationModeByEnv = process.env.SLS_DEPRECATION_NOTIFICATION_MODE;
-
 const triggeredDeprecations = new Set();
 const bufferedDeprecations = [];
 
@@ -34,6 +30,8 @@ const resolveDisabledDeprecationsByService = weakMemoizee((serviceConfig) => {
 });
 
 const resolveMode = (serviceConfig) => {
+  const notificationModeByEnv = process.env.SLS_DEPRECATION_NOTIFICATION_MODE;
+
   switch (notificationModeByEnv) {
     case 'error':
     case 'warn':
@@ -55,13 +53,14 @@ function writeDeprecation(code, message) {
   log.warning(messageLines.join('\n'));
 }
 
+const isDisabledByEnv = (code) => {
+  const disabledDeprecationCodesByEnv = extractCodes(process.env.SLS_DEPRECATION_DISABLE);
+  return disabledDeprecationCodesByEnv.has(code) || disabledDeprecationCodesByEnv.has('*');
+};
+
 module.exports = (code, message, { serviceConfig } = {}) => {
   try {
-    if (
-      triggeredDeprecations.has(code) ||
-      disabledDeprecationCodesByEnv.has(code) ||
-      disabledDeprecationCodesByEnv.has('*')
-    ) {
+    if (triggeredDeprecations.has(code) || isDisabledByEnv(code)) {
       return;
     }
 

--- a/test/unit/lib/utils/log-deprecation.test.js
+++ b/test/unit/lib/utils/log-deprecation.test.js
@@ -46,6 +46,35 @@ describe('test/unit/lib/utils/logDeprecation.test.js', () => {
     );
   });
 
+  it('should honor env notification mode set after module load', () => {
+    const logDeprecation = require('../../../../lib/utils/log-deprecation');
+    let error;
+
+    process.env.SLS_DEPRECATION_NOTIFICATION_MODE = 'error';
+
+    try {
+      logDeprecation('CODE_DYNAMIC_ENV_MODE', 'Dynamic env mode');
+    } catch (thrownError) {
+      error = thrownError;
+    }
+
+    expect(error).to.be.instanceOf(ServerlessError);
+    expect(error).to.have.property('code', 'REJECTED_DEPRECATION_CODE_DYNAMIC_ENV_MODE');
+    expect(error.message).to.include('Dynamic env mode');
+  });
+
+  it('should honor env disabled deprecations set after module load', () => {
+    const logDeprecation = require('../../../../lib/utils/log-deprecation');
+
+    process.env.SLS_DEPRECATION_DISABLE = 'CODE_DYNAMIC_ENV_DISABLE';
+
+    expect(() =>
+      logDeprecation('CODE_DYNAMIC_ENV_DISABLE', 'Dynamic env disable', {
+        serviceConfig: { deprecationNotificationMode: 'error' },
+      })
+    ).to.not.throw();
+  });
+
   it('should write deprecation docs URL to summary output', async () => {
     const logDeprecation = require('../../../../lib/utils/log-deprecation');
     const healthStatusFilename = require('../../../../lib/utils/health-status-filename');


### PR DESCRIPTION
Reads deprecation notification mode and disabled deprecation codes when a deprecation is logged instead of caching those environment values at module load. This prevents reused test module instances from keeping stale deprecation settings after the test environment changes.