### PR TITLE
Tolerate denied S3 notification cleanup on delete

### DIFF
--- a/lib/plugins/aws/custom-resources/resources/s3/handler.js
+++ b/lib/plugins/aws/custom-resources/resources/s3/handler.js
@@ -68,7 +68,9 @@ async function remove(event, context) {
         region: Region,
         functionName: FunctionName,
         bucketName: BucketName,
-      }).catch(ignoreMissingBucket)
+      })
+        .catch(ignoreMissingBucket)
+        .catch(ignoreDeniedBucketCleanup)
     );
 }
 
@@ -81,6 +83,16 @@ function ignoreMissingPermission(error) {
 
 function ignoreMissingBucket(error) {
   if (error && [error.name, error.Code, error.code].includes('NoSuchBucket')) {
+    return;
+  }
+  throw error;
+}
+
+function ignoreDeniedBucketCleanup(error) {
+  if (error && [error.name, error.Code, error.code].includes('AccessDenied')) {
+    // The old bucket may no longer be authorized after the role is recompiled
+    // from the current template. Let stack cleanup proceed; this can leave
+    // stale notification configuration on that external bucket.
     return;
   }
   throw error;

--- a/test/unit/lib/plugins/aws/custom-resources/test/s3-bucket.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/test/s3-bucket.test.js
@@ -170,13 +170,13 @@ describe('Custom resource S3 handler', () => {
     expect(removeConfiguration).to.not.have.been.called;
   });
 
-  it('should rethrow AccessDenied when removing notification configuration during delete', async () => {
+  it('should tolerate AccessDenied when removing notification configuration during delete', async () => {
     const error = Object.assign(new Error('denied'), { name: 'AccessDenied' });
     const removePermission = sinon.stub().resolves();
     const removeConfiguration = sinon.stub().rejects(error);
     const handler = makeHandler({ removePermission, removeConfiguration });
 
-    await expect(handler(deleteEvent, context)).to.be.rejectedWith('denied');
+    await handler(deleteEvent, context);
 
     expect(removeConfiguration).to.have.been.calledOnce;
   });


### PR DESCRIPTION
Tolerates AccessDenied from the existing-S3 custom resource's delete-path notification cleanup only. This is the chosen alternative to broadening the custom-resource role to s3:::*: stack cleanup can proceed when the old bucket grant has already been dropped, while the tradeoff is possible stale notification configuration on the external bucket. Lambda permission AccessDeniedException and all create and update authorization failures still propagate.