### PR TITLE
Harden the AWS SDK v3 auth shim

### DIFF
--- a/docs/guides/plugins/creating-plugins.md
+++ b/docs/guides/plugins/creating-plugins.md
@@ -255,6 +255,10 @@ including osls-resolved region, credentials, retry settings, and proxy,
 custom CA, or timeout configuration.
 
 The returned `credentials` value is an AWS SDK v3 credential provider function.
+Resolution results are memoized process-wide, so multiple clients sharing the
+provider trigger a single resolution (one MFA prompt, one AssumeRole call, one
+`credential_process` invocation), and temporary credentials are refreshed
+automatically as they approach expiry.
 
 Supported osls-specific options are:
 
@@ -268,6 +272,30 @@ Other AWS SDK v3 client options, such as `endpoint`, `logger`, `requestHandler`,
 not the recommended AWS SDK v3 plugin API. Core osls internals that have
 not migrated still use that legacy path, so this section describes the
 plugin-created SDK v3 client path only.
+
+### Credential resolution semantics
+
+AWS SDK v3 credential resolution differs from the legacy AWS SDK v2 path that
+core osls internals use, so a plugin and the framework can resolve different
+identities in the same process:
+
+- The SDK v3 provider always merges `~/.aws/config` into same-named profiles
+  from `~/.aws/credentials` (SDK v2 only does this when `AWS_SDK_LOAD_CONFIG`
+  is set, which osls does not set). A profile with static keys in the
+  credentials file and `role_arn`/`source_profile` in the config file resolves
+  via AssumeRole — potentially a different account than the framework's own
+  requests. osls logs a warning when it detects this layout.
+- `mfa_serial` in the config file is honored and triggers an interactive
+  prompt. When no interactive input is available (for example in CI), the
+  prompt fails with `MFA_CODE_UNAVAILABLE` instead of hanging.
+- SSO (IAM Identity Center), `credential_process`, and web identity profiles
+  are supported. The HTTP calls these make inherit the same proxy, custom CA,
+  and timeout configuration as regular clients.
+- `AWS_CLIENT_TIMEOUT` is enforced as a socket inactivity timeout and defaults
+  to 120 seconds.
+- If `AWS_DEFAULT_PROFILE` names a profile that does not exist in either file,
+  resolution falls back to the SDK default provider chain (environment
+  variables, ECS/EC2 instance credentials) with a warning.
 
 ## ESM plugins
 

