### PR TITLE
Pin async destination condition mismatch

### DIFF
--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1476,6 +1476,25 @@ describe('AwsCompileFunctions', () => {
       expect(error).to.have.property('code', 'EVENT_INVOKE_CONFIG_CONDITIONAL_DESTINATION');
     });
 
+    it('should reject destinations to functions with different conditions', async () => {
+      useFunctions({
+        source: {
+          condition: 'IsSourceEnabled',
+          destinations: { onSuccess: 'target' },
+        },
+        target: {
+          condition: 'IsTargetEnabled',
+        },
+      });
+
+      const error = await expectCompileError();
+
+      expect(error).to.have.property('code', 'EVENT_INVOKE_CONFIG_CONDITIONAL_DESTINATION');
+      expect(error.message).to.equal(
+        'Function "source" routes async destinations to conditional function "target". Apply condition "IsTargetEnabled" to "source" or remove the destination.'
+      );
+    });
+
     it('should allow source and destination functions with the same condition', async () => {
       useFunctions({
         source: {


### PR DESCRIPTION
Adds a regression test that a source function with one condition cannot route async destinations to an in-service target function with a different condition. This pins the strict inequality behavior of the conditional async destination guard.