### PR TITLE
Harden YAML parser unsafe key assignment

### DIFF
--- a/lib/classes/yaml-parser.js
+++ b/lib/classes/yaml-parser.js
@@ -5,7 +5,7 @@ const { pathToFileURL } = require('url');
 const yaml = require('js-yaml');
 const isPlainObject = require('type/plain-object/is');
 const ServerlessError = require('../serverless-error');
-const { isUnsafePropertyKey } = require('../utils/object-path');
+const { safeSet } = require('../utils/safe-object');
 
 let refParserModulePromise;
 
@@ -73,20 +73,6 @@ const cloneValue = (value) => {
 
 const isCircularYamlReferenceError = (error) =>
   error && error.code === 'INVALID_YAML_CIRCULAR_REFERENCE';
-
-// Preserve unsafe keys as own data properties instead of invoking prototype setters.
-const safeAssign = (target, key, value) => {
-  if (isUnsafePropertyKey(key)) {
-    Object.defineProperty(target, key, {
-      value,
-      writable: true,
-      enumerable: true,
-      configurable: true,
-    });
-  } else {
-    target[key] = value;
-  }
-};
 
 const readExternalDocument = async (documentUrl) => {
   const { FileResolver, HTTPResolver } = await getRefParserModule();
@@ -227,7 +213,7 @@ const materializeTarget = async (target, documentUrl, state, absoluteReference) 
             resolveLocalRefs: true,
             state,
           });
-          safeAssign(resolvedTarget, key, resolvedChild);
+          safeSet(resolvedTarget, key, resolvedChild);
         }
 
         return resolvedTarget;
@@ -302,7 +288,7 @@ const materializeValue = async (value, context) => {
 
       for (const [key, childValue] of Object.entries(value)) {
         const resolvedChild = await materializeValue(childValue, context);
-        safeAssign(resolvedValue, key, resolvedChild);
+        safeSet(resolvedValue, key, resolvedChild);
       }
 
       return resolvedValue;

--- a/test/unit/lib/classes/yaml-parser.test.js
+++ b/test/unit/lib/classes/yaml-parser.test.js
@@ -435,6 +435,78 @@ describe('YamlParser', () => {
       expect({}.polluted).to.equal(undefined);
     });
 
+    it('materializes __proto__ with pollution-robust property descriptors', async () => {
+      const copyDescriptor = (descriptor) =>
+        descriptor && Object.assign(Object.create(null), descriptor);
+      const defineDataProperty = (object, key, value) => {
+        Object.defineProperty(
+          object,
+          key,
+          Object.assign(Object.create(null), {
+            value,
+            writable: true,
+            enumerable: true,
+            configurable: true,
+          })
+        );
+      };
+      const definePollutingAccessor = (key) => {
+        Object.defineProperty(
+          Object.prototype,
+          key,
+          Object.assign(Object.create(null), {
+            get() {
+              throw new Error(`inherited descriptor ${key} was read`);
+            },
+            configurable: true,
+          })
+        );
+      };
+      const source = { foo: 'bar' };
+      const parser = new serverless.yamlParser.constructor({
+        utils: { readFileSync: () => source },
+      });
+      const originalGetDescriptor = copyDescriptor(
+        Object.getOwnPropertyDescriptor(Object.prototype, 'get')
+      );
+      const originalSetDescriptor = copyDescriptor(
+        Object.getOwnPropertyDescriptor(Object.prototype, 'set')
+      );
+
+      defineDataProperty(source, '__proto__', { marker: 'value' });
+
+      let result;
+      try {
+        definePollutingAccessor('get');
+        definePollutingAccessor('set');
+
+        result = await parser.parse(getTmpFilePath('descriptor-pollution.yml'));
+      } finally {
+        if (originalGetDescriptor) {
+          Object.defineProperty(Object.prototype, 'get', originalGetDescriptor);
+        } else {
+          delete Object.prototype.get;
+        }
+
+        if (originalSetDescriptor) {
+          Object.defineProperty(Object.prototype, 'set', originalSetDescriptor);
+        } else {
+          delete Object.prototype.set;
+        }
+      }
+
+      expect(result.foo).to.equal('bar');
+      expect(Object.getPrototypeOf(result)).to.equal(Object.prototype);
+      expect(Object.getOwnPropertyDescriptor(result, '__proto__')).to.deep.equal({
+        value: { marker: 'value' },
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      expect(result.marker).to.equal(undefined);
+      expect({}.marker).to.equal(undefined);
+    });
+
     it('does not resolve JSON Pointers that target inherited prototype members (#/constructor)', async () => {
       const tmpDirPath = getTmpDirPath();
       const refPath = path.join(tmpDirPath, 'ref.yml');


### PR DESCRIPTION
Replace the YAML parser local unsafe-key assignment helper with shared hardened safeSet. Add parser regression coverage for polluted descriptor get/set accessors.