--- a/lib/aws/config.js
+++ b/lib/aws/config.js
@@ -63,9 +63,8 @@ function getMaxAttempts() {
 function buildHttpOptions() {
   const httpOptions = {};
 
-  // Configure timeout. Socket inactivity semantics, matching the AWS SDK v2 default of 120
-  // seconds. A bare requestTimeout is warn-only in @smithy/node-http-handler 4.4.0+, and
-  // wall-clock enforcement would abort healthy long uploads, hence socketTimeout.
+  // Socket inactivity timeout, matching the AWS SDK v2 default of 120 seconds. A bare
+  // requestTimeout would be warn-only in @smithy/node-http-handler 4.4.0+.
   const timeout = process.env.AWS_CLIENT_TIMEOUT || process.env.aws_client_timeout;
   httpOptions.socketTimeout = timeout ? parseInt(timeout, 10) : 120000;
 
@@ -83,8 +82,7 @@ function buildHttpOptions() {
   }
 
   if (proxy) {
-    // The proxy agent is assigned for both schemes: plain-http requests (custom endpoints)
-    // must traverse the proxy too, and https-proxy-agent tunnels those as well.
+    // Assigned for both schemes; https-proxy-agent tunnels plain-http requests too
     const proxyAgent = new HttpsProxyAgent(proxy, agentOptions);
     httpOptions.httpsAgent = proxyAgent;
     httpOptions.httpAgent = proxyAgent;

--- a/lib/aws/config.js
+++ b/lib/aws/config.js
@@ -12,6 +12,8 @@ const { NodeHttpHandler } = require('@smithy/node-http-handler');
  * @param {Object|Function} options.credentials - AWS credentials or SDK v3 credential provider
  * @param {number} options.maxAttempts - Maximum retry attempts
  * @param {string} options.retryMode - Retry mode ('legacy', 'standard', 'adaptive')
+ * @param {Object} options.requestHandler - Request handler override, used in place of the
+ *   proxy, timeout, and certificate configuration derived from the environment
  * @returns {Object} AWS SDK v3 client configuration
  */
 function buildClientConfig(options = {}) {
@@ -35,10 +37,7 @@ function buildClientConfig(options = {}) {
     config.requestHandler = requestHandler;
   } else {
     // Configure HTTP options (proxy, timeout, certificates)
-    const httpOptions = buildHttpOptions();
-    if (httpOptions) {
-      config.requestHandler = new NodeHttpHandler(httpOptions);
-    }
+    config.requestHandler = new NodeHttpHandler(buildHttpOptions());
   }
 
   return config;
@@ -59,16 +58,16 @@ function getMaxAttempts() {
 
 /**
  * Build HTTP options for AWS SDK v3 clients
- * @returns {Object|null} HTTP configuration or null if no special config needed
+ * @returns {Object} HTTP configuration
  */
 function buildHttpOptions() {
   const httpOptions = {};
 
-  // Configure timeout
+  // Configure timeout. Socket inactivity semantics, matching the AWS SDK v2 default of 120
+  // seconds. A bare requestTimeout is warn-only in @smithy/node-http-handler 4.4.0+, and
+  // wall-clock enforcement would abort healthy long uploads, hence socketTimeout.
   const timeout = process.env.AWS_CLIENT_TIMEOUT || process.env.aws_client_timeout;
-  if (timeout) {
-    httpOptions.requestTimeout = parseInt(timeout, 10);
-  }
+  httpOptions.socketTimeout = timeout ? parseInt(timeout, 10) : 120000;
 
   // Configure proxy
   const proxy = getProxyUrl();
@@ -84,12 +83,16 @@ function buildHttpOptions() {
   }
 
   if (proxy) {
-    httpOptions.httpsAgent = new HttpsProxyAgent(proxy, agentOptions);
+    // The proxy agent is assigned for both schemes: plain-http requests (custom endpoints)
+    // must traverse the proxy too, and https-proxy-agent tunnels those as well.
+    const proxyAgent = new HttpsProxyAgent(proxy, agentOptions);
+    httpOptions.httpsAgent = proxyAgent;
+    httpOptions.httpAgent = proxyAgent;
   } else if (caCerts.length > 0) {
     httpOptions.httpsAgent = new https.Agent(agentOptions);
   }
 
-  return httpOptions.httpsAgent || 'requestTimeout' in httpOptions ? httpOptions : null;
+  return httpOptions;
 }
 
 /**

--- a/lib/aws/credentials.js
+++ b/lib/aws/credentials.js
@@ -5,8 +5,20 @@ const os = require('os');
 const path = require('path');
 const readline = require('readline');
 const { fromIni, fromNodeProviderChain } = require('@aws-sdk/credential-providers');
+const { NodeHttpHandler } = require('@smithy/node-http-handler');
+const { buildHttpOptions } = require('./config');
+const ServerlessError = require('../serverless-error');
+const { log } = require('../utils/serverless-utils/log');
 
-const defaultConfigProfileSectionRegex = /^profile\s+(?:default|"default"|'default')$/;
+// Shared across all credential providers so that the inner SSO/OIDC/STS clients spun up
+// during resolution inherit the same proxy, CA, and timeout configuration as regular
+// clients. Built lazily, once per process.
+let sharedRequestHandler;
+
+function getCredentialsRequestHandler() {
+  if (!sharedRequestHandler) sharedRequestHandler = new NodeHttpHandler(buildHttpOptions());
+  return sharedRequestHandler;
+}
 
 function hasEnvironmentCredentials(prefix) {
   return Boolean(
@@ -37,10 +49,23 @@ function fromPrefixedEnv(prefix) {
 function promptMfaCode(mfaSerial) {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
+    let answered = false;
     rl.question(`Enter MFA code for ${mfaSerial}: `, (answer) => {
+      answered = true;
       rl.close();
       resolve(answer);
+    });
+    // Without this, stdin EOF (e.g. in CI) would leave the promise unsettled forever
+    rl.on('close', () => {
+      if (!answered) {
+        reject(
+          new ServerlessError(
+            `MFA code required for ${mfaSerial} but no interactive terminal is available`,
+            'MFA_CODE_UNAVAILABLE'
+          )
+        );
+      }
     });
   });
 }
@@ -62,11 +87,15 @@ function getSharedConfigFilepath() {
 }
 
 function fromProfile(profile) {
+  maybeWarnIdentityDivergence(profile);
   return fromIni({
     profile,
     filepath: getSharedCredentialsFilepath(),
     configFilepath: getSharedConfigFilepath(),
     mfaCodeProvider: promptMfaCode,
+    // Inner SSO/OIDC clients take their transport exclusively from clientConfig. Region is
+    // deliberately omitted: it would override the profile's sso_region.
+    clientConfig: { requestHandler: getCredentialsRequestHandler() },
   });
 }
 
@@ -90,7 +119,77 @@ function getIniSectionNames(filePath) {
 }
 
 function isDefaultConfigProfileSection(sectionName) {
-  return sectionName === 'default' || defaultConfigProfileSectionRegex.test(sectionName);
+  return isConfigProfileSection(sectionName, 'default');
+}
+
+function isConfigProfileSection(sectionName, profile) {
+  if (sectionName === profile) return true;
+  if (!sectionName.startsWith('profile')) return false;
+  const rest = sectionName.slice('profile'.length);
+  if (!/^\s/.test(rest)) return false;
+  const name = rest.trim();
+  return name === profile || name === `"${profile}"` || name === `'${profile}'`;
+}
+
+function doesProfileExist(profile) {
+  if (getIniSectionNames(getSharedCredentialsFilepath()).has(profile)) return true;
+
+  for (const sectionName of getIniSectionNames(getSharedConfigFilepath())) {
+    if (isConfigProfileSection(sectionName, profile)) return true;
+  }
+
+  return false;
+}
+
+function doesIniSectionHaveKey(filePath, sectionMatcher, keyName) {
+  try {
+    const contents = fs.readFileSync(filePath, 'utf8');
+    let inSection = false;
+
+    for (const line of contents.split(/\r?\n/)) {
+      const trimmedLine = line.split(/(^|\s)[;#]/)[0].trim();
+      if (trimmedLine[0] === '[' && trimmedLine[trimmedLine.length - 1] === ']') {
+        inSection = sectionMatcher(trimmedLine.slice(1, -1));
+      } else if (inSection) {
+        const equalsIndex = trimmedLine.indexOf('=');
+        if (equalsIndex !== -1 && trimmedLine.slice(0, equalsIndex).trim() === keyName) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+const warnedDivergenceProfiles = new Set();
+
+function maybeWarnIdentityDivergence(profile) {
+  if (warnedDivergenceProfiles.has(profile)) return;
+  warnedDivergenceProfiles.add(profile);
+
+  const hasStaticKeys = doesIniSectionHaveKey(
+    getSharedCredentialsFilepath(),
+    (sectionName) => sectionName === profile,
+    'aws_access_key_id'
+  );
+  if (!hasStaticKeys) return;
+
+  const hasConfigRoleArn = doesIniSectionHaveKey(
+    getSharedConfigFilepath(),
+    (sectionName) => isConfigProfileSection(sectionName, profile),
+    'role_arn'
+  );
+  if (!hasConfigRoleArn) return;
+
+  log.warning(
+    `Profile "${profile}" resolves via the role_arn configured in the AWS config file; ` +
+      'the static keys in the credentials file are used only as source credentials for ' +
+      "the AssumeRole call. The framework's own AWS requests do not merge the config " +
+      'file and will use the static keys directly.'
+  );
 }
 
 function doesImplicitDefaultProfileExist() {
@@ -114,7 +213,11 @@ function fromImplicitDefaultProfileWithFallback() {
       return await profileProvider(providerOptions);
     } catch (error) {
       if (doesImplicitDefaultProfileExist()) throw error;
-      if (!fallbackProvider) fallbackProvider = fromNodeProviderChain();
+      if (!fallbackProvider) {
+        fallbackProvider = fromNodeProviderChain({
+          clientConfig: { requestHandler: getCredentialsRequestHandler() },
+        });
+      }
       return fallbackProvider(providerOptions);
     }
   };
@@ -162,7 +265,18 @@ function getAwsSdkV3CredentialsProvider({ provider, profile } = {}) {
   if (process.env.AWS_PROFILE) return fromProfile(process.env.AWS_PROFILE);
   if (hasEnvironmentCredentials('AWS')) return fromPrefixedEnv('AWS');
   if (providerProfile) return fromProfile(providerProfile);
-  if (process.env.AWS_DEFAULT_PROFILE) return fromProfile(process.env.AWS_DEFAULT_PROFILE);
+  if (process.env.AWS_DEFAULT_PROFILE) {
+    if (doesProfileExist(process.env.AWS_DEFAULT_PROFILE)) {
+      return fromProfile(process.env.AWS_DEFAULT_PROFILE);
+    }
+    log.warning(
+      `Profile "${process.env.AWS_DEFAULT_PROFILE}" (from AWS_DEFAULT_PROFILE) was not found ` +
+        'in the AWS credentials or config files; falling back to the default provider chain.'
+    );
+    return fromNodeProviderChain({
+      clientConfig: { requestHandler: getCredentialsRequestHandler() },
+    });
+  }
 
   return fromImplicitDefaultProfileWithFallback();
 }

--- a/lib/aws/credentials.js
+++ b/lib/aws/credentials.js
@@ -10,9 +10,8 @@ const { buildHttpOptions } = require('./config');
 const ServerlessError = require('../serverless-error');
 const { log } = require('../utils/serverless-utils/log');
 
-// Shared across all credential providers so that the inner SSO/OIDC/STS clients spun up
-// during resolution inherit the same proxy, CA, and timeout configuration as regular
-// clients. Built lazily, once per process.
+// Inner SSO/OIDC/STS clients created during credential resolution inherit the same
+// proxy, CA, and timeout configuration as regular clients
 let sharedRequestHandler;
 
 function getCredentialsRequestHandler() {
@@ -93,8 +92,7 @@ function fromProfile(profile) {
     filepath: getSharedCredentialsFilepath(),
     configFilepath: getSharedConfigFilepath(),
     mfaCodeProvider: promptMfaCode,
-    // Inner SSO/OIDC clients take their transport exclusively from clientConfig. Region is
-    // deliberately omitted: it would override the profile's sso_region.
+    // Region is deliberately omitted: it would override the profile's sso_region
     clientConfig: { requestHandler: getCredentialsRequestHandler() },
   });
 }

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -17,6 +17,11 @@ const {
   getAwsSdkV3CredentialsProvider,
   getAwsSdkV3CredentialsProviderCacheKey,
 } = require('../../aws/credentials');
+const {
+  memoizeIdentityProvider,
+  isIdentityExpired,
+  doesIdentityRequireRefresh,
+} = require('@smithy/core');
 const { cfValue } = require('../../utils/aws-schema-get-cf-value');
 const reportDeprecatedProperties = require('../../utils/report-deprecated-properties');
 const { toCacheKey } = require('../../utils/to-cache-key');
@@ -1808,10 +1813,17 @@ class AwsProvider {
     const cacheKey = getAwsSdkV3CredentialsProviderCacheKey({ provider: this, ...options });
 
     if (!this.awsSdkV3CredentialsProviders.has(cacheKey)) {
-      this.awsSdkV3CredentialsProviders.set(
-        cacheKey,
-        getAwsSdkV3CredentialsProvider({ provider: this, ...options })
+      // Memoize process-wide (expiry-aware), and mark the provider as memoized so clients
+      // skip their own per-client memoization. Otherwise every client constructed from
+      // this provider re-resolves independently: repeated MFA prompts, AssumeRole calls
+      // and credential_process spawns.
+      const memoized = memoizeIdentityProvider(
+        getAwsSdkV3CredentialsProvider({ provider: this, ...options }),
+        isIdentityExpired,
+        doesIdentityRequireRefresh
       );
+      memoized.memoized = true;
+      this.awsSdkV3CredentialsProviders.set(cacheKey, memoized);
     }
 
     return this.awsSdkV3CredentialsProviders.get(cacheKey);

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1813,10 +1813,8 @@ class AwsProvider {
     const cacheKey = getAwsSdkV3CredentialsProviderCacheKey({ provider: this, ...options });
 
     if (!this.awsSdkV3CredentialsProviders.has(cacheKey)) {
-      // Memoize process-wide (expiry-aware), and mark the provider as memoized so clients
-      // skip their own per-client memoization. Otherwise every client constructed from
-      // this provider re-resolves independently: repeated MFA prompts, AssumeRole calls
-      // and credential_process spawns.
+      // Memoize process-wide; the memoized flag stops each client adding its own memoizer
+      // and re-resolving (repeated MFA prompts, AssumeRole, credential_process)
       const memoized = memoizeIdentityProvider(
         getAwsSdkV3CredentialsProvider({ provider: this, ...options }),
         isIdentityExpired,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@aws-sdk/client-lambda": "^3.975.0",
     "@aws-sdk/client-s3": "^3.975.0",
     "@aws-sdk/credential-providers": "^3.975.0",
+    "@smithy/core": "^3.21.1",
     "@smithy/node-http-handler": "^4.6.1",
     "ajv": "^8.12.0",
     "ajv-formats": "^3.0.1",

--- a/test/unit/lib/aws/config.test.js
+++ b/test/unit/lib/aws/config.test.js
@@ -1,8 +1,11 @@
 'use strict';
 
 const chai = require('chai');
+const net = require('net');
 const proxyquire = require('proxyquire');
+const { NodeHttpHandler } = require('@smithy/node-http-handler');
 const { overrideEnv } = require('../../../utils/process');
+const { buildHttpOptions } = require('../../../../lib/aws/config');
 
 const { expect } = chai;
 
@@ -72,7 +75,7 @@ describe('test/unit/lib/aws/config.test.js', () => {
 
       const config = buildClientConfig();
 
-      expect(config.requestHandler.options).to.deep.equal({ requestTimeout: 1234 });
+      expect(config.requestHandler.options).to.deep.equal({ socketTimeout: 1234 });
     });
   });
 
@@ -83,7 +86,69 @@ describe('test/unit/lib/aws/config.test.js', () => {
 
       const config = buildClientConfig();
 
-      expect(config.requestHandler.options).to.deep.equal({ requestTimeout: 0 });
+      expect(config.requestHandler.options).to.deep.equal({ socketTimeout: 0 });
+    });
+  });
+
+  it('defaults to a 120 second socket timeout and always constructs a request handler', async () => {
+    await overrideEnv(async () => {
+      const { buildClientConfig } = loadConfig();
+
+      const config = buildClientConfig();
+
+      expect(config.requestHandler.options).to.deep.equal({ socketTimeout: 120000 });
+    });
+  });
+
+  it('assigns the proxy agent for both http and https requests', async () => {
+    await overrideEnv(async () => {
+      process.env.HTTPS_PROXY = 'https://proxy.example.com:1234';
+      const { buildClientConfig } = loadConfig();
+
+      const config = buildClientConfig();
+
+      expect(config.requestHandler.options.httpAgent).to.equal(
+        config.requestHandler.options.httpsAgent
+      );
+      expect(config.requestHandler.options.httpsAgent.proxy).to.equal(
+        'https://proxy.example.com:1234'
+      );
+    });
+  });
+
+  it('enforces the socket inactivity timeout with the real transport', async () => {
+    await overrideEnv(async () => {
+      process.env.AWS_CLIENT_TIMEOUT = '500';
+      const sockets = new Set();
+      const server = net.createServer((socket) => {
+        // Accept the connection and never respond
+        sockets.add(socket);
+      });
+      await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+      const handler = new NodeHttpHandler(buildHttpOptions());
+
+      try {
+        const error = await handler
+          .handle({
+            protocol: 'http:',
+            hostname: '127.0.0.1',
+            port: server.address().port,
+            method: 'GET',
+            path: '/',
+            headers: {},
+          })
+          .then(
+            () => null,
+            (handleError) => handleError
+          );
+
+        expect(error).to.exist;
+        expect(error.name).to.equal('TimeoutError');
+      } finally {
+        handler.destroy();
+        for (const socket of sockets) socket.destroy();
+        await new Promise((resolve) => server.close(resolve));
+      }
     });
   });
 

--- a/test/unit/lib/aws/credentials.test.js
+++ b/test/unit/lib/aws/credentials.test.js
@@ -44,7 +44,15 @@ describe('test/unit/lib/aws/credentials.test.js', () => {
     );
   }
 
-  function loadCredentials({ files = {}, fromIni, fromNodeProviderChain }) {
+  class FakeNodeHttpHandler {
+    constructor(options) {
+      this.options = options;
+      FakeNodeHttpHandler.instances.push(this);
+    }
+  }
+  FakeNodeHttpHandler.instances = [];
+
+  function loadCredentials({ files = {}, fromIni, fromNodeProviderChain, readline, logWarning }) {
     const readFileSync = sinon.stub().callsFake((filePath) => {
       if (Object.prototype.hasOwnProperty.call(files, filePath)) {
         const result = files[filePath];
@@ -54,20 +62,51 @@ describe('test/unit/lib/aws/credentials.test.js', () => {
       throw createMissingFileError();
     });
 
-    return proxyquire('../../../../lib/aws/credentials', {
+    const stubs = {
       '@aws-sdk/credential-providers': {
         fromIni,
         fromNodeProviderChain,
       },
+      '@smithy/node-http-handler': { NodeHttpHandler: FakeNodeHttpHandler },
+      '../utils/serverless-utils/log': { log: { warning: logWarning || sinon.stub() } },
       'fs': { readFileSync },
       'os': { homedir: () => homeDir },
-    });
+    };
+    if (readline) stubs.readline = readline;
+
+    return proxyquire('../../../../lib/aws/credentials', stubs);
+  }
+
+  function createFakeReadline({ answer } = {}) {
+    return {
+      createInterface: () => {
+        const handlers = {};
+        return {
+          question: (prompt, callback) => {
+            if (answer !== undefined) {
+              callback(answer);
+            } else {
+              // Simulate stdin EOF: the question callback never fires, the interface closes
+              setImmediate(() => handlers.close && handlers.close());
+            }
+          },
+          close: () => {
+            if (handlers.close) handlers.close();
+          },
+          on: (event, handler) => {
+            handlers[event] = handler;
+          },
+        };
+      },
+    };
   }
 
   beforeEach(() => {
     originalEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
 
     for (const key of envKeys) delete process.env[key];
+
+    FakeNodeHttpHandler.instances = [];
   });
 
   afterEach(() => {
@@ -352,27 +391,32 @@ describe('test/unit/lib/aws/credentials.test.js', () => {
     });
   });
 
-  it('does not fallback when AWS_DEFAULT_PROFILE is explicitly set but absent', async () => {
+  it('falls back to the default provider chain when AWS_DEFAULT_PROFILE is absent', async () => {
     await overrideEnv(async () => {
       process.env.AWS_DEFAULT_PROFILE = 'missing-default';
-      const fallbackProvider = sinon.stub().resolves({
+      const fallbackCredentials = {
         accessKeyId: 'fallbackAccessKeyId',
         secretAccessKey: 'fallbackSecretAccessKey',
-      });
+      };
+      const fallbackProvider = sinon.stub().resolves(fallbackCredentials);
       const fromIni = sinon
         .stub()
         .returns(sinon.stub().rejects(createUnresolvedProfileError('missing-default')));
       const fromNodeProviderChain = sinon.stub().returns(fallbackProvider);
+      const logWarning = sinon.spy();
       const { getAwsSdkV3CredentialsProvider } = loadCredentials({
         fromIni,
         fromNodeProviderChain,
+        logWarning,
       });
 
-      await expect(getAwsSdkV3CredentialsProvider()()).to.be.rejectedWith(
-        'Could not resolve credentials using profile'
+      await expect(getAwsSdkV3CredentialsProvider()()).to.eventually.deep.equal(
+        fallbackCredentials
       );
-      expect(fromNodeProviderChain).to.not.have.been.called;
-      expect(fallbackProvider).to.not.have.been.called;
+      expect(fromIni).to.not.have.been.called;
+      expect(fromNodeProviderChain).to.have.been.calledOnce;
+      expect(logWarning).to.have.been.calledOnce;
+      expect(logWarning.firstCall.args[0]).to.include('missing-default');
     });
   });
 
@@ -474,5 +518,180 @@ describe('test/unit/lib/aws/credentials.test.js', () => {
     await expect(getAwsSdkV3CredentialsProvider()()).to.be.rejectedWith('permission denied');
     expect(fromNodeProviderChain).to.not.have.been.called;
     expect(fallbackProvider).to.not.have.been.called;
+  });
+
+  it('passes a request handler to profile providers without overriding region', async () => {
+    await overrideEnv(async () => {
+      process.env.AWS_PROFILE = 'dev';
+      const fromIni = sinon.stub().returns(sinon.stub().resolves({}));
+      const fromNodeProviderChain = sinon.stub();
+      loadCredentials({ fromIni, fromNodeProviderChain }).getAwsSdkV3CredentialsProvider();
+
+      expect(fromIni).to.have.been.calledOnce;
+      const initOptions = fromIni.firstCall.args[0];
+      expect(initOptions.profile).to.equal('dev');
+      expect(initOptions.clientConfig.requestHandler).to.be.an.instanceOf(FakeNodeHttpHandler);
+      expect(initOptions.clientConfig).to.not.have.property('region');
+    });
+  });
+
+  it('passes a request handler to the default provider chain fallback', async () => {
+    const fallbackCredentials = {
+      accessKeyId: 'fallbackAccessKeyId',
+      secretAccessKey: 'fallbackSecretAccessKey',
+    };
+    const fromIni = sinon
+      .stub()
+      .returns(sinon.stub().rejects(createUnresolvedProfileError('default')));
+    const fromNodeProviderChain = sinon.stub().returns(sinon.stub().resolves(fallbackCredentials));
+    const { getAwsSdkV3CredentialsProvider } = loadCredentials({ fromIni, fromNodeProviderChain });
+
+    await expect(getAwsSdkV3CredentialsProvider()()).to.eventually.deep.equal(fallbackCredentials);
+    expect(fromNodeProviderChain).to.have.been.calledOnce;
+    const initOptions = fromNodeProviderChain.firstCall.args[0];
+    expect(initOptions.clientConfig.requestHandler).to.be.an.instanceOf(FakeNodeHttpHandler);
+    expect(initOptions.clientConfig).to.not.have.property('region');
+  });
+
+  it('shares a single request handler across all credential providers', async () => {
+    await overrideEnv(async () => {
+      const fromIni = sinon.stub().returns(sinon.stub().resolves({}));
+      const fromNodeProviderChain = sinon.stub();
+      const { getAwsSdkV3CredentialsProvider } = loadCredentials({
+        fromIni,
+        fromNodeProviderChain,
+      });
+
+      getAwsSdkV3CredentialsProvider({ profile: 'first' });
+      getAwsSdkV3CredentialsProvider({ profile: 'second' });
+
+      expect(fromIni).to.have.been.calledTwice;
+      expect(FakeNodeHttpHandler.instances).to.have.length(1);
+      expect(fromIni.firstCall.args[0].clientConfig.requestHandler).to.equal(
+        fromIni.secondCall.args[0].clientConfig.requestHandler
+      );
+    });
+  });
+
+  it('rejects the MFA prompt when input closes without an answer', async () => {
+    await overrideEnv(async () => {
+      process.env.AWS_PROFILE = 'mfa-profile';
+      const fromIni = sinon.stub().returns(sinon.stub().resolves({}));
+      const fromNodeProviderChain = sinon.stub();
+      loadCredentials({
+        fromIni,
+        fromNodeProviderChain,
+        readline: createFakeReadline(),
+      }).getAwsSdkV3CredentialsProvider();
+
+      const { mfaCodeProvider } = fromIni.firstCall.args[0];
+      const error = await mfaCodeProvider('arn:aws:iam::123456789012:mfa/user').then(
+        () => null,
+        (promptError) => promptError
+      );
+
+      expect(error).to.exist;
+      expect(error.code).to.equal('MFA_CODE_UNAVAILABLE');
+      expect(error.message).to.include('arn:aws:iam::123456789012:mfa/user');
+    });
+  });
+
+  it('resolves the MFA prompt with the provided answer', async () => {
+    await overrideEnv(async () => {
+      process.env.AWS_PROFILE = 'mfa-profile';
+      const fromIni = sinon.stub().returns(sinon.stub().resolves({}));
+      const fromNodeProviderChain = sinon.stub();
+      loadCredentials({
+        fromIni,
+        fromNodeProviderChain,
+        readline: createFakeReadline({ answer: '123456' }),
+      }).getAwsSdkV3CredentialsProvider();
+
+      const { mfaCodeProvider } = fromIni.firstCall.args[0];
+
+      await expect(mfaCodeProvider('arn:aws:iam::123456789012:mfa/user')).to.eventually.equal(
+        '123456'
+      );
+    });
+  });
+
+  it('warns once when a profile has static keys shadowed by a config file role_arn', async () => {
+    await overrideEnv(async () => {
+      process.env.AWS_PROFILE = 'divergent';
+      const fromIni = sinon.stub().returns(sinon.stub().resolves({}));
+      const fromNodeProviderChain = sinon.stub();
+      const logWarning = sinon.spy();
+      const { getAwsSdkV3CredentialsProvider } = loadCredentials({
+        files: {
+          [credentialsFilePath]: [
+            '[divergent]',
+            'aws_access_key_id = accessKeyId',
+            'aws_secret_access_key = secretAccessKey',
+          ].join('\n'),
+          [configFilePath]: [
+            '[profile divergent]',
+            'role_arn = arn:aws:iam::123456789012:role/deploy',
+            'source_profile = divergent',
+          ].join('\n'),
+        },
+        fromIni,
+        fromNodeProviderChain,
+        logWarning,
+      });
+
+      getAwsSdkV3CredentialsProvider();
+      getAwsSdkV3CredentialsProvider();
+
+      expect(logWarning).to.have.been.calledOnce;
+      expect(logWarning.firstCall.args[0]).to.include('divergent');
+      expect(logWarning.firstCall.args[0]).to.include('role_arn');
+    });
+  });
+
+  it('does not warn when a profile has no config file role_arn', async () => {
+    await overrideEnv(async () => {
+      process.env.AWS_PROFILE = 'plain';
+      const fromIni = sinon.stub().returns(sinon.stub().resolves({}));
+      const fromNodeProviderChain = sinon.stub();
+      const logWarning = sinon.spy();
+      loadCredentials({
+        files: {
+          [credentialsFilePath]: [
+            '[plain]',
+            'aws_access_key_id = accessKeyId',
+            'aws_secret_access_key = secretAccessKey',
+          ].join('\n'),
+          [configFilePath]: ['[profile plain]', 'region = us-east-1'].join('\n'),
+        },
+        fromIni,
+        fromNodeProviderChain,
+        logWarning,
+      }).getAwsSdkV3CredentialsProvider();
+
+      expect(logWarning).to.not.have.been.called;
+    });
+  });
+
+  it('does not warn when a config file role_arn profile has no static keys', async () => {
+    await overrideEnv(async () => {
+      process.env.AWS_PROFILE = 'role-only';
+      const fromIni = sinon.stub().returns(sinon.stub().resolves({}));
+      const fromNodeProviderChain = sinon.stub();
+      const logWarning = sinon.spy();
+      loadCredentials({
+        files: {
+          [configFilePath]: [
+            '[profile role-only]',
+            'role_arn = arn:aws:iam::123456789012:role/deploy',
+            'credential_source = Environment',
+          ].join('\n'),
+        },
+        fromIni,
+        fromNodeProviderChain,
+        logWarning,
+      }).getAwsSdkV3CredentialsProvider();
+
+      expect(logWarning).to.not.have.been.called;
+    });
   });
 });

--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -447,12 +447,42 @@ describe('AwsProvider', () => {
         provider,
         profile: 'custom-profile',
       });
-      expect(buildClientConfigStub).to.have.been.calledOnceWithExactly({
+      expect(buildClientConfigStub).to.have.been.calledOnce;
+      const buildClientConfigOptions = buildClientConfigStub.firstCall.args[0];
+      expect(buildClientConfigOptions).to.include({
         maxAttempts: 2,
         retryMode: 'adaptive',
         region: 'us-east-1',
-        credentials: 'credentials',
       });
+      // The raw provider is wrapped in process-wide memoization
+      expect(buildClientConfigOptions.credentials).to.be.a('function');
+      expect(buildClientConfigOptions.credentials.memoized).to.equal(true);
+      await expect(buildClientConfigOptions.credentials()).to.eventually.equal('credentials');
+    });
+
+    it('memoizes credential resolution across clients sharing a provider', async () => {
+      const resolvedCredentials = { accessKeyId: 'accessKeyId', secretAccessKey: 'secret' };
+      const baseProvider = sinon.stub().resolves(resolvedCredentials);
+      const AwsProviderProxyquired = proxyquire
+        .noCallThru()
+        .load('../../../../../lib/plugins/aws/provider.js', {
+          '../../aws/credentials': {
+            getAwsSdkV3CredentialsProviderCacheKey: sinon.stub().returns('cache-key'),
+            getAwsSdkV3CredentialsProvider: sinon.stub().returns(baseProvider),
+          },
+        });
+      const provider = new AwsProviderProxyquired(serverless, options);
+
+      const credentialsProvider = provider.getAwsSdkV3CredentialsProvider();
+
+      expect(credentialsProvider.memoized).to.equal(true);
+      await expect(credentialsProvider()).to.eventually.deep.equal(resolvedCredentials);
+      await expect(credentialsProvider()).to.eventually.deep.equal(resolvedCredentials);
+      // A second client obtaining the provider must not trigger another resolution either
+      await expect(provider.getAwsSdkV3CredentialsProvider()()).to.eventually.deep.equal(
+        resolvedCredentials
+      );
+      expect(baseProvider).to.have.been.calledOnce;
     });
 
     it('reuses SDK v3 credential providers for the same credential source', async () => {


### PR DESCRIPTION
The AWS SDK v3 auth shim that plugins consume through `provider.getAwsSdkV3Config()` and `provider.getAwsSdkV3CredentialsProvider()` has several defects that surfaced during the audit ahead of the 4.0.0 release. Since `lib/aws/config.js` and `lib/aws/credentials.js` are byte-identical on the `4.x` branch, where they carry all framework traffic, fixing them here first lets the fixes flow up through the usual `3.x` into `4.x` merge.

The documented `AWS_CLIENT_TIMEOUT` environment variable was mapped to `requestTimeout`, which `@smithy/node-http-handler` treats as warn-only since 4.4.0 across our entire declared range, so it never aborted anything. Worse, when no proxy, certificate, or timeout environment variables were set, no request handler was attached at all, leaving clients with no timeout whatsoever. The variable now maps to `socketTimeout`, which carries the inactivity semantics that AWS SDK v2 enforced, the default is 120 seconds to match the v2 behaviour users had before, and a handler is now always constructed. The proxy agent is also applied to plain-http requests, which previously bypassed the proxy entirely.

Credential resolution had its own transport gap. The `fromIni` and `fromNodeProviderChain` providers were constructed without a `clientConfig`, so the inner SSO and OIDC clients they spin up made direct connections that ignored the proxy, custom certificate authorities, and timeouts that every regular client honours. A single shared `NodeHttpHandler` is now passed through `clientConfig.requestHandler` on every construction path. The region is deliberately left out of that `clientConfig` because it would override the `sso_region` configured in the profile.

The MFA prompt never settled its promise when stdin reached end of file, which meant an indefinite hang in CI for any profile carrying `mfa_serial`, or a silent successful exit in bare scripts. It now rejects with an `MFA_CODE_UNAVAILABLE` error naming the serial. Relatedly, an `AWS_DEFAULT_PROFILE` pointing at a profile that exists in neither shared file previously failed hard at resolution time; it now logs a warning and falls back to the SDK default provider chain, which restores the behaviour users get from every other AWS tool. This deliberately reverses semantics that an earlier test had pinned, so it deserves a close look during review.

Credential resolution results are now also memoized process-wide. Previously the provider function was cached but each SDK client wrapped it in its own per-client memoizer, so a plugin constructing several clients triggered repeated MFA prompts, `AssumeRole` calls, and `credential_process` spawns. The provider is now wrapped once with `memoizeIdentityProvider` from `@smithy/core`, marked with the `memoized` flag so clients skip their own wrapping, and refreshes expiring credentials automatically. This adds `@smithy/core` as a direct dependency at the same range our AWS SDK floor already requires.

Finally, the shim resolves profiles by merging the config file into the credentials file, which the framework's own SDK v2 path never does, so a profile with static keys shadowed by a config-file `role_arn` silently yields a different identity than the framework itself uses. The shim now logs a one-time warning when it detects that layout, and the plugin documentation gained a section describing the resolution semantics.