### PR TITLE
Improve AWS transport resilience

### DIFF
--- a/lib/aws/aws-sdk-v3-error.js
+++ b/lib/aws/aws-sdk-v3-error.js
@@ -95,6 +95,40 @@ function isAwsCredentialError(error) {
   return isAwsCredentialsNotFoundError(error) || isAwsCredentialProviderError(error);
 }
 
+const throttlingErrorCodes = new Set([
+  'Throttling',
+  'ThrottlingException',
+  'ThrottledException',
+  'TooManyRequestsException',
+  'RequestLimitExceeded',
+  'RequestThrottled',
+  'RequestThrottledException',
+  'SlowDown',
+  'PriorRequestNotComplete',
+  'ProvisionedThroughputExceededException',
+]);
+
+function hasThrottlingRetryableFlag(error) {
+  const retryable = getOwnValue(error, '$retryable');
+  return Boolean(retryable && retryable.throttling);
+}
+
+function isAwsThrottlingError(error) {
+  if (hasThrottlingRetryableFlag(error)) return true;
+  if (hasThrottlingRetryableFlag(getOwnValue(error, 'providerError'))) return true;
+  if (isAwsErrorStatusCode(error, 429)) return true;
+  const code = getAwsErrorCode(error);
+  return code ? throttlingErrorCodes.has(code) : false;
+}
+
+const transientNetworkErrorCodes = new Set(['ECONNRESET', 'EPIPE', 'ETIMEDOUT']);
+
+function isTransientNetworkError(error) {
+  const code = getOwnValue(error, 'code');
+  if (code && transientNetworkErrorCodes.has(code)) return true;
+  return getAwsErrorMessage(error) === 'aborted';
+}
+
 function isApiGatewayNotFoundError(error) {
   return isAwsErrorCode(error, 'NotFoundException') || isAwsErrorStatusCode(error, 404);
 }
@@ -277,6 +311,8 @@ module.exports = {
   isAwsErrorStatusCode,
   isAwsCredentialError,
   isAwsCredentialProviderError,
+  isAwsThrottlingError,
+  isTransientNetworkError,
   isAwsCredentialsNotFoundError,
   isAwsSdkV3MissingCredentialsError,
   getAwsSdkV3UnrecognizedProfile,

--- a/lib/aws/config.js
+++ b/lib/aws/config.js
@@ -138,6 +138,7 @@ function getCACertificates() {
 module.exports = {
   buildClientConfig,
   buildHttpOptions,
+  getCACertificates,
   getMaxAttempts,
   getMaxRetries,
 };

--- a/lib/aws/retry.js
+++ b/lib/aws/retry.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const wait = require('../utils/sleep');
+const { log } = require('../utils/serverless-utils/log');
+const { isAwsThrottlingError, isTransientNetworkError } = require('./aws-sdk-v3-error');
+
+const createRetry =
+  (isRetryable, { defaultMaxRetries, defaultDelayMs, reason }) =>
+  async (
+    task,
+    { name = 'AWS request', maxRetries = defaultMaxRetries, delayMs = defaultDelayMs } = {}
+  ) => {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await task();
+      } catch (error) {
+        if (attempt >= maxRetries || !isRetryable(error)) throw error;
+        log.info(`Recoverable error occurred (${name} ${reason}), retrying in ${delayMs / 1000}s`);
+        await wait(delayMs);
+      }
+    }
+  };
+
+// On top of the SDK's own per-request retries: sustained throttling outlives the SDK
+// retry budget during polling and bulk uploads, and body-phase network failures occur
+// after send() resolves, outside the SDK retry middleware entirely.
+module.exports = {
+  retryOnThrottlingError: createRetry(isAwsThrottlingError, {
+    defaultMaxRetries: 4,
+    defaultDelayMs: 5000,
+    reason: 'was throttled',
+  }),
+  retryOnTransientNetworkError: createRetry(isTransientNetworkError, {
+    defaultMaxRetries: 2,
+    defaultDelayMs: 1000,
+    reason: 'failed on the network',
+  }),
+};

