### PR TITLE
Fail fast for conditional async destinations

### DIFF
--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -800,6 +800,8 @@ class AwsCompileFunctions {
       const hasAccessPoliciesHandledExternally = Boolean(executionRole);
 
       if (destinations.onSuccess) {
+        this.validateDestinationCondition(functionName, functionObject, destinations.onSuccess);
+
         destinationConfig.OnSuccess = {
           Destination: this.getDestinationsArn(destinations.onSuccess),
         };
@@ -810,6 +812,8 @@ class AwsCompileFunctions {
       }
 
       if (destinations.onFailure) {
+        this.validateDestinationCondition(functionName, functionObject, destinations.onFailure);
+
         destinationConfig.OnFailure = {
           Destination: this.getDestinationsArn(destinations.onFailure),
         };
@@ -853,6 +857,31 @@ class AwsCompileFunctions {
     }
 
     cfResources[this.provider.naming.getLambdaEventConfigLogicalId(functionName)] = resource;
+  }
+
+  validateDestinationCondition(functionName, functionObject, destinationsProperty) {
+    if (typeof destinationsProperty !== 'string' || destinationsProperty.startsWith('arn:')) {
+      return;
+    }
+
+    let targetFunctionObject;
+    try {
+      targetFunctionObject = this.serverless.service.getFunction(destinationsProperty);
+    } catch {
+      return;
+    }
+
+    if (
+      targetFunctionObject.condition &&
+      targetFunctionObject.condition !== functionObject.condition
+    ) {
+      throw new ServerlessError(
+        `Function "${functionName}" routes async destinations to conditional function ` +
+          `"${destinationsProperty}". Apply condition "${targetFunctionObject.condition}" ` +
+          `to "${functionName}" or remove the destination.`,
+        'EVENT_INVOKE_CONFIG_CONDITIONAL_DESTINATION'
+      );
+    }
   }
 
   getDestinationsArn(destinationsProperty) {

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1412,6 +1412,152 @@ describe('AwsCompileFunctions', () => {
       });
     });
   });
+
+  describe('#compileFunctionEventInvokeConfig()', () => {
+    function useFunctions(functions) {
+      awsCompileFunctions.serverless.service.provider.versionFunctions = false;
+      awsCompileFunctions.serverless.service.functions = Object.fromEntries(
+        Object.entries(functions).map(([name, config]) => [
+          name,
+          {
+            name,
+            handler: `${name}.handler`,
+            role: 'arn:aws:iam::123456789012:role/test-role',
+            ...config,
+          },
+        ])
+      );
+    }
+
+    function getEventInvokeConfig(functionName) {
+      return awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate
+        .Resources[awsProvider.naming.getLambdaEventConfigLogicalId(functionName)];
+    }
+
+    async function expectCompileError() {
+      try {
+        await awsCompileFunctions.compileFunctions();
+      } catch (error) {
+        return error;
+      }
+      throw new Error('Expected compileFunctions to reject');
+    }
+
+    it('should reject unconditioned source destinations to conditional functions', async () => {
+      useFunctions({
+        source: {
+          destinations: { onSuccess: 'target' },
+        },
+        target: {
+          condition: 'IsEnabled',
+        },
+      });
+
+      const error = await expectCompileError();
+
+      expect(error).to.have.property('code', 'EVENT_INVOKE_CONFIG_CONDITIONAL_DESTINATION');
+      expect(error.message).to.equal(
+        'Function "source" routes async destinations to conditional function "target". Apply condition "IsEnabled" to "source" or remove the destination.'
+      );
+    });
+
+    it('should reject onFailure destinations to conditional functions', async () => {
+      useFunctions({
+        source: {
+          destinations: { onFailure: 'target' },
+        },
+        target: {
+          condition: 'IsEnabled',
+        },
+      });
+
+      const error = await expectCompileError();
+
+      expect(error).to.have.property('code', 'EVENT_INVOKE_CONFIG_CONDITIONAL_DESTINATION');
+    });
+
+    it('should allow source and destination functions with the same condition', async () => {
+      useFunctions({
+        source: {
+          condition: 'IsEnabled',
+          destinations: { onSuccess: 'target' },
+        },
+        target: {
+          condition: 'IsEnabled',
+        },
+      });
+
+      await awsCompileFunctions.compileFunctions();
+
+      const eventInvokeConfig = getEventInvokeConfig('source');
+      expect(eventInvokeConfig.Condition).to.equal('IsEnabled');
+      expect(eventInvokeConfig.Properties.DestinationConfig).to.deep.equal({
+        OnSuccess: {
+          Destination: { 'Fn::GetAtt': [awsProvider.naming.getLambdaLogicalId('target'), 'Arn'] },
+        },
+      });
+    });
+
+    it('should allow conditional source functions to target unconditioned functions', async () => {
+      useFunctions({
+        source: {
+          condition: 'IsEnabled',
+          destinations: { onSuccess: 'target' },
+        },
+        target: {},
+      });
+
+      await awsCompileFunctions.compileFunctions();
+
+      expect(getEventInvokeConfig('source').Properties.DestinationConfig).to.deep.equal({
+        OnSuccess: {
+          Destination: { 'Fn::GetAtt': [awsProvider.naming.getLambdaLogicalId('target'), 'Arn'] },
+        },
+      });
+    });
+
+    it('should not validate ARN destination conditions', async () => {
+      const arn = 'arn:aws:lambda:us-east-1:123456789012:function:external';
+      useFunctions({
+        source: {
+          destinations: { onSuccess: arn },
+        },
+      });
+
+      await awsCompileFunctions.compileFunctions();
+
+      expect(getEventInvokeConfig('source').Properties.DestinationConfig).to.deep.equal({
+        OnSuccess: { Destination: arn },
+      });
+    });
+
+    it('should not validate object destination conditions', async () => {
+      const destination = { type: 'function', arn: { Ref: 'SomeFunctionArn' } };
+      useFunctions({
+        source: {
+          destinations: { onSuccess: destination },
+        },
+      });
+
+      await awsCompileFunctions.compileFunctions();
+
+      expect(getEventInvokeConfig('source').Properties.DestinationConfig).to.deep.equal({
+        OnSuccess: { Destination: destination.arn },
+      });
+    });
+
+    it('should preserve existing errors for unknown string destinations', async () => {
+      useFunctions({
+        source: {
+          destinations: { onSuccess: 'missingTarget' },
+        },
+      });
+
+      const error = await expectCompileError();
+
+      expect(error).to.have.property('code', 'FUNCTION_MISSING_IN_SERVICE');
+    });
+  });
 });
 
 describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {


### PR DESCRIPTION
Adds a compile-time guard for Lambda async destinations that target an in-service function with an incompatible condition. This prevents generating an EventInvokeConfig that CloudFormation can skip or fail when the destination function is conditioned out, while leaving ARN and object destinations unchanged.