### PR TITLE
Make existing-event delete cleanup idempotent

### DIFF
--- a/lib/plugins/aws/custom-resources/resources/cognito-user-pool/handler.js
+++ b/lib/plugins/aws/custom-resources/resources/cognito-user-pool/handler.js
@@ -21,8 +21,11 @@ async function create(event, context) {
 
   const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
 
-  return findUserPoolByName({ userPoolName: UserPoolName, region: Region }).then((userPool) =>
-    addPermission({
+  return findUserPoolByName({ userPoolName: UserPoolName, region: Region }).then((userPool) => {
+    if (!userPool) {
+      throw new Error(`Could not find Cognito User Pool "${UserPoolName}"`);
+    }
+    return addPermission({
       functionName: FunctionName,
       userPoolName: UserPoolName,
       partition: Partition,
@@ -36,8 +39,8 @@ async function create(event, context) {
         userPoolConfigs: UserPoolConfigs,
         region: Region,
       })
-    )
-  );
+    );
+  });
 }
 
 async function update(event, context) {
@@ -64,13 +67,22 @@ async function remove(event, context) {
     functionName: FunctionName,
     userPoolName: UserPoolName,
     region: Region,
-  }).then(() =>
-    removeConfiguration({
-      lambdaArn,
-      userPoolName: UserPoolName,
-      region: Region,
-    })
-  );
+  })
+    .catch(ignoreMissingPermission)
+    .then(() =>
+      removeConfiguration({
+        lambdaArn,
+        userPoolName: UserPoolName,
+        region: Region,
+      })
+    );
+}
+
+function ignoreMissingPermission(error) {
+  if (error && [error.name, error.Code, error.code].includes('ResourceNotFoundException')) {
+    return;
+  }
+  throw error;
 }
 
 module.exports = {

--- a/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/user-pool.js
+++ b/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/user-pool.js
@@ -67,9 +67,10 @@ async function getConfiguration(config) {
 
   cognito.config.region = () => region;
 
-  return findUserPoolByName(config).then((userPool) =>
-    cognito.send(new DescribeUserPoolCommand({ UserPoolId: userPool.Id }))
-  );
+  return findUserPoolByName(config).then((userPool) => {
+    if (!userPool) return null;
+    return cognito.send(new DescribeUserPoolCommand({ UserPoolId: userPool.Id }));
+  });
 }
 
 async function updateConfiguration(config) {
@@ -78,6 +79,9 @@ async function updateConfiguration(config) {
   cognito.config.region = () => region;
 
   return getConfiguration(config).then((res) => {
+    if (!res) {
+      throw new Error(`Could not find Cognito User Pool "${config.userPoolName}"`);
+    }
     const UserPoolId = res.UserPool.Id;
     let { LambdaConfig } = res.UserPool;
 
@@ -117,6 +121,7 @@ async function removeConfiguration(config) {
   cognito.config.region = () => region;
 
   return getConfiguration(config).then((res) => {
+    if (!res) return null;
     const UserPoolId = res.UserPool.Id;
     let { LambdaConfig } = res.UserPool;
 

--- a/lib/plugins/aws/custom-resources/resources/s3/handler.js
+++ b/lib/plugins/aws/custom-resources/resources/s3/handler.js
@@ -61,13 +61,29 @@ async function remove(event, context) {
     functionName: FunctionName,
     bucketName: BucketName,
     region: Region,
-  }).then(() =>
-    removeConfiguration({
-      region: Region,
-      functionName: FunctionName,
-      bucketName: BucketName,
-    })
-  );
+  })
+    .catch(ignoreMissingPermission)
+    .then(() =>
+      removeConfiguration({
+        region: Region,
+        functionName: FunctionName,
+        bucketName: BucketName,
+      }).catch(ignoreMissingBucket)
+    );
+}
+
+function ignoreMissingPermission(error) {
+  if (error && [error.name, error.Code, error.code].includes('ResourceNotFoundException')) {
+    return;
+  }
+  throw error;
+}
+
+function ignoreMissingBucket(error) {
+  if (error && [error.name, error.Code, error.code].includes('NoSuchBucket')) {
+    return;
+  }
+  throw error;
 }
 
 module.exports = {

--- a/test/unit/lib/plugins/aws/custom-resources/test/cognito-user-pool-lifecycle.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/test/cognito-user-pool-lifecycle.test.js
@@ -1,0 +1,218 @@
+'use strict';
+
+const { expect } = require('chai');
+const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
+const sinon = require('sinon');
+const utils = require('../../../../../../../lib/plugins/aws/custom-resources/resources/utils');
+
+describe('Custom resource Cognito user pool handler lifecycle', () => {
+  const context = {
+    invokedFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:custom-resource',
+  };
+
+  const makeHandler = ({
+    findUserPoolByName = sinon.stub().resolves({ Id: 'us-east-1_abc123' }),
+    addPermission = sinon.stub().resolves(),
+    removePermission = sinon.stub().resolves(),
+    updateConfiguration = sinon.stub().resolves(),
+    removeConfiguration = sinon.stub().resolves(),
+  } = {}) => ({
+    handler: proxyquire(
+      '../../../../../../../lib/plugins/aws/custom-resources/resources/cognito-user-pool/handler',
+      {
+        '../utils': {
+          ...utils,
+          handlerWrapper: (wrappedHandler) => wrappedHandler,
+        },
+        './lib/permissions': { addPermission, removePermission },
+        './lib/user-pool': {
+          findUserPoolByName,
+          updateConfiguration,
+          removeConfiguration,
+        },
+      }
+    ).handler,
+    findUserPoolByName,
+    addPermission,
+    removePermission,
+    updateConfiguration,
+    removeConfiguration,
+  });
+
+  it('should reject create with a descriptive missing-pool error', async () => {
+    const findUserPoolByName = sinon.stub().resolves(null);
+    const addPermission = sinon.stub().resolves();
+    const { handler } = makeHandler({ findUserPoolByName, addPermission });
+
+    await expect(
+      handler(
+        {
+          RequestType: 'Create',
+          ResourceProperties: {
+            FunctionName: 'orders',
+            UserPoolName: 'orders-pool',
+            UserPoolConfigs: [{ Trigger: 'PreSignUp' }],
+          },
+        },
+        context
+      )
+    ).to.be.rejectedWith('Could not find Cognito User Pool "orders-pool"');
+
+    expect(addPermission).to.not.have.been.called;
+  });
+
+  it('should add permission before updating the user pool on create', async () => {
+    const calls = [];
+    const findUserPoolByName = sinon.stub().resolves({ Id: 'us-east-1_abc123' });
+    const addPermission = sinon.stub().callsFake(async () => calls.push('addPermission'));
+    const updateConfiguration = sinon
+      .stub()
+      .callsFake(async () => calls.push('updateConfiguration'));
+    const { handler } = makeHandler({
+      findUserPoolByName,
+      addPermission,
+      updateConfiguration,
+    });
+
+    await handler(
+      {
+        RequestType: 'Create',
+        ResourceProperties: {
+          FunctionName: 'orders',
+          UserPoolName: 'orders-pool',
+          UserPoolConfigs: [{ Trigger: 'PreSignUp' }],
+        },
+      },
+      context
+    );
+
+    expect(calls).to.deep.equal(['addPermission', 'updateConfiguration']);
+    expect(addPermission.args[0][0]).to.include({
+      functionName: 'orders',
+      userPoolName: 'orders-pool',
+      userPoolId: 'us-east-1_abc123',
+    });
+  });
+
+  it('should remove trigger configuration when Lambda permission is already missing', async () => {
+    const removePermission = sinon.stub().rejects({ name: 'ResourceNotFoundException' });
+    const removeConfiguration = sinon.stub().resolves();
+    const { handler } = makeHandler({ removePermission, removeConfiguration });
+
+    await handler(
+      {
+        RequestType: 'Delete',
+        ResourceProperties: {
+          FunctionName: 'orders',
+          UserPoolName: 'orders-pool',
+        },
+      },
+      context
+    );
+
+    expect(removePermission).to.have.been.calledOnce;
+    expect(removeConfiguration).to.have.been.calledOnce;
+  });
+
+  it('should rethrow AccessDeniedException when removing Lambda permission during delete', async () => {
+    const removePermission = sinon
+      .stub()
+      .rejects(Object.assign(new Error('denied'), { name: 'AccessDeniedException' }));
+    const removeConfiguration = sinon.stub().resolves();
+    const { handler } = makeHandler({ removePermission, removeConfiguration });
+
+    await expect(
+      handler(
+        {
+          RequestType: 'Delete',
+          ResourceProperties: {
+            FunctionName: 'orders',
+            UserPoolName: 'orders-pool',
+          },
+        },
+        context
+      )
+    ).to.be.rejectedWith('denied');
+
+    expect(removeConfiguration).to.not.have.been.called;
+  });
+});
+
+describe('Custom resource Cognito user pool configuration', () => {
+  const makeUserPoolLib = (responses) => {
+    const sentCommands = [];
+
+    class CognitoIdentityProviderClient {
+      constructor() {
+        this.config = {};
+      }
+
+      send(command) {
+        sentCommands.push(command);
+        const response = responses.shift();
+        if (response instanceof Error) return Promise.reject(response);
+        return Promise.resolve(response);
+      }
+    }
+
+    class ListUserPoolsCommand {
+      constructor(input) {
+        this.input = input;
+      }
+    }
+
+    class DescribeUserPoolCommand {
+      constructor(input) {
+        this.input = input;
+      }
+    }
+
+    class UpdateUserPoolCommand {
+      constructor(input) {
+        this.input = input;
+      }
+    }
+
+    return {
+      sentCommands,
+      lib: proxyquire(
+        '../../../../../../../lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/user-pool',
+        {
+          '@aws-sdk/client-cognito-identity-provider': {
+            CognitoIdentityProviderClient,
+            ListUserPoolsCommand,
+            DescribeUserPoolCommand,
+            UpdateUserPoolCommand,
+          },
+        }
+      ),
+    };
+  };
+
+  it('should reject update with a descriptive missing-pool error', async () => {
+    const { lib } = makeUserPoolLib([{ UserPools: [] }]);
+
+    await expect(
+      lib.updateConfiguration({
+        lambdaArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders',
+        userPoolName: 'orders-pool',
+        userPoolConfigs: [{ Trigger: 'PreSignUp' }],
+        region: 'us-east-1',
+      })
+    ).to.be.rejectedWith('Could not find Cognito User Pool "orders-pool"');
+  });
+
+  it('should no-op delete when the target user pool no longer exists', async () => {
+    const { sentCommands, lib } = makeUserPoolLib([{ UserPools: [] }]);
+
+    await lib.removeConfiguration({
+      lambdaArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders',
+      userPoolName: 'orders-pool',
+      region: 'us-east-1',
+    });
+
+    expect(sentCommands.map((command) => command.constructor.name)).to.deep.equal([
+      'ListUserPoolsCommand',
+    ]);
+  });
+});

--- a/test/unit/lib/plugins/aws/custom-resources/test/s3-bucket.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/test/s3-bucket.test.js
@@ -2,6 +2,8 @@
 
 const { expect } = require('chai');
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
+const sinon = require('sinon');
+const utils = require('../../../../../../../lib/plugins/aws/custom-resources/resources/utils');
 
 describe('Custom resource S3 bucket configuration', () => {
   let sentCommands;
@@ -103,5 +105,79 @@ describe('Custom resource S3 bucket configuration', () => {
       'arn:aws:lambda:us-east-1:123456789012:function:manual',
       'arn:aws:lambda:us-east-1:123456789012:function:external',
     ]);
+  });
+});
+
+describe('Custom resource S3 handler', () => {
+  const context = {
+    invokedFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:custom-resource',
+  };
+
+  const deleteEvent = {
+    RequestType: 'Delete',
+    ResourceProperties: {
+      FunctionName: 'orders',
+      BucketName: 'orders-bucket',
+    },
+  };
+
+  const makeHandler = ({ removePermission, removeConfiguration }) =>
+    proxyquire('../../../../../../../lib/plugins/aws/custom-resources/resources/s3/handler', {
+      '../utils': {
+        ...utils,
+        handlerWrapper: (wrappedHandler) => wrappedHandler,
+      },
+      './lib/permissions': {
+        addPermission: sinon.stub().resolves(),
+        removePermission,
+      },
+      './lib/bucket': {
+        updateConfiguration: sinon.stub().resolves(),
+        removeConfiguration,
+      },
+    }).handler;
+
+  it('should remove notification configuration when Lambda permission is already missing', async () => {
+    const removePermission = sinon.stub().rejects({ name: 'ResourceNotFoundException' });
+    const removeConfiguration = sinon.stub().resolves();
+    const handler = makeHandler({ removePermission, removeConfiguration });
+
+    await handler(deleteEvent, context);
+
+    expect(removePermission).to.have.been.calledOnce;
+    expect(removeConfiguration).to.have.been.calledOnce;
+  });
+
+  it('should ignore NoSuchBucket while deleting notification configuration', async () => {
+    const removePermission = sinon.stub().resolves();
+    const removeConfiguration = sinon.stub().rejects({ name: 'NoSuchBucket' });
+    const handler = makeHandler({ removePermission, removeConfiguration });
+
+    await handler(deleteEvent, context);
+
+    expect(removePermission).to.have.been.calledOnce;
+    expect(removeConfiguration).to.have.been.calledOnce;
+  });
+
+  it('should rethrow AccessDeniedException when removing Lambda permission during delete', async () => {
+    const error = Object.assign(new Error('denied'), { name: 'AccessDeniedException' });
+    const removePermission = sinon.stub().rejects(error);
+    const removeConfiguration = sinon.stub().resolves();
+    const handler = makeHandler({ removePermission, removeConfiguration });
+
+    await expect(handler(deleteEvent, context)).to.be.rejectedWith('denied');
+
+    expect(removeConfiguration).to.not.have.been.called;
+  });
+
+  it('should rethrow AccessDenied when removing notification configuration during delete', async () => {
+    const error = Object.assign(new Error('denied'), { name: 'AccessDenied' });
+    const removePermission = sinon.stub().resolves();
+    const removeConfiguration = sinon.stub().rejects(error);
+    const handler = makeHandler({ removePermission, removeConfiguration });
+
+    await expect(handler(deleteEvent, context)).to.be.rejectedWith('denied');
+
+    expect(removeConfiguration).to.have.been.calledOnce;
   });
 });


### PR DESCRIPTION
Makes existing S3 and Cognito custom-resource deletes best-effort when external resources or Lambda permissions are already gone, while create and update still fail clearly for a missing Cognito user pool and authorization errors still propagate. This should ship with the follow-up Cognito cleanup permission change so multi-event Cognito cleanup is not released without the scoped RemovePermission grant.