--- a/lib/configuration/variables/sources/instance-dependent/create-cached-aws-variable-source-command-sender.js
+++ b/lib/configuration/variables/sources/instance-dependent/create-cached-aws-variable-source-command-sender.js
@@ -24,6 +24,7 @@ function createCacheKey({ commandName, region, input }) {
 function createCachedAwsVariableSourceCommandSender({
   getProvider,
   Client,
+  clientOptions,
   transformResult = ({ result }) => result,
 }) {
   const clients = new Map();
@@ -45,7 +46,7 @@ function createCachedAwsVariableSourceCommandSender({
 
     if (!clients.has(cacheKey)) {
       const clientPromise = (async () => {
-        const config = await resolveProvider().getAwsSdkV3Config({ region });
+        const config = await resolveProvider().getAwsSdkV3Config({ region, ...clientOptions });
         return new Client(config);
       })();
 

--- a/lib/configuration/variables/sources/instance-dependent/get-s3.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-s3.js
@@ -6,11 +6,14 @@ const ServerlessError = require('../../../../serverless-error');
 const s3BodyToString = require('../../../../aws/s3-body-to-string');
 const createCachedAwsVariableSourceCommandSender = require('./create-cached-aws-variable-source-command-sender');
 const { isS3GetObjectNoSuchKeyError } = require('../../../../aws/aws-sdk-v3-error');
+const { retryOnTransientNetworkError } = require('../../../../aws/retry');
 
 module.exports = (serverlessInstance) => {
   const sender = createCachedAwsVariableSourceCommandSender({
     getProvider: () => serverlessInstance.getProvider('aws'),
     Client: S3Client,
+    // Buckets may live in a different region than the provider region
+    clientOptions: { followRegionRedirects: true },
     transformResult: async ({ result }) => s3BodyToString(result.Body),
   });
 
@@ -41,7 +44,10 @@ module.exports = (serverlessInstance) => {
 
       const result = await (async () => {
         try {
-          return await sender.send(GetObjectCommand, { Bucket: bucketName, Key: key });
+          return await retryOnTransientNetworkError(
+            () => sender.send(GetObjectCommand, { Bucket: bucketName, Key: key }),
+            { name: 'S3 variable read' }
+          );
         } catch (error) {
           if (isS3GetObjectNoSuchKeyError(error)) return null;
           throw error;

--- a/lib/plugins/aws/lib/monitor-stack.js
+++ b/lib/plugins/aws/lib/monitor-stack.js
@@ -9,6 +9,7 @@ const {
   DescribeStackEventsCommand,
 } = require('@aws-sdk/client-cloudformation');
 const { isCloudFormationMissingStackError } = require('../../../aws/aws-sdk-v3-error');
+const { retryOnThrottlingError } = require('../../../aws/retry');
 
 const mainProgress = progress.get('main');
 const validStatuses = new Set(['CREATE_COMPLETE', 'UPDATE_COMPLETE', 'DELETE_COMPLETE']);
@@ -53,7 +54,10 @@ module.exports = {
       do {
         const input = { StackName: cfData.StackId };
         if (nextToken) input.NextToken = nextToken;
-        const result = await cloudFormation.send(new DescribeStackEventsCommand(input));
+        const result = await retryOnThrottlingError(
+          () => cloudFormation.send(new DescribeStackEventsCommand(input)),
+          { name: 'CloudFormation stack polling' }
+        );
         for (const event of result.StackEvents || []) {
           stackEvents.push(event);
           if (firstEventId) {

--- a/lib/plugins/aws/lib/upload-s3-object.js
+++ b/lib/plugins/aws/lib/upload-s3-object.js
@@ -3,6 +3,7 @@
 const { S3Client } = require('@aws-sdk/client-s3');
 const { Upload } = require('@aws-sdk/lib-storage');
 const { createS3UploadError } = require('../../../aws/aws-sdk-v3-error');
+const { retryOnThrottlingError } = require('../../../aws/retry');
 
 const uploadQueueSize = 6;
 const uploadPartSize = 5 * 1024 * 1024;
@@ -37,15 +38,24 @@ async function getS3UploadClient(provider) {
 module.exports = async (provider, params) => {
   const s3 = await getS3UploadClient(provider);
 
-  try {
-    return await new Upload({
-      client: s3,
-      params,
-      queueSize: uploadQueueSize,
-      partSize: uploadPartSize,
-      leavePartsOnError: false,
-    }).done();
-  } catch (error) {
-    throw createS3UploadError(error);
-  }
+  const upload = async () => {
+    try {
+      return await new Upload({
+        client: s3,
+        params,
+        queueSize: uploadQueueSize,
+        partSize: uploadPartSize,
+        leavePartsOnError: false,
+      }).done();
+    } catch (error) {
+      throw createS3UploadError(error);
+    }
+  };
+
+  // Stream bodies cannot be replayed once consumed, so only re-runnable bodies get the
+  // outer throttling retry; the SDK still retries individual requests either way
+  const isReplayableBody = typeof params.Body === 'string' || params.Body instanceof Uint8Array;
+  if (!isReplayableBody) return upload();
+
+  return retryOnThrottlingError(upload, { name: `S3 upload of ${params.Key}` });
 };

--- a/lib/plugins/aws/lib/wait-for-change-set-creation.js
+++ b/lib/plugins/aws/lib/wait-for-change-set-creation.js
@@ -9,6 +9,7 @@ const {
   CloudFormationClient,
   DescribeChangeSetCommand,
 } = require('@aws-sdk/client-cloudformation');
+const { retryOnThrottlingError } = require('../../../aws/retry');
 
 function getCloudFormationClient(context) {
   context.cloudFormationClientPromise ||= context.provider
@@ -26,7 +27,10 @@ module.exports = {
     const cloudFormation = await getCloudFormationClient(this);
 
     const callWithRetry = async () => {
-      const changeSetDescription = await cloudFormation.send(new DescribeChangeSetCommand(params));
+      const changeSetDescription = await retryOnThrottlingError(
+        () => cloudFormation.send(new DescribeChangeSetCommand(params)),
+        { name: 'CloudFormation change set polling' }
+      );
       if (
         changeSetDescription.Status === 'CREATE_COMPLETE' ||
         isChangeSetWithoutChanges(changeSetDescription)

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -126,10 +126,11 @@ class AwsCompileFunctions {
     });
 
     if (!this.s3ClientPromisesByRegion.has(cacheKey)) {
+      // Artifacts may be hosted in a bucket outside the provider region
       const configPromise =
         region === undefined
-          ? this.provider.getAwsSdkV3Config()
-          : this.provider.getAwsSdkV3Config({ region });
+          ? this.provider.getAwsSdkV3Config({ followRegionRedirects: true })
+          : this.provider.getAwsSdkV3Config({ region, followRegionRedirects: true });
       this.s3ClientPromisesByRegion.set(
         cacheKey,
         configPromise.then((config) => new S3Client(config))

--- a/lib/plugins/aws/rollback-function.js
+++ b/lib/plugins/aws/rollback-function.js
@@ -7,6 +7,7 @@ const {
 } = require('@aws-sdk/client-lambda');
 const ServerlessError = require('../../serverless-error');
 const validate = require('./lib/validate');
+const buildFetchDispatcher = require('../../utils/build-fetch-dispatcher');
 const { style, log, progress } = require('../../utils/serverless-utils/log');
 const {
   getAwsErrorCode,
@@ -133,7 +134,15 @@ class AwsRollbackFunction {
   async fetchFunctionCode(func) {
     const codeUrl = func.Code.Location;
 
-    const response = await fetch(codeUrl);
+    const response = await fetch(codeUrl, { dispatcher: buildFetchDispatcher() });
+    if (!response.ok) {
+      // Without this check an expired presigned URL's XML error document would be
+      // uploaded as the function code
+      throw new ServerlessError(
+        `Could not download function code (HTTP ${response.status})`,
+        'LAMBDA_CODE_DOWNLOAD_FAILED'
+      );
+    }
     return Buffer.from(await response.arrayBuffer());
   }
 

--- a/lib/plugins/aws/rollback.js
+++ b/lib/plugins/aws/rollback.js
@@ -17,6 +17,7 @@ const ServerlessError = require('../../serverless-error');
 const { style, log, progress } = require('../../utils/serverless-utils/log');
 const { S3Client, GetObjectCommand, paginateListObjectsV2 } = require('@aws-sdk/client-s3');
 const { isS3GetObjectNoSuchKeyError } = require('../../aws/aws-sdk-v3-error');
+const { retryOnTransientNetworkError } = require('../../aws/retry');
 
 const slsConsoleLog = log.get('console');
 
@@ -159,15 +160,22 @@ class AwsRollback {
     service.package.artifactDirectoryName = `${prefix}${dateString}`;
     const stateString = await (async () => {
       try {
-        const result = await s3.send(
-          new GetObjectCommand({
-            Bucket: this.bucketName,
-            Key: `${
-              service.package.artifactDirectoryName
-            }/${this.provider.naming.getServiceStateFileName()}`,
-          })
+        // Body-phase network failures occur after send() resolves, outside the SDK
+        // retry middleware, so the read is retried as a whole
+        return await retryOnTransientNetworkError(
+          async () => {
+            const result = await s3.send(
+              new GetObjectCommand({
+                Bucket: this.bucketName,
+                Key: `${
+                  service.package.artifactDirectoryName
+                }/${this.provider.naming.getServiceStateFileName()}`,
+              })
+            );
+            return s3BodyToString(result.Body);
+          },
+          { name: 'service state download' }
         );
-        return s3BodyToString(result.Body);
       } catch (error) {
         if (isS3GetObjectNoSuchKeyError(error)) return null;
         throw error;

--- a/lib/plugins/plugin/lib/utils.js
+++ b/lib/plugins/plugin/lib/utils.js
@@ -1,25 +1,13 @@
 'use strict';
 
-const { ProxyAgent } = require('undici');
+const buildFetchDispatcher = require('../../../utils/build-fetch-dispatcher');
 const { log, writeText, style } = require('../../../utils/serverless-utils/log');
 
 module.exports = {
   async getPlugins() {
     const endpoint = 'https://raw.githubusercontent.com/serverless/plugins/master/plugins.json';
 
-    const proxy =
-      process.env.proxy ||
-      process.env.HTTP_PROXY ||
-      process.env.http_proxy ||
-      process.env.HTTPS_PROXY ||
-      process.env.https_proxy;
-
-    const options = {};
-    if (proxy) {
-      options.dispatcher = new ProxyAgent(proxy);
-    }
-
-    return fetch(endpoint, options)
+    return fetch(endpoint, { dispatcher: buildFetchDispatcher() })
       .then((result) => result.json())
       .then((json) => json);
   },

--- a/lib/utils/build-fetch-dispatcher.js
+++ b/lib/utils/build-fetch-dispatcher.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const { EnvHttpProxyAgent, ProxyAgent } = require('undici');
+const { getCACertificates } = require('../aws/config');
+
+// Dispatcher for the framework's plain fetch() calls, mirroring the proxy and custom CA
+// configuration that AWS SDK clients receive. Built per call so environment changes are
+// honored.
+module.exports = () => {
+  const caCerts = getCACertificates();
+  const tlsOptions = caCerts.length > 0 ? { ca: caCerts } : undefined;
+  const agentOptions = tlsOptions
+    ? { connect: tlsOptions, proxyTls: tlsOptions, requestTls: tlsOptions }
+    : {};
+
+  // The nonstandard lowercase `proxy` variable is not understood by undici; honor it the
+  // same way AWS client configuration does
+  if (process.env.proxy) return new ProxyAgent({ ...agentOptions, uri: process.env.proxy });
+
+  // Standard HTTP_PROXY / HTTPS_PROXY / NO_PROXY environment handling
+  return new EnvHttpProxyAgent(agentOptions);
+};

--- a/lib/utils/download-template-from-repo.js
+++ b/lib/utils/download-template-from-repo.js
@@ -5,6 +5,7 @@ const os = require('os');
 const fs = require('fs');
 const URL = require('url');
 const download = require('./serverless-utils/download');
+const buildFetchDispatcher = require('./build-fetch-dispatcher');
 const qs = require('querystring');
 const spawn = require('./spawn');
 const untildify = require('./untildify');
@@ -235,7 +236,10 @@ function parseBitbucketServerURL(url) {
 async function retrieveBitbucketServerInfo(url) {
   const versionInfoPath = `${url.protocol}//${url.hostname}/rest/api/1.0/application-properties`;
 
-  return fetch(versionInfoPath)
+  return fetch(versionInfoPath, {
+    dispatcher: buildFetchDispatcher(),
+    signal: AbortSignal.timeout(30000),
+  })
     .then((resp) => resp.json())
     .then((body) => body.displayName === 'Bitbucket');
 }

--- a/lib/utils/serverless-utils/download.js
+++ b/lib/utils/serverless-utils/download.js
@@ -18,6 +18,7 @@ const fsp = require('fs').promises;
 const path = require('path');
 const { URL } = require('url');
 const { Agent } = require('undici');
+const buildFetchDispatcher = require('../build-fetch-dispatcher');
 const { parse: parseContentDisposition } = require('content-disposition');
 const { default: filenamify } = require('filenamify');
 const mime = require('mime-types');
@@ -153,7 +154,7 @@ module.exports = (uri, output, opts) => {
     const dispatcher =
       opts.https && opts.https.rejectUnauthorized === false
         ? new Agent({ connect: { rejectUnauthorized: false } })
-        : undefined;
+        : buildFetchDispatcher();
 
     const response = await fetchWithRedirects(uri, {
       headers,

--- a/test/unit/lib/aws/retry.test.js
+++ b/test/unit/lib/aws/retry.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const chai = require('chai');
+const sinon = require('sinon');
+
+const ServerlessError = require('../../../../lib/serverless-error');
+const {
+  retryOnThrottlingError,
+  retryOnTransientNetworkError,
+} = require('../../../../lib/aws/retry');
+
+const { expect } = chai;
+
+describe('test/unit/lib/aws/retry.test.js', () => {
+  const createThrottlingError = () =>
+    Object.assign(new Error('Rate exceeded'), { name: 'ThrottlingException' });
+
+  it('retries throttling errors until the task succeeds', async () => {
+    const task = sinon.stub();
+    task.onCall(0).rejects(createThrottlingError());
+    task.onCall(1).resolves('result');
+
+    await expect(retryOnThrottlingError(task, { delayMs: 1 })).to.eventually.equal('result');
+    expect(task).to.have.been.calledTwice;
+  });
+
+  it('retries errors the SDK marks as retryable throttling', async () => {
+    const error = Object.assign(new Error('Slow down'), { $retryable: { throttling: true } });
+    const task = sinon.stub();
+    task.onCall(0).rejects(error);
+    task.onCall(1).resolves('result');
+
+    await expect(retryOnThrottlingError(task, { delayMs: 1 })).to.eventually.equal('result');
+    expect(task).to.have.been.calledTwice;
+  });
+
+  it('retries throttling errors carried in wrapped provider errors', async () => {
+    const wrappedError = Object.assign(
+      new ServerlessError('Upload failed', 'AWS_S3_UPLOAD_SLOW_DOWN'),
+      {
+        // Both throttling signals the SDK emits, on the wrapped error only
+        providerError: Object.assign(new Error('Please reduce your request rate.'), {
+          name: 'SlowDown',
+          $retryable: { throttling: true },
+        }),
+      }
+    );
+    const task = sinon.stub();
+    task.onCall(0).rejects(wrappedError);
+    task.onCall(1).resolves('result');
+
+    await expect(retryOnThrottlingError(task, { delayMs: 1 })).to.eventually.equal('result');
+    expect(task).to.have.been.calledTwice;
+  });
+
+  it('retries when only the wrapped provider error carries the retryable flag', async () => {
+    const wrappedError = Object.assign(
+      new ServerlessError('Upload failed', 'AWS_S3_UPLOAD_ERROR'),
+      {
+        providerError: Object.assign(new Error('Reduce rate'), {
+          name: 'UnfamiliarThrottleName',
+          $retryable: { throttling: true },
+        }),
+      }
+    );
+    const task = sinon.stub();
+    task.onCall(0).rejects(wrappedError);
+    task.onCall(1).resolves('result');
+
+    await expect(retryOnThrottlingError(task, { delayMs: 1 })).to.eventually.equal('result');
+    expect(task).to.have.been.calledTwice;
+  });
+
+  it('rethrows after exhausting the retry budget', async () => {
+    const task = sinon.stub().rejects(createThrottlingError());
+
+    await expect(retryOnThrottlingError(task, { delayMs: 1, maxRetries: 2 })).to.be.rejectedWith(
+      'Rate exceeded'
+    );
+    expect(task).to.have.been.calledThrice;
+  });
+
+  it('does not retry non-throttling errors', async () => {
+    const error = Object.assign(new Error('Access denied'), {
+      name: 'AccessDenied',
+      $metadata: { httpStatusCode: 403 },
+    });
+    const task = sinon.stub().rejects(error);
+
+    await expect(retryOnThrottlingError(task, { delayMs: 1 })).to.be.rejectedWith('Access denied');
+    expect(task).to.have.been.calledOnce;
+  });
+
+  it('retries transient network errors', async () => {
+    const task = sinon.stub();
+    task.onCall(0).rejects(Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }));
+    task.onCall(1).resolves('result');
+
+    await expect(retryOnTransientNetworkError(task, { delayMs: 1 })).to.eventually.equal('result');
+    expect(task).to.have.been.calledTwice;
+  });
+
+  it('does not retry persistent errors as transient network failures', async () => {
+    const task = sinon.stub().rejects(new Error('The specified key does not exist.'));
+
+    await expect(retryOnTransientNetworkError(task, { delayMs: 1 })).to.be.rejectedWith(
+      'The specified key does not exist.'
+    );
+    expect(task).to.have.been.calledOnce;
+  });
+});

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/get-s3.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/get-s3.test.js
@@ -138,7 +138,10 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-s
   });
 
   it('should use AWS SDK v3 config and preserve credential providers', () => {
-    expect(getAwsSdkV3Config).to.have.been.calledWith({ region: 'us-east-1' });
+    expect(getAwsSdkV3Config).to.have.been.calledWith({
+      region: 'us-east-1',
+      followRegionRedirects: true,
+    });
     expect(clientInstances[0].config.credentials).to.equal(credentials);
   });
 

--- a/test/unit/lib/plugins/aws/lib/monitor-stack.test.js
+++ b/test/unit/lib/plugins/aws/lib/monitor-stack.test.js
@@ -118,6 +118,63 @@ describe('monitorStack', () => {
       expect(commands[0]).to.be.instanceOf(DescribeStackEventsCommand);
     });
 
+    it('retries stack event polling on throttling errors', async () => {
+      const throttlingError = Object.assign(new Error('Rate exceeded'), {
+        name: 'ThrottlingException',
+      });
+      const sendStub = sinon.stub();
+      sendStub.onCall(0).rejects(throttlingError);
+      sendStub.onCall(1).resolves({
+        StackEvents: [
+          {
+            EventId: 'complete',
+            StackName: 'stack-id',
+            LogicalResourceId: 'stack-id',
+            ResourceType: 'AWS::CloudFormation::Stack',
+            ResourceStatus: 'CREATE_COMPLETE',
+          },
+        ],
+      });
+      class StubCloudFormationClient {
+        async send(command) {
+          return sendStub(command);
+        }
+      }
+      const { retryOnThrottlingError } = require('../../../../../../lib/aws/retry');
+      const monitorStackWithStub = proxyquire(
+        '../../../../../../lib/plugins/aws/lib/monitor-stack',
+        {
+          '../../../utils/sleep': sinon.stub().resolves(),
+          '../../../aws/retry': {
+            retryOnThrottlingError: (task, options) =>
+              retryOnThrottlingError(task, { ...options, delayMs: 1 }),
+          },
+          '@aws-sdk/client-cloudformation': {
+            CloudFormationClient: StubCloudFormationClient,
+            DescribeStackEventsCommand,
+          },
+        }
+      );
+      const plugin = {
+        provider: {
+          getAwsSdkV3Config: sinon.stub().resolves({ region: 'us-east-1' }),
+        },
+        options: {},
+        ...monitorStackWithStub,
+      };
+
+      const stackStatus = await plugin.checkStackProgress(
+        'create',
+        { StackId: 'stack-id' },
+        'https://example.test/stack',
+        { frequency: 0 },
+        {}
+      );
+
+      expect(stackStatus).to.equal('CREATE_COMPLETE');
+      expect(sendStub).to.have.been.calledTwice;
+    });
+
     it('should skip monitoring if the stack was already created', async () => {
       const describeStackEventsStub = stubDescribeStackEvents();
 

--- a/test/unit/lib/plugins/aws/rollback-function.test.js
+++ b/test/unit/lib/plugins/aws/rollback-function.test.js
@@ -23,7 +23,7 @@ describe('AwsRollbackFunction', () => {
   let originalFetch;
 
   beforeEach(() => {
-    fetchStub = sinon.stub().resolves({ arrayBuffer: async () => new ArrayBuffer(0) });
+    fetchStub = sinon.stub().resolves({ ok: true, arrayBuffer: async () => new ArrayBuffer(0) });
     originalFetch = globalThis.fetch;
     globalThis.fetch = fetchStub;
     serverless = new Serverless({ commands: [], options: {} });
@@ -223,7 +223,7 @@ describe('AwsRollbackFunction', () => {
       const zipBuffer = Buffer.from(zipBytes);
       const functionVersion = '4711';
       const codeLocation = 'https://example.test/function.zip';
-      fetchStub.resolves({ arrayBuffer: async () => zipBytes.buffer });
+      fetchStub.resolves({ ok: true, arrayBuffer: async () => zipBytes.buffer });
 
       const { awsSdkV3Stub, serverless } = await runServerless({
         fixture: 'function',
@@ -240,7 +240,9 @@ describe('AwsRollbackFunction', () => {
       const lambdaSends = awsSdkV3Stub.sends.filter(({ service }) => service === 'Lambda');
       const expectedCredentials = serverless.getProvider('aws').getAwsSdkV3CredentialsProvider();
 
-      expect(fetchStub).to.have.been.calledOnceWithExactly(codeLocation);
+      expect(fetchStub).to.have.been.calledOnce;
+      expect(fetchStub.firstCall.args[0]).to.equal(codeLocation);
+      expect(fetchStub.firstCall.args[1].dispatcher).to.exist;
       expect(lambdaSends.map(({ method }) => method)).to.deep.equal([
         'getFunction',
         'getFunction',
@@ -460,7 +462,7 @@ describe('AwsRollbackFunction', () => {
   describe('#fetchFunctionCode()', () => {
     it('should fetch the zip file content of the previously requested function', async () => {
       const body = Uint8Array.from([1, 2, 3]);
-      fetchStub.resolves({ arrayBuffer: async () => body.buffer });
+      fetchStub.resolves({ ok: true, arrayBuffer: async () => body.buffer });
       const func = {
         Code: {
           Location: 'https://foo.com/bar',
@@ -469,9 +471,31 @@ describe('AwsRollbackFunction', () => {
 
       const result = await awsRollbackFunction.fetchFunctionCode(func);
 
-      expect(fetchStub.calledOnceWithExactly('https://foo.com/bar')).to.equal(true);
+      expect(fetchStub.calledOnce).to.equal(true);
+      expect(fetchStub.firstCall.args[0]).to.equal('https://foo.com/bar');
+      expect(fetchStub.firstCall.args[1].dispatcher).to.exist;
       expect(Buffer.isBuffer(result)).to.equal(true);
       expect(result).to.deep.equal(Buffer.from([1, 2, 3]));
+    });
+
+    it('should reject unsuccessful download responses', async () => {
+      fetchStub.resolves({ ok: false, status: 403, arrayBuffer: async () => new ArrayBuffer(0) });
+      const func = {
+        Code: {
+          Location: 'https://foo.com/bar',
+        },
+      };
+
+      try {
+        await awsRollbackFunction.fetchFunctionCode(func);
+      } catch (error) {
+        expect(error).to.be.instanceOf(ServerlessError);
+        expect(error.code).to.equal('LAMBDA_CODE_DOWNLOAD_FAILED');
+        expect(error.message).to.include('403');
+        return;
+      }
+
+      throw new Error('Expected fetchFunctionCode to reject');
     });
   });
 

--- a/test/unit/lib/utils/build-fetch-dispatcher.test.js
+++ b/test/unit/lib/utils/build-fetch-dispatcher.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const chai = require('chai');
+const http = require('http');
+const net = require('net');
+const { EnvHttpProxyAgent, ProxyAgent } = require('undici');
+const { overrideEnv } = require('../../../utils/process');
+const buildFetchDispatcher = require('../../../../lib/utils/build-fetch-dispatcher');
+
+const { expect } = chai;
+
+describe('test/unit/lib/utils/build-fetch-dispatcher.test.js', () => {
+  it('uses standard environment proxy handling by default', async () => {
+    await overrideEnv(async () => {
+      const dispatcher = buildFetchDispatcher();
+      try {
+        expect(dispatcher).to.be.an.instanceOf(EnvHttpProxyAgent);
+      } finally {
+        await dispatcher.close();
+      }
+    });
+  });
+
+  it('uses the legacy lowercase proxy variable when set', async () => {
+    await overrideEnv(async () => {
+      process.env.proxy = 'http://proxy.example.com:8080';
+      const dispatcher = buildFetchDispatcher();
+      try {
+        expect(dispatcher).to.be.an.instanceOf(ProxyAgent);
+      } finally {
+        await dispatcher.close();
+      }
+    });
+  });
+
+  it('routes requests through the proxy configured in the environment', async () => {
+    await overrideEnv(async () => {
+      const targetServer = http.createServer((request, response) => {
+        response.end('from-target');
+      });
+      await new Promise((resolve) => targetServer.listen(0, '127.0.0.1', resolve));
+
+      // undici tunnels through proxies with CONNECT, also for plain-http targets
+      const connectRequests = [];
+      const proxyServer = http.createServer();
+      proxyServer.on('connect', (request, clientSocket, head) => {
+        connectRequests.push(request.url);
+        const targetSocket = net.connect(targetServer.address().port, '127.0.0.1', () => {
+          clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+          targetSocket.write(head);
+          targetSocket.pipe(clientSocket);
+          clientSocket.pipe(targetSocket);
+        });
+      });
+      await new Promise((resolve) => proxyServer.listen(0, '127.0.0.1', resolve));
+
+      try {
+        process.env.HTTP_PROXY = `http://127.0.0.1:${proxyServer.address().port}`;
+        const dispatcher = buildFetchDispatcher();
+        try {
+          // `.invalid` never resolves; a response proves the request went via the proxy
+          const response = await fetch('http://target.invalid/artifact.zip', { dispatcher });
+          expect(await response.text()).to.equal('from-target');
+          expect(connectRequests).to.deep.equal(['target.invalid:80']);
+        } finally {
+          await dispatcher.close();
+        }
+      } finally {
+        await new Promise((resolve) => proxyServer.close(resolve));
+        await new Promise((resolve) => targetServer.close(resolve));
+      }
+    });
+  });
+});


### PR DESCRIPTION
Sustained CloudFormation or S3 throttling can outlive the SDK's per-request retry budget, since the framework-level retry loop did not survive the AWS SDK v3 migration. A new `lib/aws/retry.js` provides a bounded throttling retry with progress logging, classifying errors by the SDK's `$retryable.throttling` flag, HTTP status 429, or the well-known throttling error codes, including when the signal sits on a wrapped `providerError`. It wraps the stack event polling in `monitor-stack.js`, the change set polling in `wait-for-change-set-creation.js`, and artifact uploads in `upload-s3-object.js`. Uploads are only retried when the body is a string or `Uint8Array`, because a consumed stream cannot be replayed; stream uploads keep the SDK's own per-request retries.

S3 reads that may target a bucket in a different region than the provider region now set `followRegionRedirects`, which AWS SDK v3 disables by default. This covers `${s3:bucket/key}` variable resolution, where `create-cached-aws-variable-source-command-sender.js` gained a `clientOptions` parameter, and the download of `package.artifact` objects in `functions.js`. Without it these reads fail with `PermanentRedirect`.

The framework's plain `fetch()` calls previously ignored the proxy and custom certificate authority environment variables that all AWS SDK clients honor. A new `lib/utils/build-fetch-dispatcher.js` returns an undici dispatcher mirroring that configuration: an `EnvHttpProxyAgent` for standard `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` handling, a `ProxyAgent` when the legacy lowercase `proxy` variable is set, and the `ca`/`cafile` certificates applied in either case. It is wired into the `rollback function` code download, the template and layer downloads in `download.js`, the Bitbucket server probe in `download-template-from-repo.js` (which also gains a thirty second timeout where it previously had none), and the plugin registry fetch (which gains `NO_PROXY` and certificate support over its hand-rolled proxy handling). The `rollback function` download also now checks `response.ok` and fails with `LAMBDA_CODE_DOWNLOAD_FAILED`, where previously an expired presigned URL's XML error document would have been uploaded as the function code.

Network failures while reading an S3 response body occur after `send()` resolves and are therefore invisible to the SDK retry middleware. A bounded transient-network retry covering `ECONNRESET`, `EPIPE`, `ETIMEDOUT`, and aborted reads now wraps the `${s3:...}` variable read and the service state download during rollback.

The new dispatcher tests drive a real CONNECT-handling proxy server to prove traversal end to end, and it was verified that an unclosed dispatcher does not keep the CLI process alive after a command completes.