### PR TITLE
Take over conflicted Lambda permissions

### DIFF
--- a/lib/plugins/aws/custom-resources/resources/cognito-user-pool/handler.js
+++ b/lib/plugins/aws/custom-resources/resources/cognito-user-pool/handler.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { addPermission, removePermission } = require('./lib/permissions');
+const { addPermission, removePermission, getStatementId } = require('./lib/permissions');
 const { updateConfiguration, removeConfiguration, findUserPoolByName } = require('./lib/user-pool');
 const { getEnvironment, getLambdaArn, handlerWrapper } = require('../utils');
 
@@ -25,7 +25,7 @@ async function create(event, context) {
       if (!userPool) {
         throw new Error(`Could not find Cognito User Pool "${target.userPoolName}"`);
       }
-      return addPermission({
+      return ensurePermission({
         functionName: target.functionName,
         functionQualifier: target.functionQualifier,
         userPoolName: target.userPoolName,
@@ -33,16 +33,14 @@ async function create(event, context) {
         region: Region,
         accountId: AccountId,
         userPoolId: userPool.Id,
-      })
-        .catch(ignoreExistingPermission)
-        .then(() =>
-          updateConfiguration({
-            lambdaArn: target.lambdaArn,
-            userPoolName: target.userPoolName,
-            userPoolConfigs: target.userPoolConfigs,
-            region: Region,
-          })
-        );
+      }).then(() =>
+        updateConfiguration({
+          lambdaArn: target.lambdaArn,
+          userPoolName: target.userPoolName,
+          userPoolConfigs: target.userPoolConfigs,
+          region: Region,
+        })
+      );
     }
   );
 }
