### PR TITLE
Align function name schema tests with the 4.x harness

### DIFF
--- a/test/unit/lib/classes/config-schema-handler/index.test.js
+++ b/test/unit/lib/classes/config-schema-handler/index.test.js
@@ -86,18 +86,15 @@ describe('test/unit/lib/classes/ConfigSchemaHandler/index.test.js', () => {
     });
 
     it('should reject an explicit function name containing CloudFormation substitution syntax', async () => {
-      const serverless = new Serverless({ commands: [], options: {} });
       const userConfig = {
         service: 'service',
         frameworkVersion: '*',
         provider: { name: 'aws' },
         functions: { fn: { name: 'fn-${AWS::AccountId}' } },
       };
-      serverless.configurationInput = userConfig;
-      serverless.service.configValidationMode = 'error';
 
       await expect(
-        serverless.configSchemaHandler.validateConfig(userConfig)
+        createConfigSchemaHandler(userConfig).validateConfig(userConfig)
       ).to.eventually.be.rejected.and.have.property(
         'code',
         'INVALID_NON_SCHEMA_COMPLIANT_CONFIGURATION'
@@ -105,7 +102,6 @@ describe('test/unit/lib/classes/ConfigSchemaHandler/index.test.js', () => {
     });
 
     it('should accept explicit function names within the Lambda character set, including long ones', async () => {
-      const serverless = new Serverless({ commands: [], options: {} });
       const userConfig = {
         service: 'service',
         frameworkVersion: '*',
@@ -115,11 +111,9 @@ describe('test/unit/lib/classes/ConfigSchemaHandler/index.test.js', () => {
           longGeneratedShape: { name: 'a'.repeat(68) },
         },
       };
-      serverless.configurationInput = userConfig;
-      serverless.service.configValidationMode = 'error';
 
-      await expect(serverless.configSchemaHandler.validateConfig(userConfig)).to.eventually.be
-        .fulfilled;
+      await expect(createConfigSchemaHandler(userConfig).validateConfig(userConfig)).to.eventually
+        .be.fulfilled;
     });
 
     it('restores safe null paths and skips unsafe null paths without mutating prototypes', async () => {


### PR DESCRIPTION
This updates the function name schema validation tests to use the 4.x config schema handler harness.