### PR TITLE
Constrain function name to the Lambda character set

### DIFF
--- a/lib/config-schema.js
+++ b/lib/config-schema.js
@@ -42,7 +42,7 @@ const schema = {
         [functionNamePattern]: {
           type: 'object',
           properties: {
-            name: { type: 'string' }, // name property is added by service class
+            name: { type: 'string', pattern: functionNamePattern }, // name property is added by service class
             events: {
               type: 'array',
               items: {

--- a/test/unit/lib/classes/config-schema-handler/index.test.js
+++ b/test/unit/lib/classes/config-schema-handler/index.test.js
@@ -80,6 +80,43 @@ describe('test/unit/lib/classes/ConfigSchemaHandler/index.test.js', () => {
       expect(getConfigurationValidationResult(serverless.configurationInput)).to.be.true;
     });
 
+    it('should reject an explicit function name containing CloudFormation substitution syntax', async () => {
+      const serverless = new Serverless({ commands: [], options: {} });
+      const userConfig = {
+        service: 'service',
+        frameworkVersion: '*',
+        provider: { name: 'aws' },
+        functions: { fn: { name: 'fn-${AWS::AccountId}' } },
+      };
+      serverless.configurationInput = userConfig;
+      serverless.service.configValidationMode = 'error';
+
+      await expect(
+        serverless.configSchemaHandler.validateConfig(userConfig)
+      ).to.eventually.be.rejected.and.have.property(
+        'code',
+        'INVALID_NON_SCHEMA_COMPLIANT_CONFIGURATION'
+      );
+    });
+
+    it('should accept explicit function names within the Lambda character set, including long ones', async () => {
+      const serverless = new Serverless({ commands: [], options: {} });
+      const userConfig = {
+        service: 'service',
+        frameworkVersion: '*',
+        provider: { name: 'aws' },
+        functions: {
+          explicitName: { name: 'my-Function_1' },
+          longGeneratedShape: { name: 'a'.repeat(68) },
+        },
+      };
+      serverless.configurationInput = userConfig;
+      serverless.service.configValidationMode = 'error';
+
+      await expect(serverless.configSchemaHandler.validateConfig(userConfig)).to.eventually.be
+        .fulfilled;
+    });
+
     it('restores safe null paths and skips unsafe null paths without mutating prototypes', async () => {
       const serverless = new Serverless({ commands: [], options: {} });
       const userConfig = JSON.parse(

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1564,6 +1564,25 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
       );
     });
 
+    it('should reject `functions[].name` values outside the Lambda character set', () => {
+      return expect(
+        runServerless({
+          fixture: 'function',
+          command: 'package',
+          configExt: {
+            functions: {
+              basic: {
+                name: 'my.dotted.name',
+              },
+            },
+          },
+        })
+      ).to.eventually.be.rejected.and.have.property(
+        'code',
+        'INVALID_NON_SCHEMA_COMPLIANT_CONFIGURATION'
+      );
+    });
+
     it('should support `provider.runtimeManagement`', () => {
       const providerConfig = serviceConfig.provider;
 


### PR DESCRIPTION
This constrains explicit function names to the existing Lambda function name character set. Invalid names now fail during configuration validation while long generated-shape names remain allowed without a new length limit.