### PR TITLE
Standardize temp file random suffixes

### DIFF
--- a/lib/classes/utils.js
+++ b/lib/classes/utils.js
@@ -30,7 +30,7 @@ class Utils {
     const dirPath = path.join(
       os.tmpdir(),
       'tmpdirs-serverless',
-      crypto.randomBytes(8).toString('hex')
+      crypto.randomBytes(12).toString('hex')
     );
     fs.mkdirSync(dirPath, { recursive: true });
     return dirPath;

--- a/lib/plugins/package/lib/zip-service.js
+++ b/lib/plugins/package/lib/zip-service.js
@@ -378,7 +378,7 @@ async function excludeNodeDevDependencies(serviceDir) {
 
   // the files where we'll write the dependencies into
   const tmpDir = os.tmpdir();
-  const randHash = crypto.randomBytes(8).toString('hex');
+  const randHash = crypto.randomBytes(12).toString('hex');
   const nodeDevDepFile = path.join(tmpDir, `node-dependencies-${randHash}-dev`);
   const nodeProdDepFile = path.join(tmpDir, `node-dependencies-${randHash}-prod`);
 

--- a/lib/utils/extract-zip.js
+++ b/lib/utils/extract-zip.js
@@ -146,7 +146,7 @@ const openTempFile = async (parentPath, mode) => {
   for (let attempt = 0; attempt < 10; attempt += 1) {
     const tempPath = path.join(
       parentPath,
-      `.sls-extract-${process.pid}-${crypto.randomBytes(8).toString('hex')}.tmp`
+      `.sls-extract-${crypto.randomBytes(12).toString('hex')}.tmp`
     );
 
     try {

--- a/lib/utils/fs/get-tmp-dir-path.js
+++ b/lib/utils/fs/get-tmp-dir-path.js
@@ -7,11 +7,11 @@ const crypto = require('crypto');
 const tmpDirCommonPath = path.join(
   os.tmpdir(),
   'tmpdirs-serverless',
-  crypto.randomBytes(2).toString('hex')
+  crypto.randomBytes(12).toString('hex')
 );
 
 function getTmpDirPath() {
-  return path.join(tmpDirCommonPath, crypto.randomBytes(8).toString('hex'));
+  return path.join(tmpDirCommonPath, crypto.randomBytes(12).toString('hex'));
 }
 
 module.exports = getTmpDirPath;

--- a/lib/utils/fs/safe-move-file.js
+++ b/lib/utils/fs/safe-move-file.js
@@ -41,7 +41,7 @@ const generateTemporaryPathOnDestinationDevice = (destPath) => {
   const dirName = path.dirname(destPath);
   // Generate a unique destination file name to get the file onto the
   // destination filesystem
-  const tempName = path.basename(destPath) + crypto.randomBytes(8).toString('hex');
+  const tempName = path.basename(destPath) + crypto.randomBytes(12).toString('hex');
   return path.join(dirName, tempName);
 };
 

--- a/lib/utils/resolve-process-tmp-dir.js
+++ b/lib/utils/resolve-process-tmp-dir.js
@@ -13,7 +13,7 @@ let processTmpDirPromise;
 module.exports = async () => {
   if (!processTmpDirPromise) {
     processTmpDirPromise = fsp
-      .mkdtemp(path.join(os.tmpdir(), `${tmpDirPrefix}${crypto.randomBytes(2).toString('hex')}-`))
+      .mkdtemp(path.join(os.tmpdir(), `${tmpDirPrefix}${crypto.randomBytes(12).toString('hex')}-`))
       .then((tmpDir) => {
         process.once('exit', () => {
           try {

--- a/test/lib/process-tmp-dir.js
+++ b/test/lib/process-tmp-dir.js
@@ -15,7 +15,7 @@ try {
 }
 
 module.exports = (function self() {
-  const processTmpDir = path.join(serverlessTmpDir, crypto.randomBytes(2).toString('hex'));
+  const processTmpDir = path.join(serverlessTmpDir, crypto.randomBytes(12).toString('hex'));
   try {
     mkdirSync(processTmpDir);
   } catch (error) {

--- a/test/lib/provision-tmp-dir.js
+++ b/test/lib/provision-tmp-dir.js
@@ -7,7 +7,7 @@ const processTmpDir = require('./process-tmp-dir');
 
 module.exports = () =>
   new Promise((resolve) => {
-    const tmpDirName = path.join(processTmpDir, crypto.randomBytes(3).toString('hex'));
+    const tmpDirName = path.join(processTmpDir, crypto.randomBytes(12).toString('hex'));
     resolve(
       mkdir(tmpDirName).then(
         () => tmpDirName,

--- a/test/unit/lib/classes/utils.test.js
+++ b/test/unit/lib/classes/utils.test.js
@@ -21,7 +21,7 @@ describe('Utils', () => {
     it('should create a scoped tmp directory', () => {
       const dirPath = serverless.utils.getTmpDirPath();
       const stats = fs.statSync(dirPath);
-      expect(dirPath).to.include('tmpdirs-serverless');
+      expect(dirPath).to.match(/tmpdirs-serverless[/\\][0-9a-f]{24}$/);
       expect(stats.isDirectory()).to.equal(true);
     });
   });

--- a/test/unit/lib/plugins/package/lib/zip-service.test.js
+++ b/test/unit/lib/plugins/package/lib/zip-service.test.js
@@ -298,10 +298,10 @@ describe('zipService', () => {
             .getCalls()
             .map((call) => path.basename(call.args[0]));
           expect(
-            openedFiles.some((fileName) => /^node-dependencies-.+-dev$/.test(fileName))
+            openedFiles.some((fileName) => /^node-dependencies-[0-9a-f]{24}-dev$/.test(fileName))
           ).to.equal(true);
           expect(
-            openedFiles.some((fileName) => /^node-dependencies-.+-prod$/.test(fileName))
+            openedFiles.some((fileName) => /^node-dependencies-[0-9a-f]{24}-prod$/.test(fileName))
           ).to.equal(true);
           expect(closeFileStub).to.have.been.calledTwice;
         });

--- a/test/unit/lib/utils/ensure-artifact.test.js
+++ b/test/unit/lib/utils/ensure-artifact.test.js
@@ -10,7 +10,7 @@ const crypto = require('crypto');
 const { pathExists } = require('../../../utils/fs');
 
 describe('#ensureArtifact', () => {
-  const testArtifactName = `test-${crypto.randomBytes(2).toString('hex')}`;
+  const testArtifactName = `test-${crypto.randomBytes(12).toString('hex')}`;
 
   let testArtifactPath;
   let invokedCount = 0;

--- a/test/unit/lib/utils/ensure-exists.test.js
+++ b/test/unit/lib/utils/ensure-exists.test.js
@@ -16,14 +16,14 @@ describe('test/unit/lib/utils/ensureExists.test.js', () => {
   const testCacheDir = getTmpDirPath();
 
   it('Should call generate if file missing', async () => {
-    const testFileName = `test-${crypto.randomBytes(2).toString('hex')}`;
+    const testFileName = `test-${crypto.randomBytes(12).toString('hex')}`;
     const generateStub = sinon.stub().resolves();
     await ensureExists(path.resolve(testCacheDir, testFileName), generateStub);
     expect(generateStub.calledOnce).to.be.true;
   });
 
   it('Should not call generate if file exists', async () => {
-    const testFileName = `test-${crypto.randomBytes(2).toString('hex')}`;
+    const testFileName = `test-${crypto.randomBytes(12).toString('hex')}`;
     await fsp.mkdir(testCacheDir, { recursive: true });
     await fsp.writeFile(path.resolve(testCacheDir, testFileName), '');
     const generateStub = sinon.stub().resolves();
@@ -32,7 +32,7 @@ describe('test/unit/lib/utils/ensureExists.test.js', () => {
   });
 
   it('Should create nested cache directories before calling generate', async () => {
-    const testFileName = `test-${crypto.randomBytes(2).toString('hex')}`;
+    const testFileName = `test-${crypto.randomBytes(12).toString('hex')}`;
     const testFilePath = path.resolve(testCacheDir, 'nested', 'cache', testFileName);
     const generateStub = sinon
       .stub()

--- a/test/unit/lib/utils/extract-zip.test.js
+++ b/test/unit/lib/utils/extract-zip.test.js
@@ -269,11 +269,13 @@ describe('extractZip', () => {
 
   it('closes streamed temp file handles before renaming', async () => {
     const closeSpy = sinon.spy();
+    let openedPath;
     const fsStub = {
       ...fs,
       promises: {
         ...fs.promises,
         async open(...args) {
+          openedPath = args[0];
           const handle = await fs.promises.open(...args);
           return {
             chmod: (...chmodArgs) => handle.chmod(...chmodArgs),
@@ -297,6 +299,7 @@ describe('extractZip', () => {
     await extractZipWithFsStub(zipBuffer, tmpDir);
 
     expect(closeSpy.calledOnce).to.equal(true);
+    expect(path.basename(openedPath)).to.match(/^\.sls-extract-[0-9a-f]{24}\.tmp$/);
     expect(await fsp.readFile(path.join(tmpDir, 'file.txt'), 'utf8')).to.equal('fixture');
   });
 

--- a/test/unit/lib/utils/fs/get-tmp-dir-path.test.js
+++ b/test/unit/lib/utils/fs/get-tmp-dir-path.test.js
@@ -6,6 +6,6 @@ const getTmpDirPath = require('../../../../../lib/utils/fs/get-tmp-dir-path');
 describe('#getTmpDirPath()', () => {
   it('should return a scoped tmp dir path', () => {
     const tmpDirPath = getTmpDirPath();
-    expect(tmpDirPath).to.match(/tmpdirs-serverless/);
+    expect(tmpDirPath).to.match(/tmpdirs-serverless[/\\][0-9a-f]{24}[/\\][0-9a-f]{24}$/);
   });
 });

--- a/test/unit/lib/utils/resolve-process-tmp-dir.test.js
+++ b/test/unit/lib/utils/resolve-process-tmp-dir.test.js
@@ -10,6 +10,8 @@ const sinon = require('sinon');
 const { expect } = require('chai');
 
 describe('test/unit/lib/utils/resolve-process-tmp-dir.test.js', () => {
+  const randomHex = 'abcd'.repeat(6);
+
   afterEach(() => {
     sinon.restore();
   });
@@ -23,7 +25,7 @@ describe('test/unit/lib/utils/resolve-process-tmp-dir.test.js', () => {
     const secondTmpDir = await resolveProcessTmpDir();
 
     expect(secondTmpDir).to.equal(firstTmpDir);
-    expect(path.basename(firstTmpDir)).to.match(/^node-process-[0-9a-f]{4}-/);
+    expect(path.basename(firstTmpDir)).to.match(/^node-process-[0-9a-f]{24}-/);
     expect((await fsp.stat(firstTmpDir)).isDirectory()).to.equal(true);
 
     await fsp.rm(firstTmpDir, { recursive: true, force: true });
@@ -31,7 +33,7 @@ describe('test/unit/lib/utils/resolve-process-tmp-dir.test.js', () => {
 
   it('retries after a failed temp directory creation', async () => {
     const error = new Error('temporary failure');
-    const tmpDir = path.join(os.tmpdir(), 'node-process-abcd-retry');
+    const tmpDir = path.join(os.tmpdir(), `node-process-${randomHex}-retry`);
 
     const fsStub = {
       promises: {
@@ -46,7 +48,7 @@ describe('test/unit/lib/utils/resolve-process-tmp-dir.test.js', () => {
     const resolveProcessTmpDir = proxyquire('../../../../lib/utils/resolve-process-tmp-dir', {
       fs: fsStub,
       crypto: {
-        randomBytes: () => Buffer.from('abcd', 'hex'),
+        randomBytes: () => Buffer.from(randomHex, 'hex'),
       },
     });
 
@@ -56,7 +58,7 @@ describe('test/unit/lib/utils/resolve-process-tmp-dir.test.js', () => {
   });
 
   it('memoizes the resolved temp dir for subsequent calls', async () => {
-    const tmpDir = path.join(os.tmpdir(), 'node-process-abcd-memoized');
+    const tmpDir = path.join(os.tmpdir(), `node-process-${randomHex}-memoized`);
     const fsStub = {
       promises: { mkdtemp: sinon.stub().resolves(tmpDir) },
       rmSync: sinon.stub(),
@@ -65,7 +67,7 @@ describe('test/unit/lib/utils/resolve-process-tmp-dir.test.js', () => {
 
     const resolveProcessTmpDir = proxyquire('../../../../lib/utils/resolve-process-tmp-dir', {
       fs: fsStub,
-      crypto: { randomBytes: () => Buffer.from('abcd', 'hex') },
+      crypto: { randomBytes: () => Buffer.from(randomHex, 'hex') },
     });
 
     expect(await resolveProcessTmpDir()).to.equal(tmpDir);
@@ -74,7 +76,7 @@ describe('test/unit/lib/utils/resolve-process-tmp-dir.test.js', () => {
   });
 
   it('registers an exit cleanup for the resolved temp dir', async () => {
-    const tmpDir = path.join(os.tmpdir(), 'node-process-abcd-cleanup');
+    const tmpDir = path.join(os.tmpdir(), `node-process-${randomHex}-cleanup`);
     const fsStub = {
       promises: { mkdtemp: sinon.stub().resolves(tmpDir) },
       rmSync: sinon.stub(),
@@ -83,7 +85,7 @@ describe('test/unit/lib/utils/resolve-process-tmp-dir.test.js', () => {
 
     const resolveProcessTmpDir = proxyquire('../../../../lib/utils/resolve-process-tmp-dir', {
       fs: fsStub,
-      crypto: { randomBytes: () => Buffer.from('abcd', 'hex') },
+      crypto: { randomBytes: () => Buffer.from(randomHex, 'hex') },
     });
 
     await resolveProcessTmpDir();
@@ -97,7 +99,7 @@ describe('test/unit/lib/utils/resolve-process-tmp-dir.test.js', () => {
   });
 
   it('swallows rmSync errors during exit cleanup', async () => {
-    const tmpDir = path.join(os.tmpdir(), 'node-process-abcd-cleanup-error');
+    const tmpDir = path.join(os.tmpdir(), `node-process-${randomHex}-cleanup-error`);
     const fsStub = {
       promises: { mkdtemp: sinon.stub().resolves(tmpDir) },
       rmSync: sinon.stub().throws(new Error('cleanup failed')),
@@ -106,7 +108,7 @@ describe('test/unit/lib/utils/resolve-process-tmp-dir.test.js', () => {
 
     const resolveProcessTmpDir = proxyquire('../../../../lib/utils/resolve-process-tmp-dir', {
       fs: fsStub,
-      crypto: { randomBytes: () => Buffer.from('abcd', 'hex') },
+      crypto: { randomBytes: () => Buffer.from(randomHex, 'hex') },
     });
 
     await resolveProcessTmpDir();

--- a/test/unit/lib/utils/serverless-utils/download.test.js
+++ b/test/unit/lib/utils/serverless-utils/download.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const http = require('http');
+const crypto = require('crypto');
 const os = require('os');
 const path = require('path');
 const fsp = require('fs').promises;
@@ -29,8 +30,10 @@ describe('serverless-utils/download', () => {
     nestedZip.addFile('template-main/serverless.yml', Buffer.from('service: fixture\n'));
     nestedZipBuffer = nestedZip.toBuffer();
 
-    traversalFileName = `serverless-download-${Date.now()}-evil.txt`;
-    unsafeDispositionFileName = `serverless-download-${Date.now()}-unsafe.txt`;
+    traversalFileName = `serverless-download-${crypto.randomBytes(12).toString('hex')}-evil.txt`;
+    unsafeDispositionFileName = `serverless-download-${crypto
+      .randomBytes(12)
+      .toString('hex')}-unsafe.txt`;
     const traversalZip = new AdmZip();
     traversalZip.addFile(`xx/${traversalFileName}`, Buffer.from('evil'));
     traversalZipBuffer = traversalZip.toBuffer();

--- a/test/unit/lib/utils/spawn.test.js
+++ b/test/unit/lib/utils/spawn.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs').promises;
+const crypto = require('crypto');
 const os = require('os');
 const path = require('path');
 const { EventEmitter } = require('events');
@@ -75,7 +76,7 @@ const assertRedaction = async ({ args, redacted, visible = [] }) => {
 describe('spawn', () => {
   it('executes PATH shims through cross-platform resolution', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spawn-shim-'));
-    const commandName = `spawn-shim-${process.pid}-${Date.now()}`;
+    const commandName = `spawn-shim-${crypto.randomBytes(12).toString('hex')}`;
     const commandPath = path.join(
       tempDir,
       process.platform === 'win32' ? `${commandName}.cmd` : commandName

--- a/test/utils/fs.js
+++ b/test/utils/fs.js
@@ -10,7 +10,7 @@ const JSZip = require('jszip');
 const tmpDirCommonPath = require('../lib/process-tmp-dir');
 
 function getTmpDirPath() {
-  return path.join(tmpDirCommonPath, crypto.randomBytes(8).toString('hex'));
+  return path.join(tmpDirCommonPath, crypto.randomBytes(12).toString('hex'));
 }
 
 function getTmpFilePath(fileName) {


### PR DESCRIPTION
This backports the 4.x temp suffix standardization to the 3.x branch by using twelve random bytes encoded as hexadecimal for generated temporary file and directory names. It also updates the remaining test-only generated filenames for the spawn shim and download fixtures to use the same suffix format.