### PR TITLE
Serialize existing-event custom resources

### DIFF
--- a/lib/plugins/aws/package/compile/events/cognito-user-pool.js
+++ b/lib/plugins/aws/package/compile/events/cognito-user-pool.js
@@ -286,21 +286,13 @@ class AwsCompileCognitoUserPoolEvents {
       });
     }
 
-    // check if we need to add DependsOn clauses in case more than 1
-    // custom resources are created for one Cognito User Pool (to avoid race conditions)
-    if (Object.keys(poolResources).length > 0) {
-      Object.keys(poolResources).forEach((pool) => {
-        const resources = poolResources[pool];
-        if (resources.length > 1) {
-          resources.forEach((currResourceLogicalId, idx) => {
-            if (idx > 0) {
-              const prevResourceLogicalId = resources[idx - 1];
-              Resources[currResourceLogicalId].DependsOn.push(prevResourceLogicalId);
-            }
-          });
-        }
-      });
-    }
+    const allCustomResourceLogicalIds = Array.from(new Set(Object.values(poolResources).flat()));
+
+    allCustomResourceLogicalIds.forEach((currResourceLogicalId, idx) => {
+      if (idx > 0) {
+        Resources[currResourceLogicalId].DependsOn.push(allCustomResourceLogicalIds[idx - 1]);
+      }
+    });
 
     if (iamRoleStatements.length) {
       return addCustomResourceToService(this.provider, 'cognitoUserPool', iamRoleStatements);

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -408,21 +408,13 @@ class AwsCompileS3Events {
       });
     }
 
-    // check if we need to add DependsOn clauses in case more than 1
-    // custom resources are created for one bucket (to avoid race conditions)
-    if (Object.keys(bucketResources).length > 0) {
-      Object.keys(bucketResources).forEach((bucket) => {
-        const resources = bucketResources[bucket];
-        if (resources.length > 1) {
-          resources.forEach((currResourceLogicalId, idx) => {
-            if (idx > 0) {
-              const prevResourceLogicalId = resources[idx - 1];
-              Resources[currResourceLogicalId].DependsOn.push(prevResourceLogicalId);
-            }
-          });
-        }
-      });
-    }
+    const allCustomResourceLogicalIds = Array.from(new Set(Object.values(bucketResources).flat()));
+
+    allCustomResourceLogicalIds.forEach((currResourceLogicalId, idx) => {
+      if (idx > 0) {
+        Resources[currResourceLogicalId].DependsOn.push(allCustomResourceLogicalIds[idx - 1]);
+      }
+    });
 
     if (iamRoleStatements.length) {
       return addCustomResourceToService(this.provider, 's3', iamRoleStatements);

--- a/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
@@ -893,6 +893,54 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
       });
     });
 
