### PR TITLE
Pin alias targeting for new buckets and pools

### DIFF
--- a/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
@@ -1198,6 +1198,35 @@ describe('lib/plugins/aws/package/compile/events/cognito-user-pool.test.js', () 
       });
     });
 
+    it('should target a generated alias for new pools when targetAlias is set', async () => {
+      const { cfTemplate, awsNaming } = await runServerless({
+        fixture: 'function',
+        configExt: {
+          functions: {
+            basic: {
+              provisionedConcurrency: 1,
+              events: [{ cognitoUserPool: { pool: 'NewPool', trigger: 'PreSignUp' } }],
+            },
+          },
+        },
+        command: 'package',
+      });
+
+      const aliasLogicalId = awsNaming.getLambdaProvisionedConcurrencyAliasLogicalId('basic');
+      const poolResource = cfTemplate.Resources[awsNaming.getCognitoUserPoolLogicalId('NewPool')];
+
+      expect(poolResource.DependsOn).to.include(aliasLogicalId);
+      expect(poolResource.Properties.LambdaConfig.PreSignUp).to.deep.equal({
+        'Fn::Join': [
+          ':',
+          [
+            { 'Fn::GetAtt': [awsNaming.getLambdaLogicalId('basic'), 'Arn'] },
+            awsNaming.getLambdaProvisionedConcurrencyAliasName(),
+          ],
+        ],
+      });
+    });
+
     it('should merge generated Cognito user pool resources with custom resources', () => {
       const serviceName = serverlessInstance.service.service;
       const poolResource = cfResources[naming.getCognitoUserPoolLogicalId('CUP CustomEmailSender')];

--- a/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -1330,6 +1330,44 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
     });
   });
 
+  it('should target a generated alias for new buckets when targetAlias is set', async () => {
+    const { cfTemplate, awsNaming } = await runServerless({
+      fixture: 'function',
+      configExt: {
+        functions: {
+          basic: {
+            provisionedConcurrency: 1,
+            events: [{ s3: { bucket: 'provisioned-new-bucket', event: 's3:ObjectCreated:*' } }],
+          },
+        },
+      },
+      command: 'package',
+    });
+
+    const aliasLogicalId = awsNaming.getLambdaProvisionedConcurrencyAliasLogicalId('basic');
+    const bucketResource =
+      cfTemplate.Resources[awsNaming.getBucketLogicalId('provisioned-new-bucket')];
+
+    expect(bucketResource.DependsOn).to.include(aliasLogicalId);
+    expect(
+      bucketResource.Properties.NotificationConfiguration.LambdaConfigurations[0].Function
+    ).to.deep.equal({
+      'Fn::Join': [
+        ':',
+        [
+          { 'Fn::GetAtt': [awsNaming.getLambdaLogicalId('basic'), 'Arn'] },
+          awsNaming.getLambdaProvisionedConcurrencyAliasName(),
+        ],
+      ],
+    });
+
+    const permissionResource =
+      cfTemplate.Resources[
+        awsNaming.getLambdaS3PermissionLogicalId('basic', 'provisioned-new-bucket')
+      ];
+    expect(permissionResource.DependsOn).to.equal(aliasLogicalId);
+  });
+
   it('should disallow referencing multiple buckets in context of single function with CF references', async () => {
     await expect(
       runServerless({


### PR DESCRIPTION
This adds coverage for target alias resolution on newly created S3 buckets and Cognito user pools. The tests verify generated resources route through the provisioned concurrency alias when one is configured.