### PR TITLE
Document proxy configuration and transport corrections

### DIFF
--- a/docs/guides/credentials.md
+++ b/docs/guides/credentials.md
@@ -207,3 +207,21 @@ provider:
 It is important to understand that `deploymentRole` only affects the role CloudFormation will assume. All other interactions from the `serverless` CLI with AWS will not use that `deploymentRole`.
 
 This is why we usually recommend using the "assume role" method described above instead of `deploymentRole`.
+
+## Running behind a proxy
+
+osls routes its HTTP traffic — AWS API calls, credential resolution (including IAM Identity Center / SSO), and template, plugin registry, layer, and rollback code downloads — through the proxy configured in the standard environment variables:
+
+```bash
+export HTTPS_PROXY=http://proxy.example.com:8080
+```
+
+AWS API calls and credential resolution use the first defined of `proxy`, `HTTP_PROXY`, `http_proxy`, `HTTPS_PROXY`, or `https_proxy`. Other downloads follow standard proxy semantics: `HTTPS_PROXY` for `https` URLs, `HTTP_PROXY` for `http` URLs, and `NO_PROXY` exclusions are honored.
+
+If your proxy intercepts TLS with its own certificate authority, provide it via the `ca` or `cafile` environment variables described in the [self-signed certificate note](#quick-setup) above. The certificates apply to AWS API calls and downloads alike.
+
+AWS requests time out after 120 seconds of socket inactivity. Slow or unreliable proxy connections can be accommodated with a higher limit in milliseconds:
+
+```bash
+export AWS_CLIENT_TIMEOUT=300000
+```

--- a/docs/guides/upgrading-to-v4.md
+++ b/docs/guides/upgrading-to-v4.md
@@ -159,7 +159,9 @@ osls v3 resolved AWS credentials through AWS SDK v2, which reads `~/.aws/config`
 
 All AWS requests now go through AWS SDK v3, which changes retry, concurrency, timeout, and endpoint behavior:
 
-- **Retries.** v3 layered its own retry loop on top of AWS SDK v2's retries; v4 relies solely on the SDK v3 `standard` retry mode. `SLS_AWS_REQUEST_MAX_RETRIES` still works and sets the SDK retry count: total attempts are the value plus one (default: 4 retries, 5 attempts). Setting it to `0` now disables retries entirely, where v3 still performed SDK-level retries. Under sustained throttling, commands give up sooner than v3 did.
+- **Retries.** v3 layered a general retry loop on top of AWS SDK v2's retries; v4 uses the SDK v3 `standard` retry mode per request, plus targeted framework-level retries where the SDK budget is not enough: sustained throttling during CloudFormation polling and artifact uploads, and transient network failures while reading S3 response bodies. `SLS_AWS_REQUEST_MAX_RETRIES` still works and sets the SDK retry count: total attempts are the value plus one (default: 4 retries, 5 attempts). Setting it to `0` now disables the SDK retries entirely, where v3 still performed SDK-level retries.
+- **Error codes.** AWS failures no longer carry v3's uniform `AWS_<SERVICE>_<METHOD>_<CODE>` error codes. Commands now report context-specific codes or, for unhandled AWS service errors, a code synthesized from the AWS error name (for example `AWS_ACCESS_DENIED`). Update CI scripts or tooling that match on error codes in CLI output.
+- **Proxy and certificates.** The proxy (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) and custom certificate authority (`ca`, `cafile`) environment variables now apply to all HTTP requests osls makes — including template, plugin registry, layer, and rollback code downloads — where v3 honored them only for AWS calls. See [Running behind a proxy](./credentials.md#running-behind-a-proxy).
 - **Concurrency.** v3 funneled all AWS requests through a global queue of 2 concurrent requests; v4 has no global cap, so commands issue more requests in parallel and complete faster. Flow-specific limits such as `SLS_MAX_CONCURRENT_ARTIFACTS_UPLOADS` still apply.
 - **Timeouts.** `AWS_CLIENT_TIMEOUT` (milliseconds) is enforced as a socket inactivity timeout and defaults to 120 seconds.
 - **S3 checksums.** Uploads send CRC32 flexible checksums instead of `Content-MD5`. If you deploy to an S3-compatible endpoint that rejects them, set `AWS_REQUEST_CHECKSUM_CALCULATION=WHEN_REQUIRED`.
@@ -182,7 +184,7 @@ See [Custom commands](./plugins/custom-commands.md#command-options).
 
 osls no longer bundles AWS SDK for JavaScript v2. All built-in AWS calls use **AWS SDK v3** (`@aws-sdk/client-*` packages). For most users this is transparent.
 
-Plugin authors are affected if they used the internal v2 surfaces, which are **removed** in v4 (calling them now throws):
+Plugin authors are affected if they used the internal v2 surfaces, which are **removed** in v4 (calling them now throws a `ServerlessError` with code `AWS_SDK_V2_SURFACE_REMOVED`):
 
 - `provider.request(service, method, params, options)` — the generic v2 API proxy
 - `provider.sdk` — the raw `aws-sdk` v2 module


### PR DESCRIPTION
The upgrading guide's retry bullet became inaccurate when the transport resilience work landed after it: it claimed v4 relies solely on the SDK `standard` retry mode and gives up sooner than v3 under sustained throttling, but v4 now also carries targeted framework-level retries around CloudFormation polling, artifact uploads, and S3 body reads. The bullet now describes the layered behavior accurately while keeping the unchanged `SLS_AWS_REQUEST_MAX_RETRIES` semantics, including zero disabling the SDK retries.

The guide gains two further transport bullets. AWS failures no longer carry v3's uniform `AWS_<SERVICE>_<METHOD>_<CODE>` error codes, and instead report context-specific codes or a code synthesized from the AWS error name such as `AWS_ACCESS_DENIED`, which matters to anyone whose CI scripts match on error codes in CLI output. The proxy and custom certificate authority environment variables now apply to all HTTP requests osls makes rather than only AWS calls, covering template, plugin registry, layer, and rollback code downloads. The plugin-author section also names the `AWS_SDK_V2_SURFACE_REMOVED` error code thrown by the removed v2 surfaces.

The proxy environment variables were not documented anywhere in the user docs, despite being load-bearing for everyone deploying from behind a corporate proxy. The credentials guide gains a "Running behind a proxy" section covering the variables and their precedence for AWS calls versus downloads, `NO_PROXY` support, the interaction with the existing `ca` and `cafile` certificate variables for TLS-intercepting proxies, and raising `AWS_CLIENT_TIMEOUT` for slow proxy connections.