### PR TITLE
Regenerate missing ajv validator artifacts on read

### DIFF
--- a/lib/classes/config-schema-handler/resolve-ajv-validate.js
+++ b/lib/classes/config-schema-handler/resolve-ajv-validate.js
@@ -69,8 +69,21 @@ const getValidate = async (schema) => {
     await fsp.writeFile(tmpCachePath, moduleCode);
     await safeMoveFile(tmpCachePath, cachePath);
   };
-  await ensureExists(cachePath, generate);
-  const loadedModuleCode = await fsp.readFile(cachePath, 'utf-8');
+  const loadValidatorModuleCode = async () => {
+    await ensureExists(cachePath, generate);
+    return fsp.readFile(cachePath, 'utf-8');
+  };
+
+  let loadedModuleCode;
+  try {
+    loadedModuleCode = await loadValidatorModuleCode();
+  } catch (error) {
+    if (!error || error.code !== 'ENOENT') throw error;
+    // The cached validator lives in ~/.serverless/artifacts, which can be
+    // cleaned up externally at any time. Treat a read of a just-removed file
+    // as a cache miss: regenerate once and retry.
+    loadedModuleCode = await loadValidatorModuleCode();
+  }
   const validator = requireFromString(
     loadedModuleCode,
     path.resolve(__dirname, `[generated-ajv-validate]${filename}`)

--- a/test/unit/lib/classes/config-schema-handler/resolve-ajv-validate.test.js
+++ b/test/unit/lib/classes/config-schema-handler/resolve-ajv-validate.test.js
@@ -7,6 +7,7 @@ const deepSortObjectByKey = require('../../../../../lib/utils/deep-sort-object-b
 const path = require('path');
 const os = require('os');
 const fsp = require('fs').promises;
+const proxyquire = require('proxyquire');
 
 const expect = chai.expect;
 
@@ -52,6 +53,38 @@ describe('test/unit/lib/classes/ConfigSchemaHandler/resolveAjvValidate.test.js',
 
     const fileStat = await fsp.lstat(getExpectedCachePath(schemaHash));
     expect(fileStat.isFile()).to.be.true;
+  });
+
+  it('regenerates the cached validator module if removed externally', async () => {
+    const realFsp = require('fs').promises;
+    let injectedRemoval = false;
+    const resolveAjvValidateFresh = proxyquire(
+      '../../../../../lib/classes/config-schema-handler/resolve-ajv-validate',
+      {
+        fs: {
+          promises: {
+            ...realFsp,
+            readFile: async (filePath, ...args) => {
+              if (!injectedRemoval && String(filePath).includes('ajv-validate')) {
+                injectedRemoval = true;
+                await realFsp.unlink(filePath);
+              }
+              return realFsp.readFile(filePath, ...args);
+            },
+          },
+        },
+      }
+    );
+
+    const uniqueSchema = { ...schema, title: 'ExternallyRemovedCache' };
+    const validate = await resolveAjvValidateFresh(uniqueSchema);
+
+    expect(injectedRemoval).to.equal(true);
+    expect(typeof validate).to.equal('function');
+    expect(validate({ firstProp: 'value' })).to.equal(true);
+
+    const schemaHash = objectHash(deepSortObjectByKey(uniqueSchema));
+    expect((await realFsp.lstat(getExpectedCachePath(schemaHash))).isFile()).to.be.true;
   });
 
   it('validates date-time formats with ajv-formats v3 semantics', async () => {


### PR DESCRIPTION
Regenerates the cached ajv validator module when reading it from ~/.serverless/artifacts finds it missing. The artifacts directory is a cache that can be cleaned up externally between the existence check and the read; the loader now treats that as a cache miss, regenerates the validator module once and retries, while any second failure or non-ENOENT error still propagates. Companion to the custom-resources artifact regeneration fix; together they make both artifact-cache consumers tolerant of external cache cleanup.