### PR TITLE
Remove dayjs

### DIFF
--- a/docs/cli-reference/logs.md
+++ b/docs/cli-reference/logs.md
@@ -16,29 +16,32 @@ This command returns as many log events as can fit in 1MB (up to 10,000 log even
 - `--function` or `-f` The function you want to fetch the logs for. **Required**
 - `--stage` or `-s` The stage you want to view the function logs for. If not provided, the plugin will use the default stage listed in `serverless.yml`. If that doesn't exist either it'll just fetch the logs from the `dev` stage.
 - `--region` or `-r` The region you want to view the function logs for. If not provided, the plugin will use the default region listed in `serverless.yml`. If that doesn't exist either it'll just fetch the logs from the `us-east-1` region.
-- `--startTime` A specific unit in time to start fetching logs from (ie: `2010-10-20` or `1469705761`). Here's a list of the supported string formats:
+- `--startTime` A specific unit in time to start fetching logs from (ie: `2010-10-20` or `1469694264`). Here's a list of the supported string formats:
 
 ```bash
-30m                   # since 30 minutes ago
-2h                    # since 2 hours ago
-3d                    # since 3 days ago
+30s                        # since 30 seconds ago
+30m                        # since 30 minutes ago
+2h                         # since 2 hours ago
+3d                         # since 3 days ago
 
-2013-02-08            # A calendar date part
-2013-W06-5            # A week date part
-2013-039              # An ordinal date part
+2013-02-08                 # A calendar date
+2013-02-08T09              # An hour time part separated by a T
+2013-02-08T09:30           # An hour and minute time part
+2013-02-08T09:30:26        # An hour, minute and second time part
+2013-02-08T09:30:26.123    # With fractional seconds
+2013-02-08T09:30:26+07:00  # With an explicit UTC offset
 
-20130208              # Basic (short) full date
-2013W065              # Basic (short) week, weekday
-2013W06               # Basic (short) week only
-2013050               # Basic (short) ordinal date
+20130208                   # Basic (short) full date
+20130208T08                # Short date and time, hours only
+20130208T0809              # Short date and time up to minutes
+20130208T080910            # Short date and time up to seconds
+20130208T080910.123        # Short date and time up to ms
 
-2013-02-08T09         # An hour time part separated by a T
-20130208T080910,123   # Short date and time up to ms, separated by comma
-20130208T080910.123   # Short date and time up to ms
-20130208T080910       # Short date and time up to seconds
-20130208T0809         # Short date and time up to minutes
-20130208T08           # Short date and time, hours only
+1469694264                 # Unix epoch time in seconds
+1469694264000              # Unix epoch time in milliseconds
 ```
+
+Dates and times without an explicit UTC offset are interpreted as UTC.
 
 - `--filter` You can specify a filter string to filter the log output. This is useful if you want to to get the `error` logs for example.
 - `--tail` or `-t` You can optionally tail the logs and keep listening for new logs in your terminal session by passing this option.

--- a/docs/cli-reference/metrics.md
+++ b/docs/cli-reference/metrics.md
@@ -11,8 +11,8 @@ serverless metrics
 - `--function` or `-f` The function you want to fetch the metrics for.
 - `--stage` or `-s` The stage you want to view the function metrics for. If not provided, the plugin will use the default stage listed in `serverless.yml`. If that doesn't exist either it'll just fetch the metrics from the `dev` stage.
 - `--region` or `-r` The region you want to view the function metrics for. If not provided, the plugin will use the default region listed in `serverless.yml`. If that doesn't exist either it'll just fetch the metrics from the `us-east-1` region.
-- `--startTime` A specific unit in time to start fetching metrics from (ie: `2010-10-20`, `1469705761`, `30m` (30 minutes ago), `2h` (2 hours ago) or `3d` (3 days ago)). Date formats should be written in ISO 8601. Defaults to 24h ago.
-- `--endTime` A specific unit in time to end fetching metrics from (ie: `2010-10-21` or `1469705761`). Date formats should be written in ISO 8601. Defaults to now.
+- `--startTime` A specific unit in time to start fetching metrics from (ie: `2010-10-20`, `1469705761`, `30m` (30 minutes ago), `2h` (2 hours ago) or `3d` (3 days ago)). Accepts the same formats as [`serverless logs --startTime`](./logs.md): relative time, ISO 8601 dates and datetimes (interpreted as UTC unless an explicit offset is given), or Unix epoch time in seconds or milliseconds. Defaults to 24h ago.
+- `--endTime` A specific unit in time to end fetching metrics from (ie: `2010-10-21` or `1469705761`). Accepts the same formats as `--startTime`. Defaults to now.
 
 ## Examples
 

--- a/docs/guides/upgrading-to-v4.md
+++ b/docs/guides/upgrading-to-v4.md
@@ -132,6 +132,17 @@ events:
 
 See [Alexa Skill](../events/alexa-skill.md).
 
+### `logs` and `metrics` time options are parsed strictly
+
+The `--startTime` option of `serverless logs` and the `--startTime` / `--endTime` options of `serverless metrics` are now parsed by a single strict parser:
+
+- Unix epoch values (e.g. `1469694264`) now work in both commands; they were documented but broken (in `logs` they silently produced a wrong time range, in `metrics` they failed). Digits-only values of 9+ characters are parsed as epoch seconds, or as epoch milliseconds when at or above `10^12` (13+ characters).
+- Dates and datetimes without an explicit UTC offset are now consistently interpreted as **UTC** in both commands. Previously `metrics` interpreted datetimes (e.g. `2016-07-01T10:00`) in the machine's local time zone.
+- Malformed values now fail with an `INVALID_TIME_INPUT` error instead of being silently misparsed. For example, `--startTime 1h30m` previously subtracted 130 _milliseconds_, and ISO week dates (`2013-W06-5`) and ordinal dates (`2013-039`) produced wrong time ranges. Week and ordinal dates are no longer supported.
+- Relative values now also accept seconds (e.g. `30s`), and `metrics --endTime` accepts relative values too.
+
+See [logs](../cli-reference/logs.md) and [metrics](../cli-reference/metrics.md) for the supported formats. As part of this change, osls no longer depends on the [`dayjs`](https://www.npmjs.com/package/dayjs) package; plugins that relied on it being installed alongside osls should declare it in their own dependencies.
+
 ### Plugin custom variables: `configurationVariablesSources` only
 
 Plugins that extend variable resolution via the old `variableResolvers` API will fail with `OLD_VARIABLE_RESOLVER_NOT_SUPPORTED`. Migrate to `configurationVariablesSources`.

--- a/lib/plugins/aws/logs.js
+++ b/lib/plugins/aws/logs.js
@@ -1,19 +1,16 @@
 'use strict';
 
-const dayjs = require('dayjs');
-const utc = require('dayjs/plugin/utc');
 const wait = require('../../utils/sleep');
 const { writeText } = require('../../utils/serverless-utils/log');
 const validate = require('./lib/validate');
 const formatLambdaLogEvent = require('./utils/format-lambda-log-event');
+const { parseTimeInput, subtractTime } = require('./utils/time');
 const ServerlessError = require('../../serverless-error');
 const {
   CloudWatchLogsClient,
   DescribeLogStreamsCommand,
   FilterLogEventsCommand,
 } = require('@aws-sdk/client-cloudwatch-logs');
-
-dayjs.extend(utc);
 
 class AwsLogs {
   constructor(serverless, options) {
@@ -79,29 +76,14 @@ class AwsLogs {
       logGroupName: this.options.logGroupName,
       interleaved: true,
       logStreamNames,
-      startTime: this.options.startTime,
     };
 
     if (this.options.filter) params.filterPattern = this.options.filter;
     if (this.options.nextToken) params.nextToken = this.options.nextToken;
     if (this.options.startTime) {
-      const since =
-        ['m', 'h', 'd'].indexOf(this.options.startTime[this.options.startTime.length - 1]) !== -1;
-      if (since) {
-        params.startTime = dayjs()
-          .subtract(
-            this.options.startTime.replace(/\D/g, ''),
-            this.options.startTime.replace(/\d/g, '')
-          )
-          .valueOf();
-      } else {
-        params.startTime = dayjs.utc(this.options.startTime).valueOf();
-      }
+      params.startTime = parseTimeInput(this.options.startTime, '--startTime');
     } else {
-      params.startTime = dayjs().subtract(10, 'm').valueOf();
-      if (this.options.tail) {
-        params.startTime = dayjs().subtract(10, 's').valueOf();
-      }
+      params.startTime = subtractTime(new Date(), 10, this.options.tail ? 's' : 'm').getTime();
     }
 
     const cloudWatchLogs = await this.getCloudWatchLogsClient();

--- a/lib/plugins/aws/metrics.js
+++ b/lib/plugins/aws/metrics.js
@@ -1,14 +1,10 @@
 'use strict';
 
 const promiseLimit = require('ext/promise/limit').bind(Promise);
-const dayjs = require('dayjs');
 const validate = require('./lib/validate');
 const { writeText, style } = require('../../utils/serverless-utils/log');
+const { parseTimeInput, subtractTime, formatDisplayTime } = require('./utils/time');
 const { CloudWatchClient, GetMetricStatisticsCommand } = require('@aws-sdk/client-cloudwatch');
-
-const LocalizedFormat = require('dayjs/plugin/localizedFormat');
-
-dayjs.extend(LocalizedFormat);
 
 function getCloudWatchClient(context) {
   context.cloudWatchClientPromise ||= context.provider
@@ -38,19 +34,12 @@ class AwsMetrics {
   extendedValidate() {
     this.validate();
 
-    const today = new Date();
-    const yesterday = dayjs().subtract(1, 'day').toDate();
-
-    if (this.options.startTime) {
-      const sinceDateMatch = this.options.startTime.match(/(\d+)(m|h|d)/);
-      if (sinceDateMatch) {
-        this.options.startTime = dayjs().subtract(sinceDateMatch[1], sinceDateMatch[2]).valueOf();
-      }
-    }
-
-    // finally create a new date object
-    this.options.startTime = new Date(this.options.startTime || yesterday);
-    this.options.endTime = new Date(this.options.endTime || today);
+    this.options.startTime = this.options.startTime
+      ? new Date(parseTimeInput(this.options.startTime, '--startTime'))
+      : subtractTime(new Date(), 1, 'd');
+    this.options.endTime = this.options.endTime
+      ? new Date(parseTimeInput(this.options.endTime, '--endTime'))
+      : new Date();
   }
 
   async getMetrics() {
@@ -118,8 +107,8 @@ class AwsMetrics {
       modernMessageTokens.push('Service wide metrics');
     }
 
-    const formattedStartTime = dayjs(this.options.startTime).format('LLL');
-    const formattedEndTime = dayjs(this.options.endTime).format('LLL');
+    const formattedStartTime = formatDisplayTime(this.options.startTime);
+    const formattedEndTime = formatDisplayTime(this.options.endTime);
     modernMessageTokens.push(`${formattedStartTime} - ${formattedEndTime}\n`);
 
     if (metrics && metrics.length > 0) {

--- a/lib/plugins/aws/utils/format-lambda-log-event.js
+++ b/lib/plugins/aws/utils/format-lambda-log-event.js
@@ -1,11 +1,10 @@
 'use strict';
 
-const dayjs = require('dayjs');
 const { style } = require('../../../utils/serverless-utils/log');
+const { formatLogTimestamp } = require('./time');
 
 module.exports = (msgParam) => {
   let msg = msgParam;
-  const dateFormat = 'YYYY-MM-DD HH:mm:ss.SSS';
 
   if (!msg.startsWith('REPORT')) msg = msg.trimRight();
 
@@ -52,7 +51,7 @@ module.exports = (msgParam) => {
     return msg;
   }
   const text = msg.split(`${reqId}\t`)[1];
-  const time = dayjs(date).format(dateFormat);
+  const time = formatLogTimestamp(date);
 
   return `${style.aside(`${time}\t`)}${level}${text}`;
 };

--- a/lib/plugins/aws/utils/time.js
+++ b/lib/plugins/aws/utils/time.js
@@ -1,0 +1,154 @@
+'use strict';
+
+const ServerlessError = require('../../../serverless-error');
+
+const UNIT_IN_MS = {
+  s: 1000,
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+};
+
+const RELATIVE_TIME_PATTERN = /^(\d+)(s|m|h|d)$/;
+
+// ISO 8601 date or datetime without a UTC offset designator, in extended
+// (2013-02-08T09:30:26.123) or basic (20130208T093026.123) form. Values with
+// an explicit offset (e.g. a trailing "Z" or "+07:00") fall through to native
+// `Date.parse`.
+const EXTENDED_DATE_TIME_PATTERN =
+  /^(\d{4})-(\d{1,2})-(\d{1,2})(?:[Tt ](\d{1,2})(?::(\d{1,2})(?::(\d{1,2})(?:[.,](\d+))?)?)?)?$/;
+const BASIC_DATE_TIME_PATTERN =
+  /^(\d{4})(\d{2})(\d{2})[Tt](\d{2})(?:(\d{2})(?:(\d{2})(?:[.,](\d+))?)?)?$/;
+
+const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+const pad = (number, width = 2) => String(number).padStart(width, '0');
+
+const utcMsFromParts = (year, month, day, hour, minute, second, fraction) => {
+  const [numericYear, numericMonth, numericDay, numericHour, numericMinute, numericSecond] = [
+    year,
+    month,
+    day,
+    hour || 0,
+    minute || 0,
+    second || 0,
+  ].map(Number);
+  if (
+    numericMonth < 1 ||
+    numericMonth > 12 ||
+    numericDay < 1 ||
+    numericDay > 31 ||
+    numericHour > 23 ||
+    numericMinute > 59 ||
+    numericSecond > 59
+  ) {
+    return NaN;
+  }
+  const milliseconds = fraction == null ? 0 : Number(fraction.slice(0, 3).padEnd(3, '0'));
+  return Date.UTC(
+    numericYear,
+    numericMonth - 1,
+    numericDay,
+    numericHour,
+    numericMinute,
+    numericSecond,
+    milliseconds
+  );
+};
+
+const parseUtcMs = (input) => {
+  if (/^\d+$/.test(input)) {
+    if (input.length === 4) return Date.UTC(Number(input), 0, 1);
+    if (input.length === 8)
+      return utcMsFromParts(input.slice(0, 4), input.slice(4, 6), input.slice(6, 8));
+    if (input.length >= 9) {
+      const epoch = Number(input);
+      // Values below 10^12 are epoch seconds (covers dates up to the year
+      // 33658), larger values are epoch milliseconds
+      return epoch < 1e12 ? epoch * 1000 : epoch;
+    }
+    return NaN;
+  }
+  const match = input.match(EXTENDED_DATE_TIME_PATTERN) || input.match(BASIC_DATE_TIME_PATTERN);
+  if (match) return utcMsFromParts(...match.slice(1, 8));
+  // A signed integer is a mistyped epoch or relative value, but native
+  // parsing would accept it as a year (V8 parses "-3600" as the year 3600)
+  if (/^[+-]\d+$/.test(input)) return NaN;
+  return Date.parse(input);
+};
+
+// Subtracting days is calendar-aware (the result keeps the local clock time
+// across DST changes); other units are fixed durations
+const subtractTime = (date, amount, unit) => {
+  if (unit === 'd') {
+    const result = new Date(date);
+    result.setDate(result.getDate() - amount);
+    return result;
+  }
+  return new Date(date.getTime() - amount * UNIT_IN_MS[unit]);
+};
+
+// Parses a user-provided time option into epoch milliseconds. Relative values
+// (e.g. "30m") are resolved against the current time, dates and datetimes
+// without an explicit UTC offset are interpreted as UTC, and digits-only
+// values of 9+ characters are treated as Unix epoch time. Numbers pass
+// through unchanged (they are already epoch milliseconds).
+const parseTimeInput = (value, optionName) => {
+  if (typeof value === 'number') return value;
+
+  const input = String(value).trim();
+  const relativeMatch = input.match(RELATIVE_TIME_PATTERN);
+  if (relativeMatch) {
+    return subtractTime(new Date(), Number(relativeMatch[1]), relativeMatch[2]).getTime();
+  }
+
+  const utcMs = parseUtcMs(input);
+  // 8.64e15 is the JavaScript Date range limit; larger values would
+  // construct Invalid Dates downstream
+  if (!Number.isNaN(utcMs) && Math.abs(utcMs) <= 8.64e15) return utcMs;
+
+  throw new ServerlessError(
+    `Invalid "${optionName}" value: "${value}". Supported formats: ` +
+      'relative time ("30s", "30m", "2h" or "3d"), ' +
+      'ISO 8601 date or datetime interpreted as UTC unless an offset is given ' +
+      '("2013-02-08", "2013-02-08T09:30:26.123" or "2013-02-08T09:30:26+07:00"), ' +
+      'or Unix epoch time in seconds or milliseconds ("1469694264")',
+    'INVALID_TIME_INPUT'
+  );
+};
+
+// Local time in "YYYY-MM-DD HH:mm:ss.SSS" format
+const formatLogTimestamp = (value) => {
+  const date = new Date(value);
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ` +
+    `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}.` +
+    `${pad(date.getMilliseconds(), 3)}`
+  );
+};
+
+// Local time in "January 1, 1970 1:00 AM" format
+const formatDisplayTime = (value) => {
+  const date = new Date(value);
+  const hours = date.getHours();
+  const hour = hours % 12 || 12;
+  const meridiem = hours < 12 ? 'AM' : 'PM';
+  return (
+    `${MONTH_NAMES[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()} ` +
+    `${hour}:${pad(date.getMinutes())} ${meridiem}`
+  );
+};
+
+module.exports = { parseTimeInput, subtractTime, formatLogTimestamp, formatDisplayTime };

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "cachedir": "^2.3.0",
     "content-disposition": "^2.0.1",
     "cross-spawn": "^7.0.6",
-    "dayjs": "^1.11.8",
     "dotenv": "^17.4.2",
     "dotenv-expand": "^13.0.0",
     "ext": "^1.7.0",

--- a/test/unit/lib/plugins/aws/logs.test.js
+++ b/test/unit/lib/plugins/aws/logs.test.js
@@ -294,6 +294,59 @@ describe('AwsLogs', () => {
       });
     });
 
+    it('should call filterLogEvents API with epoch start time', async () => {
+      const logStreamNamesMock = ['2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba'];
+      const filterLogEventsStub = sinon
+        .stub(CloudWatchLogsClient.prototype, 'send')
+        .resolves({ events: [] });
+      awsLogs.serverless.service.service = 'new-service';
+      awsLogs.options = {
+        stage: 'dev',
+        region: 'us-east-1',
+        function: 'first',
+        logGroupName: awsLogs.provider.naming.getLogGroupName('new-service-dev-first'),
+        startTime: '1469694264', // epoch seconds
+      };
+
+      await awsLogs.showLogs(logStreamNamesMock);
+
+      expect(filterLogEventsStub.firstCall.args[0].input.startTime).to.equal(1469694264000);
+    });
+
+    it('should call filterLogEvents API with epoch milliseconds start time', async () => {
+      const logStreamNamesMock = ['2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba'];
+      const filterLogEventsStub = sinon
+        .stub(CloudWatchLogsClient.prototype, 'send')
+        .resolves({ events: [] });
+      awsLogs.serverless.service.service = 'new-service';
+      awsLogs.options = {
+        stage: 'dev',
+        region: 'us-east-1',
+        function: 'first',
+        logGroupName: awsLogs.provider.naming.getLogGroupName('new-service-dev-first'),
+        startTime: '1469694264000',
+      };
+
+      await awsLogs.showLogs(logStreamNamesMock);
+
+      expect(filterLogEventsStub.firstCall.args[0].input.startTime).to.equal(1469694264000);
+    });
+
+    it('should throw on a malformed start time', async () => {
+      awsLogs.serverless.service.service = 'new-service';
+      awsLogs.options = {
+        stage: 'dev',
+        region: 'us-east-1',
+        function: 'first',
+        logGroupName: awsLogs.provider.naming.getLogGroupName('new-service-dev-first'),
+        startTime: '1h30m',
+      };
+
+      await expect(
+        awsLogs.showLogs(['2016/07/28/[$LATEST]83f5206ab2a8488290349b9c1fbfe2ba'])
+      ).to.eventually.be.rejected.and.have.property('code', 'INVALID_TIME_INPUT');
+    });
+
     it('should call filterLogEvents API with latest 10 minutes if startTime not given', async () => {
       const replyMock = {
         events: [
@@ -395,6 +448,51 @@ describe('AwsLogs', () => {
         logStreamNames: logStreamNamesMock,
         startTime: fakeTime - 10 * 1000, // fakeTime - 10 seconds
       });
+    });
+
+    it('should poll from the last event timestamp + 1 when tailing', async () => {
+      const lastEventTimestamp = 1469687512311;
+      const stopError = new Error('stop tail loop');
+      const sleepStub = sinon.stub().onFirstCall().resolves().onSecondCall().rejects(stopError);
+      const MockedAwsLogs = proxyquire('../../../../../lib/plugins/aws/logs', {
+        '../../utils/sleep': sleepStub,
+      });
+
+      const options = {
+        stage: 'dev',
+        region: 'us-east-1',
+        function: 'first',
+      };
+      const { serverless: mockedServerless } = createServerlessContext(options);
+      const mockedAwsLogs = new MockedAwsLogs(mockedServerless, options);
+
+      const sendStub = sinon
+        .stub(CloudWatchLogsClient.prototype, 'send')
+        .callsFake(async (command) => {
+          if (command instanceof DescribeLogStreamsCommand) {
+            return { logStreams: [{ logStreamName: 'stream' }] };
+          }
+          return {
+            events: [{ logStreamName: 'stream', timestamp: lastEventTimestamp, message: 'test' }],
+          };
+        });
+      mockedAwsLogs.serverless.service.service = 'new-service';
+      mockedAwsLogs.options = {
+        stage: 'dev',
+        region: 'us-east-1',
+        function: 'first',
+        logGroupName: awsLogs.provider.naming.getLogGroupName('new-service-dev-first'),
+        tail: true,
+      };
+
+      await expect(mockedAwsLogs.showLogs(['stream'])).to.be.rejectedWith(stopError);
+
+      const filterCalls = sendStub
+        .getCalls()
+        .filter((call) => call.args[0] instanceof FilterLogEventsCommand);
+      expect(filterCalls).to.have.length(2);
+      expect(filterCalls[0].args[0].input.startTime).to.equal(fakeTime - 10 * 1000);
+      expect(filterCalls[1].args[0].input.startTime).to.equal(lastEventTimestamp + 1);
     });
 
     it('reuses one CloudWatch Logs client across tail polling', async () => {

--- a/test/unit/lib/plugins/aws/metrics.test.js
+++ b/test/unit/lib/plugins/aws/metrics.test.js
@@ -5,13 +5,13 @@ const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const AwsMetrics = require('../../../../../lib/plugins/aws/metrics');
 const ServerlessError = require('../../../../../lib/serverless-error');
-const dayjs = require('dayjs');
 const { CloudWatchClient, GetMetricStatisticsCommand } = require('@aws-sdk/client-cloudwatch');
 const releasePendingRequestsUntilSettled = require('../../../../utils/release-pending-requests-until-settled');
 
-const LocalizedFormat = require('dayjs/plugin/localizedFormat');
+const { formatDisplayTime } = require('../../../../../lib/plugins/aws/utils/time');
 
-dayjs.extend(LocalizedFormat);
+const toLocalDateString = (date) =>
+  `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
 
 function createServerlessContext(options) {
   const provider = {
@@ -129,9 +129,7 @@ describe('AwsMetrics', () => {
 
       awsMetrics.extendedValidate();
 
-      const defaultsStartTime = dayjs(awsMetrics.options.startTime);
-      const defaultsDate = defaultsStartTime.format('YYYY-M-D');
-      expect(defaultsDate).to.equal(yesterdaysDate);
+      expect(toLocalDateString(awsMetrics.options.startTime)).to.equal(yesterdaysDate);
     });
 
     it('should set the startTime to the provided value', () => {
@@ -157,9 +155,7 @@ describe('AwsMetrics', () => {
 
       awsMetrics.extendedValidate();
 
-      const translatedStartTime = dayjs(awsMetrics.options.startTime);
-      const translatedDate = translatedStartTime.format('YYYY-M-D');
-      expect(translatedDate).to.equal(yesterdaysDate);
+      expect(toLocalDateString(awsMetrics.options.startTime)).to.equal(yesterdaysDate);
     });
 
     it('should translate minute-based human friendly syntax for startTime', () => {
@@ -181,10 +177,7 @@ describe('AwsMetrics', () => {
 
       awsMetrics.extendedValidate();
 
-      const defaultsStartTime = dayjs(awsMetrics.options.endTime);
-      const defaultsDate = defaultsStartTime.format('YYYY-M-D');
-
-      expect(defaultsDate).to.equal(todaysDate);
+      expect(toLocalDateString(awsMetrics.options.endTime)).to.equal(todaysDate);
     });
 
     it('should set the endTime to the provided value', () => {
@@ -195,6 +188,47 @@ describe('AwsMetrics', () => {
       const endTime = awsMetrics.options.endTime.toISOString();
       const expectedEndTime = new Date('1970-01-01').toISOString();
       expect(endTime).to.equal(expectedEndTime);
+    });
+
+    it('should support epoch seconds for startTime', () => {
+      awsMetrics.options.startTime = '1469705761';
+
+      awsMetrics.extendedValidate();
+
+      expect(awsMetrics.options.startTime.getTime()).to.equal(1469705761000);
+    });
+
+    it('should support epoch milliseconds for endTime', () => {
+      awsMetrics.options.endTime = '1469705761000';
+
+      awsMetrics.extendedValidate();
+
+      expect(awsMetrics.options.endTime.getTime()).to.equal(1469705761000);
+    });
+
+    it('should interpret datetimes without an offset as UTC', () => {
+      awsMetrics.options.startTime = '2016-07-01T10:00';
+
+      awsMetrics.extendedValidate();
+
+      expect(awsMetrics.options.startTime.getTime()).to.equal(Date.UTC(2016, 6, 1, 10));
+    });
+
+    it('should translate human friendly syntax for endTime', () => {
+      awsMetrics.options.endTime = '1h';
+
+      awsMetrics.extendedValidate();
+
+      const expectedEndTime = Date.now() - 60 * 60 * 1000;
+      expect(awsMetrics.options.endTime.getTime()).to.be.closeTo(expectedEndTime, 5000);
+    });
+
+    it('should throw on a malformed startTime', () => {
+      awsMetrics.options.startTime = '1h30m';
+
+      expect(() => awsMetrics.extendedValidate())
+        .to.throw(ServerlessError)
+        .with.property('code', 'INVALID_TIME_INPUT');
     });
   });
 
@@ -520,6 +554,10 @@ describe('AwsMetrics', () => {
       ]);
 
       expect(writeTextStub).to.have.been.calledOnce;
+      expect(writeTextStub.firstCall.args[0]).to.include(
+        `${formatDisplayTime(proxiedMetrics.options.startTime)} - ` +
+          `${formatDisplayTime(proxiedMetrics.options.endTime)}\n`
+      );
       expect(writeTextStub.firstCall.args[0]).to.include('invocations: 9');
       expect(writeTextStub.firstCall.args[0]).to.include('throttles: 1');
       expect(writeTextStub.firstCall.args[0]).to.include('errors: 1');

--- a/test/unit/lib/plugins/aws/utils/format-lambda-log-event.test.js
+++ b/test/unit/lib/plugins/aws/utils/format-lambda-log-event.test.js
@@ -1,9 +1,20 @@
 'use strict';
 
 const expect = require('chai').expect;
-const dayjs = require('dayjs');
 const { style } = require('../../../../../../lib/utils/serverless-utils/log');
 const formatLambdaLogEvent = require('../../../../../../lib/plugins/aws/utils/format-lambda-log-event');
+
+// Log timestamps are printed in local time, so expectations are computed from
+// the local clock to stay independent of the machine's time zone
+const localTimestamp = (value) => {
+  const pad = (number, width = 2) => String(number).padStart(width, '0');
+  const date = new Date(value);
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ` +
+    `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}.` +
+    `${pad(date.getMilliseconds(), 3)}`
+  );
+};
 
 describe('#formatLambdaLogEvent()', () => {
   it('should format invocation report', () => {
@@ -23,7 +34,7 @@ describe('#formatLambdaLogEvent()', () => {
     const nodeLogLine = '2016-01-01T12:00:00Z\t99c30000-b01a-11e5-93f7-b8e85631a00e\tINFO\ttest';
 
     let expectedLogMessage = '';
-    const date = dayjs('2016-01-01T12:00:00Z').format('YYYY-MM-DD HH:mm:ss.SSS');
+    const date = localTimestamp('2016-01-01T12:00:00Z');
     expectedLogMessage += `${style.aside(date)}\t`;
     expectedLogMessage += 'INFO\t';
     expectedLogMessage += 'test';
@@ -36,12 +47,22 @@ describe('#formatLambdaLogEvent()', () => {
       '[INFO]\t2016-01-01T12:00:00Z\t99c30000-b01a-11e5-93f7-b8e85631a00e\ttest';
 
     let expectedLogMessage = '';
-    const date = dayjs('2016-01-01T12:00:00Z').format('YYYY-MM-DD HH:mm:ss.SSS');
+    const date = localTimestamp('2016-01-01T12:00:00Z');
     expectedLogMessage += `${style.aside(date)}\t`;
     expectedLogMessage += `${'[INFO]'}\t`;
     expectedLogMessage += 'test';
 
     expect(formatLambdaLogEvent(pythonLoggerLine)).to.equal(expectedLogMessage);
+  });
+
+  it('should keep millisecond precision in timestamps', () => {
+    const nodeLogLine =
+      '2016-01-01T12:00:00.123Z\t99c30000-b01a-11e5-93f7-b8e85631a00e\tINFO\ttest';
+
+    const date = localTimestamp('2016-01-01T12:00:00.123Z');
+    const expectedLogMessage = `${style.aside(date)}\tINFO\ttest`;
+
+    expect(formatLambdaLogEvent(nodeLogLine)).to.equal(expectedLogMessage);
   });
 
   it('should pass through log lines with no tabs', () => {

--- a/test/unit/lib/plugins/aws/utils/time.test.js
+++ b/test/unit/lib/plugins/aws/utils/time.test.js
@@ -1,0 +1,193 @@
+'use strict';
+
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const ServerlessError = require('../../../../../../lib/serverless-error');
+const {
+  parseTimeInput,
+  subtractTime,
+  formatLogTimestamp,
+  formatDisplayTime,
+} = require('../../../../../../lib/plugins/aws/utils/time');
+
+describe('aws/utils/time', () => {
+  describe('#parseTimeInput()', () => {
+    describe('relative values', () => {
+      let clock;
+      const fakeTime = Date.UTC(2016, 9, 15, 12);
+
+      beforeEach(() => {
+        clock = sinon.useFakeTimers(fakeTime);
+      });
+
+      afterEach(() => {
+        clock.restore();
+      });
+
+      it('should resolve seconds against the current time', () => {
+        expect(parseTimeInput('90s', '--startTime')).to.equal(fakeTime - 90 * 1000);
+      });
+
+      it('should resolve minutes against the current time', () => {
+        expect(parseTimeInput('30m', '--startTime')).to.equal(fakeTime - 30 * 60 * 1000);
+      });
+
+      it('should resolve hours against the current time', () => {
+        expect(parseTimeInput('2h', '--startTime')).to.equal(fakeTime - 2 * 60 * 60 * 1000);
+      });
+
+      it('should resolve days against the current time', () => {
+        expect(parseTimeInput('3d', '--startTime')).to.equal(fakeTime - 3 * 24 * 60 * 60 * 1000);
+      });
+    });
+
+    it('should parse extended dates and datetimes as UTC', () => {
+      expect(parseTimeInput('2010-10-20', '--startTime')).to.equal(Date.UTC(2010, 9, 20));
+      expect(parseTimeInput('2013-02-08T09', '--startTime')).to.equal(Date.UTC(2013, 1, 8, 9));
+      expect(parseTimeInput('2013-02-08 09:30', '--startTime')).to.equal(
+        Date.UTC(2013, 1, 8, 9, 30)
+      );
+      expect(parseTimeInput('2013-02-08T09:30:26.123', '--startTime')).to.equal(
+        Date.UTC(2013, 1, 8, 9, 30, 26, 123)
+      );
+    });
+
+    it('should parse basic dates and datetimes as UTC', () => {
+      expect(parseTimeInput('20130208', '--startTime')).to.equal(Date.UTC(2013, 1, 8));
+      expect(parseTimeInput('20130208T08', '--startTime')).to.equal(Date.UTC(2013, 1, 8, 8));
+      expect(parseTimeInput('20130208T0809', '--startTime')).to.equal(Date.UTC(2013, 1, 8, 8, 9));
+      expect(parseTimeInput('20130208T080910', '--startTime')).to.equal(
+        Date.UTC(2013, 1, 8, 8, 9, 10)
+      );
+      expect(parseTimeInput('20130208T080910.123', '--startTime')).to.equal(
+        Date.UTC(2013, 1, 8, 8, 9, 10, 123)
+      );
+    });
+
+    it('should support a comma as the fraction separator', () => {
+      expect(parseTimeInput('20130208T080910,123', '--startTime')).to.equal(
+        Date.UTC(2013, 1, 8, 8, 9, 10, 123)
+      );
+    });
+
+    it('should pad fractional seconds', () => {
+      expect(parseTimeInput('2013-02-08T09:30:26.5', '--startTime')).to.equal(
+        Date.UTC(2013, 1, 8, 9, 30, 26, 500)
+      );
+    });
+
+    it('should respect an explicit UTC offset', () => {
+      expect(parseTimeInput('2013-02-08T09:30:26Z', '--startTime')).to.equal(
+        Date.UTC(2013, 1, 8, 9, 30, 26)
+      );
+      expect(parseTimeInput('2013-02-08T09:30:26+07:00', '--startTime')).to.equal(
+        Date.UTC(2013, 1, 8, 2, 30, 26)
+      );
+    });
+
+    it('should parse a year as January 1st UTC', () => {
+      expect(parseTimeInput('2013', '--startTime')).to.equal(Date.UTC(2013, 0, 1));
+    });
+
+    it('should parse a year and month via native fallback', () => {
+      expect(parseTimeInput('2013-02', '--startTime')).to.equal(Date.UTC(2013, 1, 1));
+    });
+
+    it('should accept single-digit months and days', () => {
+      expect(parseTimeInput('2013-2-8', '--startTime')).to.equal(Date.UTC(2013, 1, 8));
+    });
+
+    it('should accept a lowercase time separator', () => {
+      expect(parseTimeInput('2013-02-08t09:30', '--startTime')).to.equal(
+        Date.UTC(2013, 1, 8, 9, 30)
+      );
+    });
+
+    it('should trim surrounding whitespace', () => {
+      expect(parseTimeInput(' 2010-10-20 ', '--startTime')).to.equal(Date.UTC(2010, 9, 20));
+    });
+
+    it('should parse epoch seconds', () => {
+      expect(parseTimeInput('1469694264', '--startTime')).to.equal(1469694264000);
+    });
+
+    it('should parse 9-digit epoch seconds', () => {
+      expect(parseTimeInput('999999999', '--startTime')).to.equal(999999999000);
+    });
+
+    it('should parse epoch milliseconds', () => {
+      expect(parseTimeInput('1469694264000', '--startTime')).to.equal(1469694264000);
+    });
+
+    it('should treat values at the 10^12 boundary as milliseconds', () => {
+      expect(parseTimeInput('999999999999', '--startTime')).to.equal(999999999999000);
+      expect(parseTimeInput('1000000000000', '--startTime')).to.equal(1000000000000);
+    });
+
+    it('should pass through numbers as epoch milliseconds', () => {
+      expect(parseTimeInput(1469694264000, '--startTime')).to.equal(1469694264000);
+    });
+
+    it('should throw on unsupported values', () => {
+      for (const value of [
+        '1h30m', // mixed units
+        '2013-W06-5', // ISO week date
+        '2013-039', // ISO ordinal date
+        '2013050', // basic ordinal date
+        '12345', // digits-only but neither a date nor an epoch
+        '9999999999999999', // epoch beyond the JavaScript Date range
+        '-3600', // negative epoch
+        '2013-13-01', // out-of-range month
+        '2013-02-08T25:00', // out-of-range hour
+        '2013-02-08T09:60', // out-of-range minute
+        'invalid',
+        '',
+      ]) {
+        expect(() => parseTimeInput(value, '--startTime'), value)
+          .to.throw(ServerlessError, '--startTime')
+          .with.property('code', 'INVALID_TIME_INPUT');
+      }
+    });
+
+    it('should name the failing option in the error message', () => {
+      expect(() => parseTimeInput('invalid', '--endTime')).to.throw(ServerlessError, '--endTime');
+    });
+  });
+
+  describe('#subtractTime()', () => {
+    it('should subtract fixed durations for seconds, minutes and hours', () => {
+      const date = new Date(1469694264000);
+      expect(subtractTime(date, 30, 's').getTime()).to.equal(1469694264000 - 30 * 1000);
+      expect(subtractTime(date, 10, 'm').getTime()).to.equal(1469694264000 - 10 * 60 * 1000);
+      expect(subtractTime(date, 2, 'h').getTime()).to.equal(1469694264000 - 2 * 60 * 60 * 1000);
+    });
+
+    it('should subtract calendar days keeping the local clock time', () => {
+      const date = new Date(2016, 9, 15, 12, 30);
+      expect(subtractTime(date, 3, 'd').getTime()).to.equal(
+        new Date(2016, 9, 12, 12, 30).getTime()
+      );
+    });
+  });
+
+  describe('#formatLogTimestamp()', () => {
+    it('should format local time with millisecond precision', () => {
+      expect(formatLogTimestamp(new Date(2016, 0, 5, 13, 7, 8, 9))).to.equal(
+        '2016-01-05 13:07:08.009'
+      );
+    });
+  });
+
+  describe('#formatDisplayTime()', () => {
+    it('should format local time in long form', () => {
+      expect(formatDisplayTime(new Date(2016, 0, 5, 13, 7))).to.equal('January 5, 2016 1:07 PM');
+    });
+
+    it('should format midnight and noon as 12 AM and 12 PM', () => {
+      expect(formatDisplayTime(new Date(2016, 11, 31, 0, 0))).to.equal(
+        'December 31, 2016 12:00 AM'
+      );
+      expect(formatDisplayTime(new Date(2016, 5, 1, 12, 0))).to.equal('June 1, 2016 12:00 PM');
+    });
+  });
+});


### PR DESCRIPTION
This PR removes the Day.js dependency, which was only used by the `logs` and `metrics` commands. The relative time arithmetic, UTC parsing and timestamp formatting it provided are now handled by a small internal helper at `lib/plugins/aws/utils/time.js`, which preserves the existing output formats, including the localised display format used by `metrics` and the millisecond timestamps printed for Lambda log lines.

Replacing the parser was also an opportunity to fix several long-standing bugs. Epoch start times such as `1469694264` were documented for both commands but did not work, since `logs` interpreted them as nonsense calendar dates and `metrics` rejected them outright; both commands now accept epoch values in seconds or milliseconds. Dates and datetimes without an explicit UTC offset are now consistently interpreted as UTC in both commands, whereas `metrics` previously used the machine's local time zone. Malformed values such as `1h30m`, which previously subtracted 130 milliseconds, and ISO week or ordinal dates, which silently produced wrong time ranges, now fail with a clear error listing the supported formats. Relative values additionally accept seconds, and `metrics --endTime` now accepts relative values as well.

The CLI reference documentation has been rewritten to describe the formats that are actually supported, and the v4 upgrade guide documents the behaviour changes for anyone relying on the old parsing. New unit tests cover the parser and formatters and pass across multiple time zones.