### PR TITLE
Remove object-hash

### DIFF
--- a/lib/classes/config-schema-handler/resolve-ajv-validate.js
+++ b/lib/classes/config-schema-handler/resolve-ajv-validate.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Ajv = require('ajv').default;
-const objectHash = require('object-hash');
 const path = require('path');
 const os = require('os');
 const Module = require('module');
@@ -10,7 +9,7 @@ const { log } = require('../../utils/serverless-utils/log');
 const fsp = require('fs').promises;
 const resolveTmpdir = require('../../utils/resolve-process-tmp-dir');
 const safeMoveFile = require('../../utils/fs/safe-move-file');
-const deepSortObjectByKey = require('../../utils/deep-sort-object-by-key');
+const getSchemaHash = require('./schema-hash');
 const ensureExists = require('../../utils/ensure-exists');
 const ServerlessError = require('../../serverless-error');
 const ajvVersion = require('ajv/package').version;
@@ -40,7 +39,7 @@ const loadModuleFromString = (code, filename) => {
 const cachedValidatorsBySchemaHash = {};
 
 const getValidate = async (schema) => {
-  const schemaHash = objectHash(deepSortObjectByKey(schema));
+  const schemaHash = getSchemaHash(schema);
   if (cachedValidatorsBySchemaHash[schemaHash]) {
     return cachedValidatorsBySchemaHash[schemaHash];
   }

--- a/lib/classes/config-schema-handler/schema-hash.js
+++ b/lib/classes/config-schema-handler/schema-hash.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const crypto = require('crypto');
+const deepSortObjectByKey = require('../../utils/deep-sort-object-by-key');
+
+module.exports = (schema) =>
+  crypto
+    .createHash('sha256')
+    .update(JSON.stringify(deepSortObjectByKey(schema)))
+    .digest('hex');

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "memoizee": "^0.4.15",
     "micromatch": "^4.0.5",
     "mime-types": "^3.0.2",
-    "object-hash": "^3.0.0",
     "semver": "^7.5.3",
     "signal-exit": "^4.1.0",
     "tsx": "^4.20.3",

--- a/test/unit/lib/classes/config-schema-handler/resolve-ajv-validate.test.js
+++ b/test/unit/lib/classes/config-schema-handler/resolve-ajv-validate.test.js
@@ -2,8 +2,7 @@
 
 const chai = require('chai');
 const resolveAjvValidate = require('../../../../../lib/classes/config-schema-handler/resolve-ajv-validate');
-const objectHash = require('object-hash');
-const deepSortObjectByKey = require('../../../../../lib/utils/deep-sort-object-by-key');
+const getSchemaHash = require('../../../../../lib/classes/config-schema-handler/schema-hash');
 const path = require('path');
 const os = require('os');
 const fsp = require('fs').promises;
@@ -36,7 +35,7 @@ describe('test/unit/lib/classes/ConfigSchemaHandler/resolveAjvValidate.test.js',
 
   it('generates schema validation file', async () => {
     await resolveAjvValidate(schema);
-    const schemaHash = objectHash(deepSortObjectByKey(schema));
+    const schemaHash = getSchemaHash(schema);
 
     const fileStat = await fsp.lstat(getExpectedCachePath(schemaHash));
     expect(fileStat.isFile()).to.be.true;
@@ -49,7 +48,7 @@ describe('test/unit/lib/classes/ConfigSchemaHandler/resolveAjvValidate.test.js',
       title: 'ChangedTitle',
     };
     await resolveAjvValidate(updatedSchema);
-    const schemaHash = objectHash(deepSortObjectByKey(updatedSchema));
+    const schemaHash = getSchemaHash(updatedSchema);
 
     const fileStat = await fsp.lstat(getExpectedCachePath(schemaHash));
     expect(fileStat.isFile()).to.be.true;
@@ -83,7 +82,7 @@ describe('test/unit/lib/classes/ConfigSchemaHandler/resolveAjvValidate.test.js',
     expect(typeof validate).to.equal('function');
     expect(validate({ firstProp: 'value' })).to.equal(true);
 
-    const schemaHash = objectHash(deepSortObjectByKey(uniqueSchema));
+    const schemaHash = getSchemaHash(uniqueSchema);
     expect((await realFsp.lstat(getExpectedCachePath(schemaHash))).isFile()).to.be.true;
   });
 


### PR DESCRIPTION
This PR removes the `object-hash` dependency, which was used in a single place to derive the cache key for compiled AJV validators. The schema is already normalized with a deep sort of its keys before hashing, and its content is limited to JSON-serializable values, so a SHA-256 digest of the sorted schema's JSON serialization provides the same discrimination. The hash computation now lives in `lib/classes/config-schema-handler/schema-hash.js`. Because the cache filenames change, validators are recompiled once on first use after upgrading, while the previous files are left behind in the artifacts directory, which is already keyed by AJV version and accumulates entries by design, and different versions of the framework can share it without conflicts.