### PR TITLE
Remove cachedir

### DIFF
--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -12,7 +12,7 @@ const spawnExt = require('../../../utils/spawn');
 const { spawn } = require('child_process');
 const inspect = require('util').inspect;
 const download = require('../../../utils/serverless-utils/download');
-const cachedir = require('cachedir');
+const resolveCacheDir = require('../../../utils/resolve-cache-dir');
 const { extractZip } = require('../../../utils/extract-zip');
 const { randomUUID } = require('node:crypto');
 const ServerlessError = require('../../../serverless-error');
@@ -33,7 +33,7 @@ const {
   ListStackResourcesCommand,
 } = require('@aws-sdk/client-cloudformation');
 
-const cachePath = path.join(cachedir('serverless'), 'invokeLocal');
+const cachePath = path.join(resolveCacheDir('serverless'), 'invokeLocal');
 
 const mainProgress = progress.get('main');
 const dockerProgress = progress.get('invokeLocalDocker');

--- a/lib/utils/resolve-cache-dir.js
+++ b/lib/utils/resolve-cache-dir.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+
+module.exports = (id) => {
+  switch (os.platform()) {
+    case 'darwin':
+      return path.join(os.homedir(), 'Library', 'Caches', id);
+    case 'win32':
+      return path.join(
+        process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local'),
+        id,
+        'Cache'
+      );
+    default:
+      return path.join(process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache'), id);
+  }
+};

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@smithy/node-http-handler": "^4.6.1",
     "ajv": "^8.12.0",
     "ajv-formats": "^3.0.1",
-    "cachedir": "^2.3.0",
     "content-disposition": "^2.0.1",
     "cross-spawn": "^7.0.6",
     "dotenv": "^17.4.2",

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -1425,7 +1425,7 @@ describe('AwsInvokeLocal', () => {
             },
           },
           '../../../utils/fs/copy': copyStub,
-          'cachedir': sinon.stub().returns(cacheDirPath),
+          '../../../utils/resolve-cache-dir': sinon.stub().returns(cacheDirPath),
           '../../../utils/fs/dir-exists': dirExistsStub,
           '../../../utils/serverless-utils/download': downloadStub,
         });
@@ -1479,7 +1479,7 @@ describe('AwsInvokeLocal', () => {
             },
           },
           '../../../utils/fs/copy': copyStub,
-          'cachedir': sinon.stub().returns(cacheDirPath),
+          '../../../utils/resolve-cache-dir': sinon.stub().returns(cacheDirPath),
           '../../../utils/fs/dir-exists': dirExistsStub,
           '../../../utils/serverless-utils/download': downloadStub,
         });
@@ -1705,7 +1705,9 @@ describe('AwsInvokeLocal', () => {
           '../../../utils/spawn': sinon.stub().resolves({
             stdoutBuffer: Buffer.from('Mocked output'),
           }),
-          'cachedir': sinon.stub().returns(path.join(tempRoot, 'cache-root')),
+          '../../../utils/resolve-cache-dir': sinon
+            .stub()
+            .returns(path.join(tempRoot, 'cache-root')),
         });
 
       try {
@@ -1806,7 +1808,7 @@ describe('AwsInvokeLocal', () => {
             },
           },
           '../../../utils/fs/copy': sinon.stub().resolves(),
-          'cachedir': sinon.stub().returns(cacheDirPath),
+          '../../../utils/resolve-cache-dir': sinon.stub().returns(cacheDirPath),
           '../../../utils/fs/dir-exists': sinon.stub().resolves(false),
           '../../../utils/serverless-utils/download': sinon.stub().resolves(),
         });

--- a/test/unit/lib/utils/resolve-cache-dir.test.js
+++ b/test/unit/lib/utils/resolve-cache-dir.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const resolveCacheDir = require('../../../../lib/utils/resolve-cache-dir');
+
+describe('#resolveCacheDir()', () => {
+  let originalLocalAppData;
+  let originalXdgCacheHome;
+
+  beforeEach(() => {
+    originalLocalAppData = process.env.LOCALAPPDATA;
+    originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+    delete process.env.LOCALAPPDATA;
+    delete process.env.XDG_CACHE_HOME;
+  });
+
+  afterEach(() => {
+    if (originalLocalAppData == null) delete process.env.LOCALAPPDATA;
+    else process.env.LOCALAPPDATA = originalLocalAppData;
+    if (originalXdgCacheHome == null) delete process.env.XDG_CACHE_HOME;
+    else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+    sinon.restore();
+  });
+
+  it('should resolve the macOS cache directory', () => {
+    sinon.stub(os, 'platform').returns('darwin');
+    sinon.stub(os, 'homedir').returns(path.join(path.sep, 'home-dir'));
+
+    expect(resolveCacheDir('serverless')).to.equal(
+      path.join(path.sep, 'home-dir', 'Library', 'Caches', 'serverless')
+    );
+  });
+
+  it('should resolve the Windows cache directory from LOCALAPPDATA', () => {
+    sinon.stub(os, 'platform').returns('win32');
+    process.env.LOCALAPPDATA = path.join(path.sep, 'local-app-data');
+
+    expect(resolveCacheDir('serverless')).to.equal(
+      path.join(path.sep, 'local-app-data', 'serverless', 'Cache')
+    );
+  });
+
+  it('should resolve the Windows cache directory from the home directory', () => {
+    sinon.stub(os, 'platform').returns('win32');
+    sinon.stub(os, 'homedir').returns(path.join(path.sep, 'home-dir'));
+
+    expect(resolveCacheDir('serverless')).to.equal(
+      path.join(path.sep, 'home-dir', 'AppData', 'Local', 'serverless', 'Cache')
+    );
+  });
+
+  it('should resolve the cache directory from XDG_CACHE_HOME on other platforms', () => {
+    sinon.stub(os, 'platform').returns('linux');
+    process.env.XDG_CACHE_HOME = path.join(path.sep, 'xdg-cache');
+
+    expect(resolveCacheDir('serverless')).to.equal(path.join(path.sep, 'xdg-cache', 'serverless'));
+  });
+
+  it('should resolve the cache directory from the home directory on other platforms', () => {
+    sinon.stub(os, 'platform').returns('linux');
+    sinon.stub(os, 'homedir').returns(path.join(path.sep, 'home-dir'));
+
+    expect(resolveCacheDir('serverless')).to.equal(
+      path.join(path.sep, 'home-dir', '.cache', 'serverless')
+    );
+  });
+});


### PR DESCRIPTION
This PR removes the `cachedir` dependency, which was used in a single place to locate the platform-specific cache directory for `invoke local` artifacts. Its path logic now lives in `lib/utils/resolve-cache-dir.js` and produces exactly the same locations on macOS, Windows and other platforms, including the `LOCALAPPDATA` and `XDG_CACHE_HOME` environment overrides, so existing caches remain valid. The input validation and the unsupported platform warning from the original package were dropped because the only caller passes a fixed identifier.