### PR TITLE
Regenerate missing custom-resource artifacts on copy

### DIFF
--- a/lib/plugins/aws/custom-resources/index.js
+++ b/lib/plugins/aws/custom-resources/index.js
@@ -6,14 +6,31 @@ const fsp = require('fs').promises;
 const memoizee = require('memoizee');
 const { log } = require('../../../utils/serverless-utils/log');
 const generateZip = require('./generate-zip');
+const ensureArtifact = require('../../../utils/ensure-artifact');
 const ServerlessError = require('../../../serverless-error');
+
+const copyCustomResourcesZip = async (zipFilePath) => {
+  const [cachedZipFilePath] = await Promise.all([
+    generateZip(),
+    fsp.mkdir(path.dirname(zipFilePath), { recursive: true }),
+  ]);
+  await fsp.copyFile(cachedZipFilePath, zipFilePath);
+};
 
 const prepareCustomResourcePackage = memoizee(
   async (zipFilePath) => {
     log.info('Generating custom CloudFormation resources');
-    return Promise.all([generateZip(), fsp.mkdir(path.dirname(zipFilePath), { recursive: true })])
-      .then(([cachedZipFilePath]) => fsp.copyFile(cachedZipFilePath, zipFilePath))
-      .then(() => path.basename(zipFilePath));
+    try {
+      await copyCustomResourcesZip(zipFilePath);
+    } catch (error) {
+      if (!error || error.code !== 'ENOENT') throw error;
+      // The cached artifact lives in ~/.serverless/artifacts, which can be
+      // cleaned up externally at any time. Treat a missing source as a cache
+      // miss: drop the memoized ensure result, regenerate once and retry.
+      ensureArtifact.clear();
+      await copyCustomResourcesZip(zipFilePath);
+    }
+    return path.basename(zipFilePath);
   },
   { promise: true, primitive: true }
 );
@@ -219,4 +236,5 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
 
 module.exports = {
   addCustomResourceToService,
+  clearArtifactCopyCache: prepareCustomResourcePackage.clear,
 };

--- a/test/unit/lib/plugins/aws/custom-resources/index.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/index.test.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const chai = require('chai');
+const os = require('os');
 const path = require('path');
 const AwsProvider = require('../../../../../../lib/plugins/aws/provider');
 const Serverless = require('../../../../../../lib/serverless');
 const CLI = require('../../../../../../lib/classes/cli');
-const { createTmpDir, pathExists } = require('../../../../../utils/fs');
+const { createTmpDir, pathExists, remove } = require('../../../../../utils/fs');
 const {
   addCustomResourceToService,
 } = require('../../../../../../lib/plugins/aws/custom-resources/index.js');
@@ -438,6 +439,25 @@ describe('#addCustomResourceToService()', () => {
   it('creates the package directory before copying the generated zip', async () => {
     serverless.serviceDir = path.join(tmpDirPath, 'nested', 'service');
 
+    await addCustomResourceToService(provider, 's3', iamRoleStatements);
+
+    expect(
+      await pathExists(
+        path.join(
+          serverless.serviceDir,
+          '.serverless',
+          provider.naming.getCustomResourcesArtifactName()
+        )
+      )
+    ).to.equal(true);
+  });
+
+  it('regenerates the cached zip when the artifact cache was removed externally', async () => {
+    await addCustomResourceToService(provider, 's3', iamRoleStatements);
+
+    await remove(path.resolve(os.homedir(), '.serverless', 'artifacts'));
+
+    serverless.serviceDir = createTmpDir();
     await addCustomResourceToService(provider, 's3', iamRoleStatements);
 
     expect(


### PR DESCRIPTION
Regenerates the cached custom-resources zip when copying it into the package directory finds it missing. The ~/.serverless/artifacts cache can be removed externally at any time, so the copy now treats a missing source as a cache miss, drops the memoized ensure result, regenerates once and retries, while any second failure or non-ENOENT error still propagates. Also exposes the copy memoization's clear hook for the test harness.