### PR TITLE
Guard removed AWS SDK v2 surfaces and improve error reporting

### DIFF
--- a/lib/aws/aws-sdk-v3-error.js
+++ b/lib/aws/aws-sdk-v3-error.js
@@ -82,6 +82,15 @@ function isAwsSdkV3MissingCredentialsError(error) {
   return message ? message.includes('Could not load credentials from any providers') : false;
 }
 
+const unrecognizedProfilePattern = /Could not resolve credentials using profile: \[([^\]]+)\]/;
+
+function getAwsSdkV3UnrecognizedProfile(error) {
+  if (!isAwsCredentialProviderError(error)) return undefined;
+  const message = getAwsErrorMessage(error);
+  const match = message ? message.match(unrecognizedProfilePattern) : undefined;
+  return match ? match[1] : undefined;
+}
+
 function isAwsCredentialError(error) {
   return isAwsCredentialsNotFoundError(error) || isAwsCredentialProviderError(error);
 }
@@ -270,6 +279,7 @@ module.exports = {
   isAwsCredentialProviderError,
   isAwsCredentialsNotFoundError,
   isAwsSdkV3MissingCredentialsError,
+  getAwsSdkV3UnrecognizedProfile,
   isApiGatewayNotFoundError,
   isCloudFormationValidationError,
   isCloudFormationValidationErrorWithMessage,

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -43,15 +43,25 @@ const { hasOwn } = require('../../utils/safe-object');
 const { progress, log } = require('../../utils/serverless-utils/log');
 const validateStage = require('../../utils/validate-stage');
 const {
+  getAwsSdkV3UnrecognizedProfile,
   isAwsSdkV3MissingCredentialsError,
   isEcrRepositoryNotFoundError,
 } = require('../../aws/aws-sdk-v3-error');
+const awsCredentialsDocsUrl = require('../../aws/credentials-help-url');
 const resolveLambdaTarget = require('./utils/resolve-lambda-target');
 
 const isLambdaArn = RegExp.prototype.test.bind(/^arn:[^:]+:lambda:/);
 const isEcrUri = RegExp.prototype.test.bind(
   /^\d+\.dkr\.ecr\.[a-z0-9-]+..amazonaws.com\/([^@]+)|([^@:]+@sha256:[a-f0-9]{64})$/
 );
+const createAwsSdkV2SurfaceRemovedError = (surface) =>
+  new ServerlessError(
+    `${surface} is no longer available. Construct AWS SDK v3 clients with configuration from ` +
+      'provider.getAwsSdkV3Config() instead. See ' +
+      'https://github.com/oss-serverless/osls/blob/4.x/docs/guides/upgrading-to-v4.md',
+    'AWS_SDK_V2_SURFACE_REMOVED'
+  );
+
 function caseInsensitive(str) {
   return { type: 'string', regexp: new RegExp(`^${str}$`, 'i').toString() };
 }
@@ -1697,6 +1707,21 @@ class AwsProvider {
     return this.cloudFormationClientPromise;
   }
 
+  // Guarded stubs for the removed AWS SDK v2 plugin surface: a guided error instead of a
+  // raw TypeError when an unmigrated plugin calls them
+  // TODO: Remove the stubs in v5
+  request() {
+    throw createAwsSdkV2SurfaceRemovedError('provider.request()');
+  }
+
+  getCredentials() {
+    throw createAwsSdkV2SurfaceRemovedError('provider.getCredentials()');
+  }
+
+  get sdk() {
+    throw createAwsSdkV2SurfaceRemovedError('provider.sdk');
+  }
+
   getAwsSdkV3CredentialsProvider(options = {}) {
     const cacheKey = getAwsSdkV3CredentialsProviderCacheKey({ provider: this, ...options });
 
@@ -1710,9 +1735,17 @@ class AwsProvider {
           try {
             return await credentialsProvider(providerOptions);
           } catch (error) {
+            const unrecognizedProfile = getAwsSdkV3UnrecognizedProfile(error);
+            if (unrecognizedProfile) {
+              throw new ServerlessError(
+                `AWS profile "${unrecognizedProfile}" doesn't seem to be configured`,
+                'UNRECOGNIZED_AWS_PROFILE'
+              );
+            }
             if (isAwsSdkV3MissingCredentialsError(error)) {
               throw new ServerlessError(
-                'AWS provider credentials not found.',
+                'AWS provider credentials not found. Learn how to set up AWS provider ' +
+                  `credentials in our docs here: <${awsCredentialsDocsUrl}>.`,
                 'AWS_CREDENTIALS_NOT_FOUND'
               );
             }

--- a/lib/utils/tokenize-exception.js
+++ b/lib/utils/tokenize-exception.js
@@ -2,18 +2,33 @@
 
 const { inspect } = require('util');
 const isError = require('type/error/is');
+const { hasOwn } = require('./safe-object');
 
 const userErrorNames = new Set(['ServerlessError']);
 
+// AWS SDK v3 service errors carry response metadata in `$metadata`
+const isAwsSdkV3ServiceError = (exception) =>
+  Boolean(hasOwn(exception, '$metadata') && exception.$metadata && exception.name);
+
+const toConstantCase = (name) =>
+  name
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toUpperCase();
+
 module.exports = (exception) => {
   if (isError(exception)) {
+    const isAwsServiceError = isAwsSdkV3ServiceError(exception);
     return {
       title: exception.name.replace(/([A-Z])/g, ' $1').trim(),
       name: exception.name,
       stack: exception.stack,
       message: exception.message,
-      isUserError: userErrorNames.has(exception.name),
-      code: exception.code,
+      // AWS service errors (access denied, throttling exhaustion, ...) reflect the user's
+      // account or environment, not framework bugs - render them without a stack trace
+      isUserError: userErrorNames.has(exception.name) || isAwsServiceError,
+      code:
+        exception.code ?? (isAwsServiceError ? `AWS_${toConstantCase(exception.name)}` : undefined),
       decoratedMessage: exception.decoratedMessage,
     };
   }

--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -8,6 +8,7 @@ const sinon = require('sinon');
 const { overrideEnv } = require('../../../../utils/process');
 
 const AwsProvider = require('../../../../../lib/plugins/aws/provider');
+const awsCredentialsDocsUrl = require('../../../../../lib/aws/credentials-help-url');
 const Serverless = require('../../../../../lib/serverless');
 const ServerlessError = require('../../../../../lib/serverless-error');
 const runServerless = require('../../../../utils/run-serverless');
@@ -69,6 +70,26 @@ describe('AwsProvider', () => {
       CloudFormationClient.prototype.send.restore();
     }
     restoreEnv();
+  });
+
+  describe('removed AWS SDK v2 surface', () => {
+    it('throws a guided error from provider.request()', () => {
+      expect(() => awsProvider.request('S3', 'getObject', {}))
+        .to.throw(ServerlessError, /provider\.getAwsSdkV3Config\(\)/)
+        .with.property('code', 'AWS_SDK_V2_SURFACE_REMOVED');
+    });
+
+    it('throws a guided error from provider.getCredentials()', () => {
+      expect(() => awsProvider.getCredentials())
+        .to.throw(ServerlessError)
+        .with.property('code', 'AWS_SDK_V2_SURFACE_REMOVED');
+    });
+
+    it('throws a guided error when accessing provider.sdk', () => {
+      expect(() => awsProvider.sdk)
+        .to.throw(ServerlessError)
+        .with.property('code', 'AWS_SDK_V2_SURFACE_REMOVED');
+    });
   });
 
   describe('#getRuntime()', () => {
@@ -456,6 +477,36 @@ describe('AwsProvider', () => {
         throw new Error('Expected credentials provider to reject');
       } catch (error) {
         expect(error.code).to.equal('AWS_CREDENTIALS_NOT_FOUND');
+        expect(error.message).to.include(awsCredentialsDocsUrl);
+      }
+    });
+
+    it('normalizes unrecognized profile errors', async () => {
+      const profileError = Object.assign(
+        new Error(
+          'Could not resolve credentials using profile: [missing-profile] in configuration/credentials file(s).'
+        ),
+        { name: 'CredentialsProviderError' }
+      );
+      const credentialsProvider = sinon.stub().rejects(profileError);
+      const AwsProviderProxyquired = proxyquire
+        .noCallThru()
+        .load('../../../../../lib/plugins/aws/provider.js', {
+          '../../aws/credentials': {
+            getAwsSdkV3CredentialsProviderCacheKey: sinon.stub().returns('cache-key'),
+            getAwsSdkV3CredentialsProvider: sinon.stub().returns(credentialsProvider),
+          },
+        });
+      const provider = new AwsProviderProxyquired(serverless, options);
+
+      const config = await provider.getAwsSdkV3Config();
+
+      try {
+        await config.credentials();
+        throw new Error('Expected credentials provider to reject');
+      } catch (error) {
+        expect(error.code).to.equal('UNRECOGNIZED_AWS_PROFILE');
+        expect(error.message).to.include('missing-profile');
       }
     });
 

--- a/test/unit/lib/utils/tokenize-exception.test.js
+++ b/test/unit/lib/utils/tokenize-exception.test.js
@@ -28,6 +28,43 @@ describe('test/unit/lib/utils/tokenize-exception.test.js', () => {
     expect(errorTokens.isUserError).to.equal(false);
   });
 
+  it('Should tokenize AWS SDK service error as user error', () => {
+    const exception = Object.assign(
+      new Error('User is not authorized to perform: cloudformation:UpdateStack'),
+      { name: 'AccessDenied', $metadata: { httpStatusCode: 403 } }
+    );
+    const errorTokens = tokenizeError(exception);
+    expect(errorTokens.title).to.equal('Access Denied');
+    expect(errorTokens.isUserError).to.equal(true);
+    expect(errorTokens.code).to.equal('AWS_ACCESS_DENIED');
+  });
+
+  it('Should normalize AWS SDK service error names into codes', () => {
+    const exception = Object.assign(new Error('Rate exceeded'), {
+      name: 'ThrottlingException',
+      $metadata: { httpStatusCode: 429 },
+    });
+    expect(tokenizeError(exception).code).to.equal('AWS_THROTTLING_EXCEPTION');
+  });
+
+  it('Should preserve explicit codes on AWS SDK service errors', () => {
+    const exception = Object.assign(new Error('Some error'), {
+      name: 'ThrottlingException',
+      code: 'CUSTOM_CODE',
+      $metadata: { httpStatusCode: 429 },
+    });
+    const errorTokens = tokenizeError(exception);
+    expect(errorTokens.isUserError).to.equal(true);
+    expect(errorTokens.code).to.equal('CUSTOM_CODE');
+  });
+
+  it('Should not classify errors without $metadata as AWS service errors', () => {
+    const exception = Object.assign(new Error('Some error'), { name: 'AccessDenied' });
+    const errorTokens = tokenizeError(exception);
+    expect(errorTokens.isUserError).to.equal(false);
+    expect(errorTokens.code).to.equal(undefined);
+  });
+
   it('Should tokenize non-error exception', () => {
     const errorTokens = tokenizeError(null);
     expect(errorTokens.title).to.equal('Exception');


### PR DESCRIPTION
Plugins that still call the removed AWS SDK v2 surface previously crashed with a raw `TypeError` rendered as a framework bug with a full stack trace. `provider.request()`, `provider.getCredentials()`, and the `provider.sdk` getter now exist as guarded stubs that throw a `ServerlessError` with code `AWS_SDK_V2_SURFACE_REMOVED`, pointing at `provider.getAwsSdkV3Config()` and the upgrading guide. The `sdk` stub is a prototype getter, so it is non-enumerable and does not affect serialization or key enumeration of the provider instance. The stubs carry a TODO to remove them in v5, and nothing in the framework or test suite touches the removed surface.

A nonexistent `--aws-profile` or `provider.profile` previously surfaced as a raw `CredentialsProviderError` with a stack trace. The credential provider wrapper now maps the SDK's missing-profile error to `UNRECOGNIZED_AWS_PROFILE` with a message naming the profile. The wording is deliberately hedged as the profile not seeming to be configured, because the SDK emits an identical error for a profile that exists but cannot resolve. The detection was verified against the real `CredentialsProviderError` class shipped in `@smithy/core`, which carries `name` as an own property, rather than only against test fakes.

The `AWS_CREDENTIALS_NOT_FOUND` error message regained its link to the credentials setup documentation, which also makes `lib/aws/credentials-help-url.js` live code again.

Unhandled AWS service errors, such as an access denial during a stack update, previously rendered as framework crashes with full stack traces. The exception tokenizer now classifies errors carrying an own `$metadata` property as user errors and, when no code is present, synthesizes a stable one from the error name, for example `AWS_ACCESS_DENIED`; explicit codes are preserved. The gate is strict so genuine framework bugs keep their stack traces, and the classification was verified against a real `S3ServiceException` instance.