@@ -54,7 +52,9 @@ async function update(event, context) {
   const oldTarget =
     event.OldResourceProperties && resolveTarget(event.OldResourceProperties, environment);
 
-  if (!isSameTarget(target, oldTarget)) {
+  const sameTarget = isSameTarget(target, oldTarget);
+
+  if (!sameTarget) {
     const userPool = await findUserPoolByName({
       userPoolName: target.userPoolName,
       region: Region,
@@ -62,7 +62,7 @@ async function update(event, context) {
     if (!userPool) {
       throw new Error(`Could not find Cognito User Pool "${target.userPoolName}"`);
     }
-    await addPermission({
+    await ensurePermission({
       functionName: target.functionName,
       functionQualifier: target.functionQualifier,
       userPoolName: target.userPoolName,
@@ -70,7 +70,7 @@ async function update(event, context) {
       region: Region,
       accountId: AccountId,
       userPoolId: userPool.Id,
-    }).catch(ignoreExistingPermission);
+    });
   }
 
   await updateConfiguration({
@@ -90,13 +90,26 @@ async function update(event, context) {
     });
   }
 
-  if (oldTarget && !isSameTarget(target, oldTarget)) {
+  if (oldTarget && !sameTarget && !sharesPermissionStatement(target, oldTarget)) {
     await removePermission({
       functionName: oldTarget.functionName,
       functionQualifier: oldTarget.functionQualifier,
       userPoolName: oldTarget.userPoolName,
       region: Region,
     }).catch(ignoreMissingPermission);
+  }
+}
+
+async function ensurePermission(config) {
+  try {
+    await addPermission(config);
+  } catch (error) {
+    if (!error || ![error.name, error.Code, error.code].includes('ResourceConflictException')) {
+      throw error;
+    }
+
+    await removePermission(config).catch(ignoreMissingPermission);
+    await addPermission(config);
   }
 }
 
@@ -148,15 +161,18 @@ function isSameTarget(target, oldTarget) {
   );
 }
 
-function ignoreMissingPermission(error) {
-  if (error && [error.name, error.Code, error.code].includes('ResourceNotFoundException')) {
-    return;
-  }
-  throw error;
+function sharesPermissionStatement(target, oldTarget) {
+  return (
+    oldTarget &&
+    oldTarget.functionName === target.functionName &&
+    oldTarget.functionQualifier === target.functionQualifier &&
+    getStatementId(oldTarget.functionName, oldTarget.userPoolName) ===
+      getStatementId(target.functionName, target.userPoolName)
+  );
 }
 
-function ignoreExistingPermission(error) {
-  if (error && [error.name, error.Code, error.code].includes('ResourceConflictException')) {
+function ignoreMissingPermission(error) {
+  if (error && [error.name, error.Code, error.code].includes('ResourceNotFoundException')) {
     return;
   }
   throw error;

--- a/lib/plugins/aws/custom-resources/resources/s3/handler.js
+++ b/lib/plugins/aws/custom-resources/resources/s3/handler.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { addPermission, removePermission } = require('./lib/permissions');
+const { addPermission, removePermission, getStatementId } = require('./lib/permissions');
 const { updateConfiguration, removeConfiguration } = require('./lib/bucket');
 const { getEnvironment, getLambdaArn, handlerWrapper } = require('../utils');
 
@@ -20,24 +20,22 @@ async function create(event, context) {
   const { Partition, Region, AccountId } = environment;
   const target = resolveTarget(event.ResourceProperties, environment);
 
-  return addPermission({
+  await ensurePermission({
     functionName: target.functionName,
     functionQualifier: target.functionQualifier,
     bucketName: target.bucketName,
     partition: Partition,
     region: Region,
     accountId: AccountId,
-  })
-    .catch(ignoreExistingPermission)
-    .then(() =>
-      updateConfiguration({
-        lambdaArn: target.lambdaArn,
-        region: Region,
-        functionName: target.functionName,
-        bucketName: target.bucketName,
-        bucketConfigs: target.bucketConfigs,
-      })
-    );
+  });
+
+  return updateConfiguration({
+    lambdaArn: target.lambdaArn,
+    region: Region,
+    functionName: target.functionName,
+    bucketName: target.bucketName,
+    bucketConfigs: target.bucketConfigs,
+  });
 }
 
 async function update(event, context) {
@@ -47,15 +45,17 @@ async function update(event, context) {
   const oldTarget =
     event.OldResourceProperties && resolveTarget(event.OldResourceProperties, environment);
 
-  if (!isSameTarget(target, oldTarget)) {
-    await addPermission({
+  const sameTarget = isSameTarget(target, oldTarget);
+
+  if (!sameTarget) {
+    await ensurePermission({
       functionName: target.functionName,
       functionQualifier: target.functionQualifier,
       bucketName: target.bucketName,
       partition: Partition,
       region: Region,
       accountId: AccountId,
-    }).catch(ignoreExistingPermission);
+    });
   }
 
   await updateConfiguration({
@@ -80,13 +80,26 @@ async function update(event, context) {
       .catch(ignoreDeniedNotificationCleanup);
   }
 
-  if (oldTarget && !isSameTarget(target, oldTarget)) {
+  if (oldTarget && !sameTarget && !sharesPermissionStatement(target, oldTarget)) {
     await removePermission({
       functionName: oldTarget.functionName,
       functionQualifier: oldTarget.functionQualifier,
       bucketName: oldTarget.bucketName,
       region: Region,
     }).catch(ignoreMissingPermission);
+  }
+}
+
+async function ensurePermission(config) {
+  try {
+    await addPermission(config);
+  } catch (error) {
+    if (!error || ![error.name, error.Code, error.code].includes('ResourceConflictException')) {
+      throw error;
+    }
+
+    await removePermission(config).catch(ignoreMissingPermission);
+    await addPermission(config);
   }
 }
 
@@ -140,6 +153,16 @@ function isSameTarget(target, oldTarget) {
   );
 }
 
+function sharesPermissionStatement(target, oldTarget) {
+  return (
+    oldTarget &&
+    oldTarget.functionName === target.functionName &&
+    oldTarget.functionQualifier === target.functionQualifier &&
+    getStatementId(oldTarget.functionName, oldTarget.bucketName) ===
+      getStatementId(target.functionName, target.bucketName)
+  );
+}
+
 function ignoreMissingPermission(error) {
   if (error && [error.name, error.Code, error.code].includes('ResourceNotFoundException')) {
     return;
@@ -162,13 +185,6 @@ function ignoreDeniedNotificationCleanup(error) {
     console.log(
       'Skipping S3 notification cleanup after AccessDenied; stale configuration may remain on the old bucket.'
     );
-    return;
-  }
-  throw error;
-}
-
-function ignoreExistingPermission(error) {
-  if (error && [error.name, error.Code, error.code].includes('ResourceConflictException')) {
     return;
   }
   throw error;

--- a/test/unit/lib/plugins/aws/custom-resources/test/cognito-user-pool.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/test/cognito-user-pool.test.js
@@ -81,6 +81,152 @@ describe('Custom resource Cognito user pool permissions', () => {
 });
 
 describe('Custom resource Cognito user pool handler', () => {
+  function getStatementId(functionName, userPoolName) {
+    return `${functionName}-${userPoolName.toLowerCase().replace(/[.:*\s]/g, '')}`;
+  }
+
+  function makeHandler({
+    findUserPoolByName = sinon.stub().resolves({ Id: 'us-east-1_abc123' }),
+    addPermission = sinon.stub().resolves(),
+    updateConfiguration = sinon.stub().resolves(),
+    removePermission = sinon.stub().resolves(),
+    removeConfiguration = sinon.stub().resolves(),
+    getStatementId: resolveStatementId = getStatementId,
+  } = {}) {
+    const { handler } = proxyquire(
+      '../../../../../../../lib/plugins/aws/custom-resources/resources/cognito-user-pool/handler',
+      {
+        '../utils': {
+          ...utils,
+          getEnvironment: () => ({
+            Partition: 'aws',
+            Region: 'us-east-1',
+            AccountId: '123456789012',
+          }),
+          handlerWrapper: (wrappedHandler) => wrappedHandler,
+        },
+        './lib/permissions': {
+          addPermission,
+          removePermission,
+          getStatementId: resolveStatementId,
+        },
+        './lib/user-pool': {
+          findUserPoolByName,
+          updateConfiguration,
+          removeConfiguration,
+        },
+      }
+    );
+
+    return {
+      handler,
+      findUserPoolByName,
+      addPermission,
+      updateConfiguration,
+      removePermission,
+      removeConfiguration,
+    };
+  }
+
+  it('should not churn Lambda permission on same-target ForceDeploy updates', async () => {
+    const { handler, addPermission, updateConfiguration, removePermission } = makeHandler();
+
+    await handler(
+      {
+        RequestType: 'Update',
+        ResourceProperties: {
+          FunctionName: 'orders',
+          UserPoolName: 'orders-pool',
+          UserPoolConfigs: [{ Trigger: 'PreSignUp' }],
+          ForceDeploy: 'new',
+        },
+        OldResourceProperties: {
+          FunctionName: 'orders',
+          UserPoolName: 'orders-pool',
+          UserPoolConfigs: [{ Trigger: 'PreSignUp' }],
+          ForceDeploy: 'old',
+        },
+      },
+      {}
+    );
+
+    expect(addPermission).to.not.have.been.called;
+    expect(updateConfiguration).to.have.been.calledOnce;
+    expect(removePermission).to.not.have.been.called;
+  });
+
+  it('should remove and re-add conflicting Lambda permission on create', async () => {
+    const calls = [];
+    const addPermission = sinon.stub();
+    addPermission.onFirstCall().callsFake(async (input) => {
+      calls.push(['addPermission', input]);
+      throw Object.assign(new Error('permission exists'), {
+        name: 'ResourceConflictException',
+      });
+    });
+    addPermission.onSecondCall().callsFake(async (input) => {
+      calls.push(['addPermission', input]);
+    });
+    const updateConfiguration = sinon.stub().callsFake(async (input) => {
+      calls.push(['updateConfiguration', input]);
+    });
+    const removePermission = sinon.stub().callsFake(async (input) => {
+      calls.push(['removePermission', input]);
+    });
+    const { handler } = makeHandler({ addPermission, updateConfiguration, removePermission });
+
+    await handler(
+      {
+        RequestType: 'Create',
+        ResourceProperties: {
+          FunctionName: 'orders',
+          FunctionQualifier: 'provisioned',
+          UserPoolName: 'orders-pool',
+          UserPoolConfigs: [{ Trigger: 'PreSignUp' }],
+        },
+      },
+      {}
+    );
+
+    expect(addPermission).to.have.been.calledTwice;
+    expect(removePermission).to.have.been.calledOnce;
+    expect(removePermission.args[0][0]).to.include({
+      functionName: 'orders',
+      functionQualifier: 'provisioned',
+      userPoolName: 'orders-pool',
+    });
+    expect(calls.map(([name]) => name)).to.deep.equal([
+      'addPermission',
+      'removePermission',
+      'addPermission',
+      'updateConfiguration',
+    ]);
+  });
+
+  it('should rethrow non-conflict Lambda permission add errors', async () => {
+    const addPermission = sinon
+      .stub()
+      .rejects(Object.assign(new Error('denied'), { name: 'AccessDeniedException' }));
+    const { handler, updateConfiguration, removePermission } = makeHandler({ addPermission });
+
+    await expect(
+      handler(
+        {
+          RequestType: 'Create',
+          ResourceProperties: {
+            FunctionName: 'orders',
+            UserPoolName: 'orders-pool',
+            UserPoolConfigs: [{ Trigger: 'PreSignUp' }],
+          },
+        },
+        {}
+      )
+    ).to.be.rejectedWith('denied');
+
+    expect(removePermission).to.not.have.been.called;
+    expect(updateConfiguration).to.not.have.been.called;
+  });
+
   it('should reject create with a descriptive missing-pool error', async () => {
     const findUserPoolByName = sinon.stub().resolves(null);
     const addPermission = sinon.stub().resolves();
@@ -318,10 +464,24 @@ describe('Custom resource Cognito user pool handler', () => {
   });
 
   it('should continue migration when qualified permission already exists', async () => {
+    const calls = [];
     const findUserPoolByName = sinon.stub().resolves({ Id: 'us-east-1_abc123' });
-    const addPermission = sinon.stub().rejects({ name: 'ResourceConflictException' });
-    const updateConfiguration = sinon.stub().resolves();
-    const removePermission = sinon.stub().resolves();
+    const addPermission = sinon.stub();
+    addPermission.onFirstCall().callsFake(async (input) => {
+      calls.push(['addPermission', input]);
+      throw Object.assign(new Error('permission exists'), {
+        name: 'ResourceConflictException',
+      });
+    });
+    addPermission.onSecondCall().callsFake(async (input) => {
+      calls.push(['addPermission', input]);
+    });
+    const updateConfiguration = sinon.stub().callsFake(async (input) => {
+      calls.push(['updateConfiguration', input]);
+    });
+    const removePermission = sinon.stub().callsFake(async (input) => {
+      calls.push(['removePermission', input]);
+    });
     const removeConfiguration = sinon.stub().resolves();
 
     const { handler } = proxyquire(
@@ -336,7 +496,7 @@ describe('Custom resource Cognito user pool handler', () => {
           }),
           handlerWrapper: (wrappedHandler) => wrappedHandler,
         },
-        './lib/permissions': { addPermission, removePermission },
+        './lib/permissions': { addPermission, removePermission, getStatementId },
         './lib/user-pool': {
           findUserPoolByName,
           updateConfiguration,
@@ -363,8 +523,55 @@ describe('Custom resource Cognito user pool handler', () => {
       {}
     );
 
+    expect(addPermission).to.have.been.calledTwice;
     expect(updateConfiguration).to.have.been.calledOnce;
-    expect(removePermission).to.have.been.calledOnce;
+    expect(removePermission).to.have.been.calledTwice;
+    expect(removePermission.args[0][0]).to.include({
+      functionName: 'orders',
+      functionQualifier: 'provisioned',
+      userPoolName: 'orders-pool',
+    });
+    expect(removePermission.args[1][0]).to.include({
+      functionName: 'orders',
+      userPoolName: 'orders-pool',
+    });
+    expect(removePermission.args[1][0]).to.have.property('functionQualifier', undefined);
+    expect(calls.map(([name]) => name)).to.deep.equal([
+      'addPermission',
+      'removePermission',
+      'addPermission',
+      'updateConfiguration',
+      'removePermission',
+    ]);
+  });
+
+  it('should not remove old permission when migrated user pools share a statement ID', async () => {
+    const removeConfiguration = sinon.stub().resolves();
+    const { handler, removePermission } = makeHandler({ removeConfiguration });
+
+    await handler(
+      {
+        RequestType: 'Update',
+        ResourceProperties: {
+          FunctionName: 'orders',
+          UserPoolName: 'orderspool',
+          UserPoolConfigs: [{ Trigger: 'PreSignUp' }],
+        },
+        OldResourceProperties: {
+          FunctionName: 'orders',
+          UserPoolName: 'Orders Pool',
+          UserPoolConfigs: [{ Trigger: 'PreSignUp' }],
+        },
+      },
+      {}
+    );
+
+    expect(removeConfiguration).to.have.been.calledOnceWithExactly({
+      lambdaArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders',
+      userPoolName: 'Orders Pool',
+      region: 'us-east-1',
+    });
+    expect(removePermission).to.not.have.been.called;
   });
 
   it('should not remove previous Lambda arn from a new user pool', async () => {
@@ -422,6 +629,13 @@ describe('Custom resource Cognito user pool handler', () => {
       lambdaArn: 'arn:aws:lambda:us-east-1:123456789012:function:orders',
       userPoolName: 'old-orders-pool',
     });
+    expect(removePermission).to.have.been.calledOnce;
+    expect(removePermission.args[0][0]).to.include({
+      functionName: 'orders',
+      userPoolName: 'old-orders-pool',
+      region: 'us-east-1',
+    });
+    expect(removePermission.args[0][0]).to.have.property('functionQualifier', undefined);
   });
 
   it('should remove trigger configuration when Lambda permission is already missing', async () => {

--- a/test/unit/lib/plugins/aws/custom-resources/test/s3.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/test/s3.test.js
@@ -80,11 +80,16 @@ describe('Custom resource S3 permissions', () => {
 });
 
 describe('Custom resource S3 handler', () => {
+  function getStatementId(functionName, bucketName) {
+    return `${functionName}-${bucketName.replace(/[.:*]/g, '')}`;
+  }
+
   function makeHandler({
     addPermission = sinon.stub().resolves(),
     updateConfiguration = sinon.stub().resolves(),
     removePermission = sinon.stub().resolves(),
     removeConfiguration = sinon.stub().resolves(),
+    getStatementId: resolveStatementId = getStatementId,
   } = {}) {
     const { handler } = proxyquire(
       '../../../../../../../lib/plugins/aws/custom-resources/resources/s3/handler',
@@ -98,13 +103,116 @@ describe('Custom resource S3 handler', () => {
           }),
           handlerWrapper: (wrappedHandler) => wrappedHandler,
         },
-        './lib/permissions': { addPermission, removePermission },
+        './lib/permissions': {
+          addPermission,
+          removePermission,
+          getStatementId: resolveStatementId,
+        },
         './lib/bucket': { updateConfiguration, removeConfiguration },
       }
     );
 
     return { handler, addPermission, updateConfiguration, removePermission, removeConfiguration };
   }
+
+  it('should not churn Lambda permission on same-target ForceDeploy updates', async () => {
+    const { handler, addPermission, updateConfiguration, removePermission } = makeHandler();
+
+    await handler(
+      {
+        RequestType: 'Update',
+        ResourceProperties: {
+          FunctionName: 'orders',
+          BucketName: 'orders-bucket',
+          BucketConfigs: [],
+          ForceDeploy: 'new',
+        },
+        OldResourceProperties: {
+          FunctionName: 'orders',
+          BucketName: 'orders-bucket',
+          BucketConfigs: [],
+          ForceDeploy: 'old',
+        },
+      },
+      {}
+    );
+
+    expect(addPermission).to.not.have.been.called;
+    expect(updateConfiguration).to.have.been.calledOnce;
+    expect(removePermission).to.not.have.been.called;
+  });
+
+  it('should remove and re-add conflicting Lambda permission on create', async () => {
+    const calls = [];
+    const addPermission = sinon.stub();
+    addPermission.onFirstCall().callsFake(async (input) => {
+      calls.push(['addPermission', input]);
+      throw Object.assign(new Error('permission exists'), {
+        name: 'ResourceConflictException',
+      });
+    });
+    addPermission.onSecondCall().callsFake(async (input) => {
+      calls.push(['addPermission', input]);
+    });
+    const updateConfiguration = sinon.stub().callsFake(async (input) => {
+      calls.push(['updateConfiguration', input]);
+    });
+    const removePermission = sinon.stub().callsFake(async (input) => {
+      calls.push(['removePermission', input]);
+    });
+    const { handler } = makeHandler({ addPermission, updateConfiguration, removePermission });
+
+    await handler(
+      {
+        RequestType: 'Create',
+        ResourceProperties: {
+          FunctionName: 'orders',
+          FunctionQualifier: 'provisioned',
+          BucketName: 'orders-bucket',
+          BucketConfigs: [],
+        },
+      },
+      {}
+    );
+
+    expect(addPermission).to.have.been.calledTwice;
+    expect(removePermission).to.have.been.calledOnce;
+    expect(removePermission.args[0][0]).to.include({
+      functionName: 'orders',
+      functionQualifier: 'provisioned',
+      bucketName: 'orders-bucket',
+    });
+    expect(calls.map(([name]) => name)).to.deep.equal([
+      'addPermission',
+      'removePermission',
+      'addPermission',
+      'updateConfiguration',
+    ]);
+  });
+
+  it('should rethrow non-conflict Lambda permission add errors', async () => {
+    const addPermission = sinon
+      .stub()
+      .rejects(Object.assign(new Error('denied'), { name: 'AccessDeniedException' }));
+    const { handler, updateConfiguration, removePermission } = makeHandler({ addPermission });
+
+    await expect(
+      handler(
+        {
+          RequestType: 'Create',
+          ResourceProperties: {
+            FunctionName: 'orders',
+            BucketName: 'orders-bucket',
+            BucketConfigs: [],
+          },
+        },
+        {}
+      )
+    ).to.be.rejectedWith('denied');
+
+    expect(removePermission).to.not.have.been.called;
+    expect(updateConfiguration).to.not.have.been.called;
+  });
 
   it('should add qualified permission before migrating existing notification target', async () => {
     const calls = [];
@@ -244,7 +352,9 @@ describe('Custom resource S3 handler', () => {
 
   it('should clean up old notification target only when the bucket changes', async () => {
     const removeConfiguration = sinon.stub().resolves();
-    const { handler, updateConfiguration } = makeHandler({ removeConfiguration });
+    const { handler, updateConfiguration, removePermission } = makeHandler({
+      removeConfiguration,
+    });
 
     await handler(
       {
@@ -269,6 +379,41 @@ describe('Custom resource S3 handler', () => {
       functionName: 'orders',
       bucketName: 'old-orders-bucket',
     });
+    expect(removePermission).to.have.been.calledOnce;
+    expect(removePermission.args[0][0]).to.include({
+      functionName: 'orders',
+      bucketName: 'old-orders-bucket',
+      region: 'us-east-1',
+    });
+  });
+
+  it('should not remove old permission when migrated buckets share a statement ID', async () => {
+    const removeConfiguration = sinon.stub().resolves();
+    const { handler, removePermission } = makeHandler({ removeConfiguration });
+
+    await handler(
+      {
+        RequestType: 'Update',
+        ResourceProperties: {
+          FunctionName: 'orders',
+          BucketName: 'ordersbucket',
+          BucketConfigs: [],
+        },
+        OldResourceProperties: {
+          FunctionName: 'orders',
+          BucketName: 'orders.bucket',
+          BucketConfigs: [],
+        },
+      },
+      {}
+    );
+
+    expect(removeConfiguration).to.have.been.calledOnceWithExactly({
+      region: 'us-east-1',
+      functionName: 'orders',
+      bucketName: 'orders.bucket',
+    });
+    expect(removePermission).to.not.have.been.called;
   });
 
   it('should tolerate missing old bucket while cleaning up migrated notification target', async () => {
@@ -385,9 +530,23 @@ describe('Custom resource S3 handler', () => {
   });
 
   it('should continue migration when qualified permission already exists', async () => {
-    const addPermission = sinon.stub().rejects({ name: 'ResourceConflictException' });
-    const updateConfiguration = sinon.stub().resolves();
-    const removePermission = sinon.stub().resolves();
+    const calls = [];
+    const addPermission = sinon.stub();
+    addPermission.onFirstCall().callsFake(async (input) => {
+      calls.push(['addPermission', input]);
+      throw Object.assign(new Error('permission exists'), {
+        name: 'ResourceConflictException',
+      });
+    });
+    addPermission.onSecondCall().callsFake(async (input) => {
+      calls.push(['addPermission', input]);
+    });
+    const updateConfiguration = sinon.stub().callsFake(async (input) => {
+      calls.push(['updateConfiguration', input]);
+    });
+    const removePermission = sinon.stub().callsFake(async (input) => {
+      calls.push(['removePermission', input]);
+    });
     const removeConfiguration = sinon.stub().resolves();
 
     const { handler } = proxyquire(
@@ -402,7 +561,7 @@ describe('Custom resource S3 handler', () => {
           }),
           handlerWrapper: (wrappedHandler) => wrappedHandler,
         },
-        './lib/permissions': { addPermission, removePermission },
+        './lib/permissions': { addPermission, removePermission, getStatementId },
         './lib/bucket': { updateConfiguration, removeConfiguration },
       }
     );
@@ -425,8 +584,26 @@ describe('Custom resource S3 handler', () => {
       {}
     );
 
+    expect(addPermission).to.have.been.calledTwice;
     expect(updateConfiguration).to.have.been.calledOnce;
-    expect(removePermission).to.have.been.calledOnce;
+    expect(removePermission).to.have.been.calledTwice;
+    expect(removePermission.args[0][0]).to.include({
+      functionName: 'orders',
+      functionQualifier: 'provisioned',
+      bucketName: 'orders-bucket',
+    });
+    expect(removePermission.args[1][0]).to.include({
+      functionName: 'orders',
+      bucketName: 'orders-bucket',
+    });
+    expect(removePermission.args[1][0]).to.have.property('functionQualifier', undefined);
+    expect(calls.map(([name]) => name)).to.deep.equal([
+      'addPermission',
+      'removePermission',
+      'addPermission',
+      'updateConfiguration',
+      'removePermission',
+    ]);
   });
 
   it('should remove notification configuration when Lambda permission is already missing', async () => {


### PR DESCRIPTION
Replaces blind AddPermission conflict swallowing in the existing S3 and Cognito custom resources. A conflicting statement is now removed and re-added with the desired SourceArn, and old-target cleanup skips removal only when old and new targets share the same statement ID on the same Lambda policy.