### PR TITLE
Allow Cognito permission cleanup for removed functions

### DIFF
--- a/lib/plugins/aws/package/compile/events/cognito-user-pool.js
+++ b/lib/plugins/aws/package/compile/events/cognito-user-pool.js
@@ -265,6 +265,13 @@ class AwsCompileCognitoUserPoolEvents {
       iamRoleStatements.push({
         Effect: 'Allow',
         Resource: {
+          'Fn::Sub': 'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:*',
+        },
+        Action: ['lambda:RemovePermission'],
+      });
+      iamRoleStatements.push({
+        Effect: 'Allow',
+        Resource: {
           'Fn::Sub': 'arn:${AWS::Partition}:iam::*:role/*',
         },
         Action: ['iam:PassRole'],

--- a/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
@@ -506,6 +506,13 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
             Resource: { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:first' },
           },
           {
+            Action: ['lambda:RemovePermission'],
+            Effect: 'Allow',
+            Resource: {
+              'Fn::Sub': 'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:*',
+            },
+          },
+          {
             Effect: 'Allow',
             Resource: {
               'Fn::Sub': 'arn:${AWS::Partition}:iam::*:role/*',
@@ -641,6 +648,13 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
             Resource: { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:first' },
           },
           {
+            Action: ['lambda:RemovePermission'],
+            Effect: 'Allow',
+            Resource: {
+              'Fn::Sub': 'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:*',
+            },
+          },
+          {
             Effect: 'Allow',
             Resource: {
               'Fn::Sub': 'arn:${AWS::Partition}:iam::*:role/*',
@@ -768,6 +782,13 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
             Action: ['lambda:AddPermission', 'lambda:RemovePermission'],
             Effect: 'Allow',
             Resource: { 'Fn::Sub': 'arn:${AWS::Partition}:lambda:*:*:function:second' },
+          },
+          {
+            Action: ['lambda:RemovePermission'],
+            Effect: 'Allow',
+            Resource: {
+              'Fn::Sub': 'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:*',
+            },
           },
           {
             Effect: 'Allow',


### PR DESCRIPTION
Adds a cleanup-only Cognito custom-resource permission for lambda:RemovePermission across functions in the current region and account. This allows CloudFormation cleanup deletes to remove Lambda permissions for functions that were present in the previous template but are no longer present in the current one, while the existing per-function AddPermission permissions remain unchanged.