### PR TITLE
Document AWS credential and request behavior changes

### DIFF
--- a/docs/guides/plugins/creating-plugins.md
+++ b/docs/guides/plugins/creating-plugins.md
@@ -56,7 +56,7 @@ It is also a good practice to add `osls` to the `peerDependencies` section. That
 {
   ...
   "peerDependencies": {
-    "osls": "^3.67"
+    "osls": "^4.0"
   }
 }
 ```

--- a/docs/guides/upgrading-to-v4.md
+++ b/docs/guides/upgrading-to-v4.md
@@ -143,6 +143,29 @@ The `--startTime` option of `serverless logs` and the `--startTime` / `--endTime
 
 See [logs](../cli-reference/logs.md) and [metrics](../cli-reference/metrics.md) for the supported formats. As part of this change, osls no longer depends on the [`dayjs`](https://www.npmjs.com/package/dayjs) package; plugins that relied on it being installed alongside osls should declare it in their own dependencies.
 
+### AWS credential resolution changes
+
+osls v3 resolved AWS credentials through AWS SDK v2, which reads `~/.aws/config` only when `AWS_SDK_LOAD_CONFIG` is set (osls never set it). osls v4 resolves credentials with standard AWS SDK v3 semantics, matching the AWS CLI and other modern AWS tools: `~/.aws/config` is **always merged** into same-named profiles from `~/.aws/credentials`. This changes behavior for several profile layouts:
+
+- **Your deploy identity can change.** If a profile has static keys in the credentials file and a same-named section with `role_arn` and `source_profile` in the config file, v3 used the static keys directly; v4 performs AssumeRole and runs under the role, potentially in a **different AWS account**. osls logs a warning when it detects this layout. To keep the previous identity, remove or rename the config-file section, or point osls at a dedicated profile.
+- **`mfa_serial` is now honored.** Profiles configured with `mfa_serial` trigger an interactive MFA prompt. In non-interactive environments (such as CI) the prompt fails fast with `MFA_CODE_UNAVAILABLE` instead of waiting for input.
+- **`role_arn` with `credential_source = Ec2InstanceMetadata`** now attempts the EC2 instance metadata service as configured. On machines outside EC2 this fails with a timeout, even if the credentials file also contains static keys for that profile.
+- **IAM Identity Center (SSO), `credential_process`, and web identity profiles are now supported.** These were ignored or unsupported in v3. The HTTP calls they make honor the same proxy, custom CA, and timeout configuration as all other AWS requests.
+- **`AWS_DEFAULT_PROFILE`** pointing at a profile that exists in neither shared file logs a warning and falls back to the SDK default provider chain (environment variables, ECS/EC2 instance credentials). v3 skipped it silently.
+- **Credentials resolve once per command** and are shared by all AWS clients, so a deploy triggers at most one MFA prompt, one AssumeRole call, or one `credential_process` invocation. Temporary credentials refresh automatically as they approach expiry.
+- **`invoke local`** now materializes the fully resolved credentials (including SSO, assume-role, and `credential_process` profiles) into the invoked function's environment. `AWS_PROFILE` and `AWS_DEFAULT_PROFILE` are removed from that environment when resolved keys are injected, unless you set them explicitly via `provider.environment`.
+
+### AWS request behavior changes
+
+All AWS requests now go through AWS SDK v3, which changes retry, concurrency, timeout, and endpoint behavior:
+
+- **Retries.** v3 layered its own retry loop on top of AWS SDK v2's retries; v4 relies solely on the SDK v3 `standard` retry mode. `SLS_AWS_REQUEST_MAX_RETRIES` still works and sets the SDK retry count: total attempts are the value plus one (default: 4 retries, 5 attempts). Setting it to `0` now disables retries entirely, where v3 still performed SDK-level retries. Under sustained throttling, commands give up sooner than v3 did.
+- **Concurrency.** v3 funneled all AWS requests through a global queue of 2 concurrent requests; v4 has no global cap, so commands issue more requests in parallel and complete faster. Flow-specific limits such as `SLS_MAX_CONCURRENT_ARTIFACTS_UPLOADS` still apply.
+- **Timeouts.** `AWS_CLIENT_TIMEOUT` (milliseconds) is enforced as a socket inactivity timeout and defaults to 120 seconds.
+- **S3 checksums.** Uploads send CRC32 flexible checksums instead of `Content-MD5`. If you deploy to an S3-compatible endpoint that rejects them, set `AWS_REQUEST_CHECKSUM_CALCULATION=WHEN_REQUIRED`.
+- **STS endpoints.** Security Token Service calls now use the regional endpoint (`sts.<region>.amazonaws.com`) instead of the global one, and `AWS_STS_REGIONAL_ENDPOINTS` is ignored. If your network egress rules pin `sts.amazonaws.com`, allow the regional endpoints or set `AWS_ENDPOINT_URL_STS=https://sts.amazonaws.com`.
+- **Endpoint overrides are now honored.** `AWS_ENDPOINT_URL`, `AWS_ENDPOINT_URL_<SERVICE>`, and the profile `endpoint_url` setting apply to every AWS call osls makes. This enables LocalStack-style workflows without plugins, but also means a leftover `AWS_ENDPOINT_URL` export in your shell silently redirects real deploys, so check your environment if requests go somewhere unexpected.
+
 ### Plugin custom variables: `configurationVariablesSources` only
 
 Plugins that extend variable resolution via the old `variableResolvers` API will fail with `OLD_VARIABLE_RESOLVER_NOT_SUPPORTED`. Migrate to `configurationVariablesSources`.
@@ -174,6 +197,8 @@ const result = await client.send(new ListBucketsCommand({}));
 ```
 
 Declare any `@aws-sdk/client-*` packages your plugin imports in its own dependencies.
+
+See [AWS plugins](./plugins/creating-plugins.md#aws-plugins) for the full plugin-facing AWS API. The [credential resolution changes](#aws-credential-resolution-changes) above apply to plugin-created clients as well.
 
 ### Bundled `open` and `punycode` packages removed (plugin authors)
 


### PR DESCRIPTION
The upgrading guide gains two sections under breaking changes covering behavioral consequences of the AWS SDK v3 migration that were previously documented nowhere.

The credential resolution section explains that profiles now resolve with standard AWS SDK v3 semantics: `~/.aws/config` is always merged into same-named profiles from `~/.aws/credentials`, which v3 never read. The most important consequence is that a profile with static keys shadowed by a config-file `role_arn` now runs commands under the assumed role, potentially in a different AWS account. Since release documentation deliberately avoids cross-version comparisons everywhere else, this guide is the only place that warns migrating users about that identity change. The section also covers `mfa_serial` becoming effective and failing fast with `MFA_CODE_UNAVAILABLE` where no interactive input exists, `credential_source = Ec2InstanceMetadata` profiles failing outside EC2, newly supported SSO, `credential_process`, and web identity profiles, the `AWS_DEFAULT_PROFILE` fallback to the default provider chain, once-per-command credential resolution, and the credentials that `invoke local` injects into the function environment.

The request behavior section documents that `SLS_AWS_REQUEST_MAX_RETRIES` now sets the SDK retry count alone, with total attempts being the value plus one and zero disabling retries entirely, and that the framework-level retry loop and the global two-request concurrency queue are gone. It also covers the `AWS_CLIENT_TIMEOUT` socket inactivity timeout with its 120 second default, the switch from `Content-MD5` to CRC32 flexible checksums with the `AWS_REQUEST_CHECKSUM_CALCULATION=WHEN_REQUIRED` opt-out for S3-compatible endpoints, regional STS endpoints with the `AWS_ENDPOINT_URL_STS` workaround for pinned egress rules, and the newly honored `AWS_ENDPOINT_URL` family of endpoint overrides.

The plugin documentation's `peerDependencies` example now suggests `"osls": "^4.0"` rather than a v3 range, and the SDK v2 removal section links to the new credential section since the same resolution semantics apply to plugin-created clients.