+    it('should chain custom resources across different existing user pools', async () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          name: 'first',
+          targetAlias: { logicalId: 'FirstLambdaAlias', name: 'live' },
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'first-existing-user-pool',
+                trigger: 'CustomMessage',
+                existing: true,
+              },
+            },
+          ],
+        },
+        second: {
+          name: 'second',
+          targetAlias: { logicalId: 'SecondLambdaAlias', name: 'live' },
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'second-existing-user-pool',
+                trigger: 'PostConfirmation',
+                existing: true,
+              },
+            },
+          ],
+        },
+      };
+
+      await awsCompileCognitoUserPoolEvents.existingCognitoUserPools();
+
+      const { Resources } =
+        awsCompileCognitoUserPoolEvents.serverless.service.provider.compiledCloudFormationTemplate;
+
+      expect(Resources.FirstCustomCognitoUserPool1.DependsOn).to.deep.equal([
+        'FirstLambdaFunction',
+        'FirstLambdaAlias',
+        'CustomDashresourceDashexistingDashcupLambdaFunction',
+      ]);
+      expect(Resources.SecondCustomCognitoUserPool1.DependsOn).to.deep.equal([
+        'SecondLambdaFunction',
+        'SecondLambdaAlias',
+        'CustomDashresourceDashexistingDashcupLambdaFunction',
+        'FirstCustomCognitoUserPool1',
+      ]);
+    });
+
     it('should throw if more than 1 Cognito User Pool is configured per function', () => {
       awsCompileCognitoUserPoolEvents.serverless.service.functions = {
         first: {
@@ -1227,6 +1275,9 @@ describe('lib/plugins/aws/package/compile/events/cognito-user-pool.test.js', () 
         naming.getLambdaLogicalId('provisionedExisting'),
         naming.getLambdaProvisionedConcurrencyAliasLogicalId('provisionedExisting'),
         naming.getCustomResourceCognitoUserPoolHandlerFunctionLogicalId(),
+        naming.getCustomResourceCognitoUserPoolResourceLogicalId(
+          'singleCustomSenderSourceForMultiplePoolsExisting2'
+        ),
       ]);
       expect(provisionedResource.Properties).to.deep.include({
         FunctionName: serverlessInstance.service.getFunction('provisionedExisting').name,
@@ -1501,6 +1552,7 @@ describe('lib/plugins/aws/package/compile/events/cognito-user-pool.test.js', () 
           DependsOn: [
             'SingleCustomSenderSourceKmsStringARNExistingLambdaFunction',
             'CustomDashresourceDashexistingDashcupLambdaFunction',
+            'ExistingCustomEmailSenderCustomCognitoUserPool1',
           ],
           Properties: {
             ServiceToken: {
@@ -1533,6 +1585,7 @@ describe('lib/plugins/aws/package/compile/events/cognito-user-pool.test.js', () 
           DependsOn: [
             'SingleCustomSenderSourceKmsRefARNExistingLambdaFunction',
             'CustomDashresourceDashexistingDashcupLambdaFunction',
+            'SingleCustomSenderSourceKmsStringARNExistingCustomCognitoUserPool1',
           ],
           Properties: {
             ServiceToken: {
@@ -1566,6 +1619,7 @@ describe('lib/plugins/aws/package/compile/events/cognito-user-pool.test.js', () 
           DependsOn: [
             'MultipleCustomSenderSourceForSinglePoolExistingLambdaFunction',
             'CustomDashresourceDashexistingDashcupLambdaFunction',
+            'SingleCustomSenderSourceKmsRefARNExistingCustomCognitoUserPool1',
           ],
           Properties: {
             ServiceToken: {
@@ -1604,6 +1658,7 @@ describe('lib/plugins/aws/package/compile/events/cognito-user-pool.test.js', () 
           DependsOn: [
             'SingleCustomSenderSourceForMultiplePoolsExisting1LambdaFunction',
             'CustomDashresourceDashexistingDashcupLambdaFunction',
+            'MultipleCustomSenderSourceForSinglePoolExistingCustomCognitoUserPool1',
           ],
           Properties: {
             ServiceToken: {
@@ -1634,6 +1689,7 @@ describe('lib/plugins/aws/package/compile/events/cognito-user-pool.test.js', () 
           DependsOn: [
             'SingleCustomSenderSourceForMultiplePoolsExisting2LambdaFunction',
             'CustomDashresourceDashexistingDashcupLambdaFunction',
+            'SingleCustomSenderSourceForMultiplePoolsExisting1CustomCognitoUserPool1',
           ],
           Properties: {
             ServiceToken: {

--- a/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -924,6 +924,52 @@ describe('AwsCompileS3Events', () => {
       });
     });
 
+    it('should chain custom resources across different existing buckets', async () => {
+      awsCompileS3Events.serverless.service.functions = {
+        first: {
+          name: 'first',
+          targetAlias: { logicalId: 'FirstLambdaAlias', name: 'live' },
+          events: [
+            {
+              s3: {
+                bucket: 'first-existing-s3-bucket',
+                existing: true,
+              },
+            },
+          ],
+        },
+        second: {
+          name: 'second',
+          targetAlias: { logicalId: 'SecondLambdaAlias', name: 'live' },
+          events: [
+            {
+              s3: {
+                bucket: 'second-existing-s3-bucket',
+                existing: true,
+              },
+            },
+          ],
+        },
+      };
+
+      await awsCompileS3Events.existingS3Buckets();
+
+      const { Resources } =
+        awsCompileS3Events.serverless.service.provider.compiledCloudFormationTemplate;
+
+      expect(Resources.FirstCustomS31.DependsOn).to.deep.equal([
+        'FirstLambdaFunction',
+        'FirstLambdaAlias',
+        'CustomDashresourceDashexistingDashs3LambdaFunction',
+      ]);
+      expect(Resources.SecondCustomS31.DependsOn).to.deep.equal([
+        'SecondLambdaFunction',
+        'SecondLambdaAlias',
+        'CustomDashresourceDashexistingDashs3LambdaFunction',
+        'FirstCustomS31',
+      ]);
+    });
+
     it('should throw if more than 1 S3 bucket is configured per function', () => {
       awsCompileS3Events.serverless.service.functions = {
         first: {
@@ -1189,7 +1235,11 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
     expect(cfResources[naming.getCustomResourceS3ResourceLogicalId('other')]).to.deep.equal({
       Type: 'Custom::S3',
       Version: 1,
-      DependsOn: ['OtherLambdaFunction', 'CustomDashresourceDashexistingDashs3LambdaFunction'],
+      DependsOn: [
+        'OtherLambdaFunction',
+        'CustomDashresourceDashexistingDashs3LambdaFunction',
+        'BasicCustomS31',
+      ],
       Properties: {
         ServiceToken: {
           'Fn::GetAtt': ['CustomDashresourceDashexistingDashs3LambdaFunction', 'Arn'],
@@ -1205,7 +1255,11 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
     expect(cfResources[naming.getCustomResourceS3ResourceLogicalId('withIf')]).to.deep.equal({
       Type: 'Custom::S3',
       Version: 1,
-      DependsOn: ['WithIfLambdaFunction', 'CustomDashresourceDashexistingDashs3LambdaFunction'],
+      DependsOn: [
+        'WithIfLambdaFunction',
+        'CustomDashresourceDashexistingDashs3LambdaFunction',
+        'OtherCustomS31',
+      ],
       Properties: {
         ServiceToken: {
           'Fn::GetAtt': ['CustomDashresourceDashexistingDashs3LambdaFunction', 'Arn'],
@@ -1228,6 +1282,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
       DependsOn: [
         'PrefixSuffixWithCfFunctionLambdaFunction',
         'CustomDashresourceDashexistingDashs3LambdaFunction',
+        'WithIfCustomS31',
       ],
       Properties: {
         ServiceToken: {
@@ -1266,6 +1321,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
       naming.getLambdaLogicalId('provisionedExisting'),
       aliasLogicalId,
       naming.getCustomResourceS3HandlerFunctionLogicalId(),
+      naming.getCustomResourceS3ResourceLogicalId('prefixSuffixWithCfFunction'),
     ]);
     expect(resource.Properties).to.deep.include({
       FunctionName: serverlessInstance.service.getFunction('provisionedExisting').name,


### PR DESCRIPTION
Serializes existing S3 custom resources and existing Cognito user-pool custom resources at the service level. This avoids parallel read-modify-write updates when 4.x target migration cleanup writes to a previously configured bucket or user pool that is not visible in the new template.