### PR TITLE
Add YAML external ref policies

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,7 @@
 
 - [Overview](./guides/plugins/README.md)
 - [Creating Plugins](./guides/plugins/creating-plugins.md)
+  - [Parsing YAML files](./guides/plugins/creating-plugins.md#parsing-yaml-files)
   - [CLI Output](./guides/plugins/cli-output.md)
   - [Custom Commands](./guides/plugins/custom-commands.md)
   - [Custom Variables](./guides/plugins/custom-variables.md)

--- a/docs/guides/plugins/creating-plugins.md
+++ b/docs/guides/plugins/creating-plugins.md
@@ -140,6 +140,45 @@ module.exports = MyPlugin;
 
 **Note:** configuration values are only resolved _after_ plugins are initialized. Do not try to read configuration in the plugin constructor, as variables aren't resolved yet. Read configuration in lifecycle events only.
 
+## Parsing YAML files
+
+Plugins can parse additional YAML files with `serverless.yamlParser.parse(filePath, options)`.
+This helper supports JSON Schema style `$ref` entries in the parsed YAML document.
+
+For v3 compatibility, external `$ref` loading keeps the legacy defaults: file references
+can read outside the parsed file's directory, and HTTP references can reach local or
+private hosts. Plugins that parse untrusted or user-controlled YAML should opt in to
+stricter external reference policies:
+
+```javascript
+const schema = await this.serverless.yamlParser.parse('schema.yml', {
+  externalRefs: {
+    file: {
+      allowedRoots: ['.'],
+    },
+    http: {
+      allowUnsafeUrls: false,
+      allowedUnsafeHosts: ['schemas.example.com'],
+    },
+  },
+});
+```
+
+`externalRefs.file.allowedRoots` limits file `$ref` targets to the listed directories.
+Relative roots are resolved from the parsed YAML file's directory. `file://` roots are
+also supported. Symlink escapes outside an allowed root are blocked.
+
+`externalRefs.http.allowUnsafeUrls: false` blocks HTTP `$ref` targets that use local,
+private, link-local, multicast, reserved, or internal hostnames and addresses. Redirects
+are checked on every hop. `externalRefs.http.allowedUnsafeHosts` can allow a specific
+unsafe host when a plugin intentionally needs it; prefer exact `host:port` entries.
+HTTP policy does not restrict file `$ref` entries found inside remote YAML documents;
+set `externalRefs.file.allowedRoots` too when parsing untrusted remote YAML.
+
+The public `externalRefs.http` options are limited to `allowUnsafeUrls` and
+`allowedUnsafeHosts`. Redirect and timeout limits use osls defaults and are not public
+parser options.
+
 ## Constructor-injected utilities
 
 osls may pass utility helpers as the third constructor argument:

--- a/lib/classes/yaml-parser.js
+++ b/lib/classes/yaml-parser.js
@@ -5,27 +5,12 @@ const { pathToFileURL } = require('url');
 const yaml = require('js-yaml');
 const isPlainObject = require('type/plain-object/is');
 const ServerlessError = require('../serverless-error');
+const { isExternalRefAccessDeniedError } = require('./yaml-parser/external-ref-errors');
+const { normalizeExternalRefOptions } = require('./yaml-parser/external-ref-options');
+const { readExternalDocument } = require('./yaml-parser/external-ref-reader');
 const { safeSet } = require('../utils/safe-object');
 
-let refParserModulePromise;
-
-const getRefParserModule = () => {
-  if (!refParserModulePromise) {
-    refParserModulePromise = import('@apidevtools/json-schema-ref-parser');
-  }
-
-  return refParserModulePromise;
-};
-
 const getDocumentUrl = (yamlFilePath) => pathToFileURL(path.resolve(yamlFilePath)).href;
-
-const getFileExtension = (documentUrl) => {
-  try {
-    return path.extname(new URL(documentUrl).pathname).toLowerCase();
-  } catch {
-    return path.extname(documentUrl).toLowerCase();
-  }
-};
 
 const splitReference = (absoluteReference) => {
   const hashIndex = absoluteReference.indexOf('#');
@@ -74,33 +59,11 @@ const cloneValue = (value) => {
 const isCircularYamlReferenceError = (error) =>
   error && error.code === 'INVALID_YAML_CIRCULAR_REFERENCE';
 
-const readExternalDocument = async (documentUrl) => {
-  const { FileResolver, HTTPResolver } = await getRefParserModule();
-  // Preserve historical json-refs behavior: external HTTP(S) refs, including
-  // localhost/private-network targets, remain allowed for this compatibility API.
-  const httpResolver = { ...HTTPResolver, safeUrlResolver: false };
-  const fileInfo = {
-    url: documentUrl,
-    extension: getFileExtension(documentUrl),
-    hash: '',
-  };
-
-  if (FileResolver.canRead(fileInfo)) {
-    return FileResolver.read(fileInfo);
-  }
-
-  if (httpResolver.canRead(fileInfo)) {
-    return httpResolver.read(fileInfo);
-  }
-
-  throw new Error(`Unsupported $ref protocol: ${documentUrl}`);
-};
-
 const loadExternalDocument = (documentUrl, state) => {
   if (!state.documents.has(documentUrl)) {
     state.documents.set(
       documentUrl,
-      readExternalDocument(documentUrl).then((document) =>
+      readExternalDocument(documentUrl, state.externalRefs).then((document) =>
         yaml.load(Buffer.isBuffer(document) ? document.toString('utf8') : String(document))
       )
     );
@@ -141,6 +104,7 @@ const materializeRef = async (refObject, context) => {
     return resolvedTarget;
   } catch (error) {
     if (isCircularYamlReferenceError(error)) throw error;
+    if (isExternalRefAccessDeniedError(error)) throw error;
     return cloneValue(refObject);
   } finally {
     context.state.activeReferences.delete(absoluteReference);
@@ -308,8 +272,9 @@ class YamlParser {
     this.serverless = serverless;
   }
 
-  async parse(yamlFilePath) {
+  async parse(yamlFilePath, options) {
     const root = this.serverless.utils.readFileSync(yamlFilePath);
+    const externalRefs = await normalizeExternalRefOptions(yamlFilePath, options);
 
     return materializeValue(root, {
       documentUrl: getDocumentUrl(yamlFilePath),
@@ -320,6 +285,7 @@ class YamlParser {
         references: new Map(),
         materialized: new WeakMap(),
         inProgress: new WeakSet(),
+        externalRefs,
       },
     });
   }

--- a/lib/classes/yaml-parser/external-ref-errors.js
+++ b/lib/classes/yaml-parser/external-ref-errors.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const ServerlessError = require('../../serverless-error');
+
+const YAML_REF_ACCESS_DENIED = 'YAML_REF_ACCESS_DENIED';
+const YAML_REF_OPTIONS_ERROR = 'YAML_REF_OPTIONS_ERROR';
+
+const isExternalRefAccessDeniedError = (error) => error && error.code === YAML_REF_ACCESS_DENIED;
+
+const createExternalRefAccessDeniedError = (message) =>
+  new ServerlessError(message, YAML_REF_ACCESS_DENIED);
+
+const denyExternalRef = (message) => {
+  throw createExternalRefAccessDeniedError(message);
+};
+
+const getExternalRefAccessDeniedError = (error, seenErrors = new Set()) => {
+  if (error == null || typeof error !== 'object') return null;
+  if (seenErrors.has(error)) return null;
+
+  seenErrors.add(error);
+
+  if (isExternalRefAccessDeniedError(error)) return error;
+
+  const causeError = getExternalRefAccessDeniedError(error.cause, seenErrors);
+  if (causeError) return causeError;
+
+  if (Array.isArray(error.errors)) {
+    for (const childError of error.errors) {
+      const accessDeniedError = getExternalRefAccessDeniedError(childError, seenErrors);
+      if (accessDeniedError) return accessDeniedError;
+    }
+  }
+
+  return null;
+};
+
+const throwOptionsError = (message) => {
+  throw new ServerlessError(message, YAML_REF_OPTIONS_ERROR);
+};
+
+module.exports = {
+  createExternalRefAccessDeniedError,
+  denyExternalRef,
+  getExternalRefAccessDeniedError,
+  isExternalRefAccessDeniedError,
+  throwOptionsError,
+  YAML_REF_ACCESS_DENIED,
+  YAML_REF_OPTIONS_ERROR,
+};

--- a/lib/classes/yaml-parser/external-ref-options.js
+++ b/lib/classes/yaml-parser/external-ref-options.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const path = require('path');
+const { throwOptionsError } = require('./external-ref-errors');
+const { normalizeFileRefOptions } = require('./file-ref-policy');
+const { assertKnownOptions, assertOptionsObject } = require('./option-validation');
+
+const normalizeStringArrayOption = (value, optionName) => {
+  if (value == null) return [];
+
+  const values = Array.isArray(value) ? value : [value];
+
+  return values.map((item) => {
+    if (typeof item !== 'string') {
+      throwOptionsError(`YAML parser option ${optionName} must contain only strings.`);
+    }
+
+    return item;
+  });
+};
+
+const normalizeAllowedUnsafeHost = (host) => {
+  const trimmedHost = host.trim().toLowerCase();
+
+  if (!trimmedHost) return trimmedHost;
+  if (!trimmedHost.includes('://') && !trimmedHost.startsWith('//')) return trimmedHost;
+
+  try {
+    return new URL(trimmedHost.startsWith('//') ? `http:${trimmedHost}` : trimmedHost).host;
+  } catch {
+    return trimmedHost;
+  }
+};
+
+const normalizeHttpRefOptions = (options = {}) => {
+  assertOptionsObject(options, 'externalRefs.http');
+  assertKnownOptions(options, 'externalRefs.http', ['allowUnsafeUrls', 'allowedUnsafeHosts']);
+
+  if (options.allowUnsafeUrls != null && typeof options.allowUnsafeUrls !== 'boolean') {
+    throwOptionsError('YAML parser option externalRefs.http.allowUnsafeUrls must be a boolean.');
+  }
+
+  return {
+    allowUnsafeUrls: options.allowUnsafeUrls == null ? true : options.allowUnsafeUrls,
+    allowedUnsafeHosts: normalizeStringArrayOption(
+      options.allowedUnsafeHosts,
+      'externalRefs.http.allowedUnsafeHosts'
+    )
+      .map(normalizeAllowedUnsafeHost)
+      .filter(Boolean),
+  };
+};
+
+const normalizeExternalRefOptions = async (yamlFilePath, options = {}) => {
+  assertOptionsObject(options, 'options');
+  assertKnownOptions(options, 'options', ['externalRefs']);
+
+  const documentDir = path.dirname(path.resolve(yamlFilePath));
+  const externalRefs = options.externalRefs == null ? {} : options.externalRefs;
+
+  assertOptionsObject(externalRefs, 'externalRefs');
+  assertKnownOptions(externalRefs, 'externalRefs', ['file', 'http']);
+
+  return {
+    file: await normalizeFileRefOptions(
+      documentDir,
+      externalRefs.file == null ? { allowedRoots: null } : externalRefs.file
+    ),
+    http: normalizeHttpRefOptions(externalRefs.http == null ? undefined : externalRefs.http),
+  };
+};
+
+module.exports = {
+  normalizeExternalRefOptions,
+  normalizeHttpRefOptions,
+};

--- a/lib/classes/yaml-parser/external-ref-reader.js
+++ b/lib/classes/yaml-parser/external-ref-reader.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const path = require('path');
+const { assertFileRefAllowed } = require('./file-ref-policy');
+const { readHttpRef } = require('./http-ref-reader');
+
+let refParserModulePromise;
+
+const getRefParserModule = () => {
+  if (!refParserModulePromise) {
+    refParserModulePromise = import('@apidevtools/json-schema-ref-parser');
+  }
+
+  return refParserModulePromise;
+};
+
+const getFileExtension = (documentUrl) => {
+  try {
+    return path.extname(new URL(documentUrl).pathname).toLowerCase();
+  } catch {
+    return path.extname(documentUrl).toLowerCase();
+  }
+};
+
+const getFileInfo = (documentUrl) => ({
+  url: documentUrl,
+  extension: getFileExtension(documentUrl),
+  hash: '',
+});
+
+const readExternalDocument = async (documentUrl, externalRefs) => {
+  const { FileResolver, HTTPResolver } = await getRefParserModule();
+  const fileInfo = getFileInfo(documentUrl);
+
+  if (FileResolver.canRead(fileInfo)) {
+    await assertFileRefAllowed(documentUrl, externalRefs.file);
+    return FileResolver.read(fileInfo);
+  }
+
+  const httpResolver = { ...HTTPResolver, safeUrlResolver: false };
+
+  if (httpResolver.canRead(fileInfo)) {
+    return readHttpRef(documentUrl, fileInfo, HTTPResolver, externalRefs.http);
+  }
+
+  throw new Error(`Unsupported $ref protocol: ${documentUrl}`);
+};
+
+module.exports = {
+  readExternalDocument,
+};

--- a/lib/classes/yaml-parser/file-ref-policy.js
+++ b/lib/classes/yaml-parser/file-ref-policy.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const fsp = require('fs').promises;
+const path = require('path');
+const { fileURLToPath } = require('url');
+const { denyExternalRef, throwOptionsError } = require('./external-ref-errors');
+const { assertKnownOptions, assertOptionsObject } = require('./option-validation');
+
+const realpathIfExists = async (filePath) => {
+  try {
+    return await fsp.realpath(filePath);
+  } catch (error) {
+    if (error.code === 'ENOENT' || error.code === 'ENOTDIR') return filePath;
+    throw error;
+  }
+};
+
+const isPathInside = (rootPath, candidatePath) => {
+  const relativePath = path.relative(rootPath, candidatePath);
+  return (
+    relativePath === '' ||
+    (Boolean(relativePath) && !relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+  );
+};
+
+const normalizeAllowedRoot = async (documentDir, rootPath) => {
+  if (typeof rootPath !== 'string') {
+    throwOptionsError(
+      'YAML parser option externalRefs.file.allowedRoots must contain only strings.'
+    );
+  }
+
+  let absolutePath;
+  try {
+    absolutePath = rootPath.toLowerCase().startsWith('file:')
+      ? fileURLToPath(rootPath)
+      : path.resolve(documentDir, rootPath);
+  } catch {
+    throwOptionsError(
+      `YAML parser option externalRefs.file.allowedRoots contains an invalid file URL: ${rootPath}`
+    );
+  }
+
+  return {
+    path: absolutePath,
+    realpath: await realpathIfExists(absolutePath),
+  };
+};
+
+const normalizeFileRefOptions = async (documentDir, options = {}) => {
+  assertOptionsObject(options, 'externalRefs.file');
+  assertKnownOptions(options, 'externalRefs.file', ['allowedRoots']);
+
+  if (options.allowedRoots == null) return { allowedRoots: null };
+
+  const allowedRoots = Array.isArray(options.allowedRoots)
+    ? options.allowedRoots
+    : [options.allowedRoots];
+
+  return {
+    allowedRoots: await Promise.all(
+      allowedRoots.map((allowedRoot) => normalizeAllowedRoot(documentDir, allowedRoot))
+    ),
+  };
+};
+
+const getRefFilePath = (documentUrl) => {
+  try {
+    const url = new URL(documentUrl);
+    if (url.protocol === 'file:') return fileURLToPath(url);
+    return null;
+  } catch {
+    return path.resolve(documentUrl);
+  }
+};
+
+const isFileRefAllowedByPath = (candidatePath, allowedRoots, rootProperty) =>
+  allowedRoots.some((allowedRoot) => isPathInside(allowedRoot[rootProperty], candidatePath));
+
+const assertFileRefAllowed = async (documentUrl, options) => {
+  if (options.allowedRoots == null) return;
+
+  const candidatePath = getRefFilePath(documentUrl);
+  if (!candidatePath) {
+    denyExternalRef(`Blocked YAML $ref file outside allowed roots: ${documentUrl}`);
+  }
+
+  if (!isFileRefAllowedByPath(candidatePath, options.allowedRoots, 'path')) {
+    denyExternalRef(`Blocked YAML $ref file outside allowed roots: ${documentUrl}`);
+  }
+
+  const candidateRealpath = await realpathIfExists(candidatePath);
+
+  if (!isFileRefAllowedByPath(candidateRealpath, options.allowedRoots, 'realpath')) {
+    denyExternalRef(`Blocked YAML $ref file outside allowed roots: ${documentUrl}`);
+  }
+};
+
+module.exports = {
+  assertFileRefAllowed,
+  normalizeFileRefOptions,
+};

--- a/lib/classes/yaml-parser/http-ref-reader.js
+++ b/lib/classes/yaml-parser/http-ref-reader.js
@@ -1,0 +1,258 @@
+'use strict';
+
+const dns = require('dns');
+const dnsPromises = dns.promises;
+const net = require('net');
+const { Agent } = require('undici');
+const {
+  createExternalRefAccessDeniedError,
+  denyExternalRef,
+  getExternalRefAccessDeniedError,
+} = require('./external-ref-errors');
+
+const DEFAULT_HTTP_REDIRECTS = 5;
+const DEFAULT_HTTP_TIMEOUT = 60000;
+const UNSAFE_HOSTNAME_SUFFIXES = ['.local', '.internal', '.intranet', '.corp', '.home', '.lan'];
+const UNSAFE_IP_BLOCKS = [
+  ['subnet', '0.0.0.0', 8, 'ipv4'],
+  ['subnet', '10.0.0.0', 8, 'ipv4'],
+  ['subnet', '100.64.0.0', 10, 'ipv4'],
+  ['subnet', '127.0.0.0', 8, 'ipv4'],
+  ['subnet', '169.254.0.0', 16, 'ipv4'],
+  ['subnet', '172.16.0.0', 12, 'ipv4'],
+  ['subnet', '192.0.0.0', 24, 'ipv4'],
+  ['subnet', '192.0.2.0', 24, 'ipv4'],
+  ['subnet', '192.168.0.0', 16, 'ipv4'],
+  ['subnet', '198.18.0.0', 15, 'ipv4'],
+  ['subnet', '198.51.100.0', 24, 'ipv4'],
+  ['subnet', '203.0.113.0', 24, 'ipv4'],
+  ['subnet', '224.0.0.0', 4, 'ipv4'],
+  ['subnet', '240.0.0.0', 4, 'ipv4'],
+  ['address', '::', 'ipv6'],
+  ['address', '::1', 'ipv6'],
+  ['subnet', '64:ff9b::', 96, 'ipv6'],
+  ['subnet', '64:ff9b:1::', 48, 'ipv6'],
+  ['subnet', '100::', 64, 'ipv6'],
+  ['subnet', '2001::', 32, 'ipv6'],
+  ['subnet', '2001:db8::', 32, 'ipv6'],
+  ['subnet', '2002::', 16, 'ipv6'],
+  ['subnet', 'fc00::', 7, 'ipv6'],
+  ['subnet', 'fe80::', 10, 'ipv6'],
+  ['subnet', 'fec0::', 10, 'ipv6'],
+  ['subnet', 'ff00::', 8, 'ipv6'],
+];
+
+let safeHttpAgent;
+
+const createUnsafeIpBlockList = () => {
+  const blockList = new net.BlockList();
+
+  for (const entry of UNSAFE_IP_BLOCKS) {
+    if (entry[0] === 'address') {
+      blockList.addAddress(entry[1], entry[2]);
+    } else {
+      blockList.addSubnet(entry[1], entry[2], entry[3]);
+    }
+  }
+
+  return blockList;
+};
+
+const unsafeIpBlockList = createUnsafeIpBlockList();
+
+const isAllowedUnsafeHttpHost = (documentUrl, allowedUnsafeHosts) => {
+  const url = new URL(documentUrl);
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+
+  const host = url.host.toLowerCase();
+  const hostname = url.hostname.toLowerCase();
+  const normalizedHostname = normalizeHostname(hostname);
+  const hostCandidates = [host, hostname, normalizedHostname];
+
+  if (url.port) {
+    hostCandidates.push(`${normalizedHostname}:${url.port}`);
+  }
+
+  return allowedUnsafeHosts.some((allowedHost) => hostCandidates.includes(allowedHost));
+};
+
+const normalizeHostname = (hostname) =>
+  hostname
+    .toLowerCase()
+    .replace(/^\[(.*)]$/, '$1')
+    .replace(/\.$/, '');
+
+const isUnsafeHostname = (hostname) => {
+  const normalizedHostname = normalizeHostname(hostname);
+
+  return (
+    normalizedHostname === 'localhost' ||
+    normalizedHostname.endsWith('.localhost') ||
+    UNSAFE_HOSTNAME_SUFFIXES.some((suffix) => normalizedHostname.endsWith(suffix))
+  );
+};
+
+const getMappedIPv4Address = (address) => {
+  const match = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/.exec(address.toLowerCase());
+  return match && match[1];
+};
+
+const isUnsafeIpAddress = (address) => {
+  const normalizedAddress = normalizeHostname(address);
+  const mappedIPv4Address = getMappedIPv4Address(normalizedAddress);
+
+  if (mappedIPv4Address) return isUnsafeIpAddress(mappedIPv4Address);
+
+  const ipVersion = net.isIP(normalizedAddress);
+  if (!ipVersion) return false;
+
+  return unsafeIpBlockList.check(normalizedAddress, ipVersion === 6 ? 'ipv6' : 'ipv4');
+};
+
+const validateResolvedAddress = (hostname, address) => {
+  if (!isUnsafeIpAddress(address)) return;
+
+  throw createExternalRefAccessDeniedError(
+    `Blocked unsafe YAML $ref host resolution: ${hostname} resolved to ${address}`
+  );
+};
+
+const getSafeHttpAgent = () => {
+  if (!safeHttpAgent) {
+    safeHttpAgent = new Agent({
+      connect: {
+        lookup(hostname, options, callback) {
+          dns.lookup(hostname, options, (error, address, family) => {
+            if (error) {
+              callback(error);
+              return;
+            }
+
+            try {
+              if (Array.isArray(address)) {
+                for (const entry of address) validateResolvedAddress(hostname, entry.address);
+              } else {
+                validateResolvedAddress(hostname, address);
+              }
+            } catch (validationError) {
+              callback(validationError);
+              return;
+            }
+
+            callback(null, address, family);
+          });
+        },
+      },
+    });
+  }
+
+  return safeHttpAgent;
+};
+
+const assertHttpRefResolvesSafely = async (documentUrl) => {
+  const { hostname, protocol } = new URL(documentUrl);
+  const normalizedHostname = normalizeHostname(hostname);
+
+  if (protocol !== 'http:' && protocol !== 'https:') {
+    denyExternalRef(`Blocked unsupported YAML $ref URL: ${documentUrl}`);
+  }
+
+  if (isUnsafeHostname(normalizedHostname) || isUnsafeIpAddress(normalizedHostname)) {
+    denyExternalRef(`Blocked unsafe YAML $ref URL: ${documentUrl}`);
+  }
+
+  if (net.isIP(normalizedHostname)) return;
+
+  const addresses = await dnsPromises.lookup(normalizedHostname, { all: true, order: 'verbatim' });
+
+  if (addresses.some(({ address }) => isUnsafeIpAddress(address))) {
+    denyExternalRef(`Blocked unsafe YAML $ref URL: ${documentUrl}`);
+  }
+};
+
+const assertHttpRefAllowed = async (documentUrl, options) => {
+  if (isAllowedUnsafeHttpHost(documentUrl, options.allowedUnsafeHosts)) return;
+  await assertHttpRefResolvesSafely(documentUrl);
+};
+
+const requestHttpDocument = async (documentUrl, dispatcher) => {
+  let timeoutId;
+  let controller;
+
+  if (typeof AbortController !== 'undefined') {
+    controller = new AbortController();
+    timeoutId = setTimeout(() => controller.abort(), DEFAULT_HTTP_TIMEOUT);
+  }
+
+  try {
+    const fetchOptions = {
+      method: 'GET',
+      redirect: 'manual',
+      signal: controller ? controller.signal : null,
+    };
+
+    if (dispatcher) fetchOptions.dispatcher = dispatcher;
+
+    const response = await fetch(documentUrl, fetchOptions);
+
+    if (response.status >= 300 && response.status < 400) {
+      return {
+        redirectLocation: response.headers.get('location'),
+        status: response.status,
+      };
+    }
+
+    if (response.status >= 400) {
+      throw new Error(`HTTP ERROR ${response.status}`);
+    }
+
+    return { document: Buffer.from(await response.arrayBuffer()) };
+  } catch (error) {
+    const accessDeniedError = getExternalRefAccessDeniedError(error);
+    if (accessDeniedError) throw accessDeniedError;
+    throw error;
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+};
+
+const readHttpDocumentSafely = async (documentUrl, options) => {
+  let currentUrl = documentUrl;
+
+  for (let redirectCount = 0; ; redirectCount += 1) {
+    await assertHttpRefAllowed(currentUrl, options);
+
+    const dispatcher = isAllowedUnsafeHttpHost(currentUrl, options.allowedUnsafeHosts)
+      ? null
+      : getSafeHttpAgent();
+    const result = await requestHttpDocument(currentUrl, dispatcher);
+
+    if (result.redirectLocation !== undefined) {
+      if (redirectCount >= DEFAULT_HTTP_REDIRECTS) {
+        throw new Error(`Too many redirects while resolving ${documentUrl}`);
+      }
+
+      if (!result.redirectLocation) {
+        throw new Error(`HTTP ${result.status} redirect with no location header`);
+      }
+
+      currentUrl = new URL(result.redirectLocation, currentUrl).href;
+      continue;
+    }
+
+    return result.document;
+  }
+};
+
+const readHttpRef = async (documentUrl, fileInfo, HTTPResolver, options) => {
+  if (options.allowUnsafeUrls) {
+    const httpResolver = { ...HTTPResolver, safeUrlResolver: false };
+    return httpResolver.read(fileInfo);
+  }
+
+  return readHttpDocumentSafely(documentUrl, options);
+};
+
+module.exports = {
+  readHttpRef,
+};

--- a/lib/classes/yaml-parser/option-validation.js
+++ b/lib/classes/yaml-parser/option-validation.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const isPlainObject = require('type/plain-object/is');
+const { throwOptionsError } = require('./external-ref-errors');
+
+const getOptionLabel = (optionName) =>
+  optionName === 'options' ? 'YAML parser options' : `YAML parser option ${optionName}`;
+
+const assertOptionsObject = (value, optionName) => {
+  if (value == null || !isPlainObject(value)) {
+    throwOptionsError(`${getOptionLabel(optionName)} must be an object.`);
+  }
+};
+
+const assertKnownOptions = (options, optionName, allowedOptions) => {
+  for (const key of Object.keys(options)) {
+    if (!allowedOptions.includes(key)) {
+      const optionPath = optionName === 'options' ? key : `${optionName}.${key}`;
+      throwOptionsError(`YAML parser option ${optionPath} is not supported.`);
+    }
+  }
+};
+
+module.exports = {
+  assertKnownOptions,
+  assertOptionsObject,
+};

--- a/test/unit/lib/classes/yaml-parser.test.js
+++ b/test/unit/lib/classes/yaml-parser.test.js
@@ -399,6 +399,233 @@ describe('YamlParser', () => {
     });
   });
 
+  describe('#parse() - external ref policy', () => {
+    const expectAccessDenied = (promise) =>
+      expect(promise).to.be.rejected.then((err) => {
+        expect(err.code).to.equal('YAML_REF_ACCESS_DENIED');
+      });
+
+    const listen = (server, host = '127.0.0.1') =>
+      new Promise((resolve) => server.listen(0, host, resolve));
+
+    const close = (server) =>
+      new Promise((resolve, reject) =>
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        })
+      );
+
+    it('passes HTTP policy options to external ref loading', async () => {
+      const tmpFilePath = getTmpFilePath('blocked-local-http-ref.yml');
+      let wasRequested = false;
+      const server = http.createServer((req, res) => {
+        wasRequested = true;
+        res.writeHead(200, { 'Content-Type': 'application/yaml' });
+        res.end('foo: bar\n');
+      });
+
+      await listen(server);
+      const { port } = server.address();
+
+      serverless.utils.writeFileSync(tmpFilePath, {
+        main: { $ref: `http://127.0.0.1:${port}/ref.yml` },
+      });
+
+      try {
+        await expectAccessDenied(
+          serverless.yamlParser.parse(tmpFilePath, {
+            externalRefs: { http: { allowUnsafeUrls: false } },
+          })
+        );
+        expect(wasRequested).to.equal(false);
+      } finally {
+        await close(server);
+      }
+    });
+
+    it('passes file allow-list options to external ref loading', async () => {
+      const tmpDirPath = getTmpDirPath();
+      const refPath = path.join(tmpDirPath, 'ref.yml');
+      const testPath = path.join(tmpDirPath, 'test.yml');
+
+      serverless.utils.writeFileSync(refPath, { foo: 'bar' });
+      serverless.utils.writeFileSync(testPath, { main: { $ref: './ref.yml' } });
+
+      const result = await serverless.yamlParser.parse(testPath, {
+        externalRefs: { file: { allowedRoots: ['.'] } },
+      });
+
+      expect(result).to.have.nested.property('main.foo').to.equal('bar');
+    });
+
+    it('throws access denied for file refs outside configured roots', async () => {
+      const tmpDirPath = getTmpDirPath();
+      const serviceDirPath = path.join(tmpDirPath, 'service');
+      const outsidePath = path.join(tmpDirPath, 'outside.yml');
+      const testPath = path.join(serviceDirPath, 'test.yml');
+
+      serverless.utils.writeFileSync(outsidePath, { foo: 'bar' });
+      serverless.utils.writeFileSync(testPath, { main: { $ref: '../outside.yml' } });
+
+      await expectAccessDenied(
+        serverless.yamlParser.parse(testPath, {
+          externalRefs: { file: { allowedRoots: ['.'] } },
+        })
+      );
+    });
+
+    it('enforces file allow-list policy for nested external refs', async () => {
+      const tmpDirPath = getTmpDirPath();
+      const serviceDirPath = path.join(tmpDirPath, 'service');
+      const outsidePath = path.join(tmpDirPath, 'outside.yml');
+      const refPath = path.join(serviceDirPath, 'ref.yml');
+      const testPath = path.join(serviceDirPath, 'test.yml');
+
+      serverless.utils.writeFileSync(outsidePath, { foo: 'bar' });
+      serverless.utils.writeFileSync(refPath, { nested: { $ref: '../outside.yml' } });
+      serverless.utils.writeFileSync(testPath, { main: { $ref: './ref.yml' } });
+
+      await expectAccessDenied(
+        serverless.yamlParser.parse(testPath, {
+          externalRefs: { file: { allowedRoots: ['.'] } },
+        })
+      );
+    });
+
+    it('enforces HTTP policy for nested absolute unsafe refs', async () => {
+      const tmpFilePath = getTmpFilePath('nested-unsafe-http-ref.yml');
+      const server = http.createServer((req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/yaml' });
+        res.end('nested:\n  $ref: http://169.254.169.254/latest/meta-data/\n');
+      });
+
+      await listen(server);
+      const { port } = server.address();
+
+      serverless.utils.writeFileSync(tmpFilePath, {
+        main: { $ref: `http://127.0.0.1:${port}/ref.yml` },
+      });
+
+      try {
+        await expectAccessDenied(
+          serverless.yamlParser.parse(tmpFilePath, {
+            externalRefs: {
+              http: {
+                allowUnsafeUrls: false,
+                allowedUnsafeHosts: [`127.0.0.1:${port}`],
+              },
+            },
+          })
+        );
+      } finally {
+        await close(server);
+      }
+    });
+
+    it('enforces HTTP policy for nested scheme-relative unsafe refs', async () => {
+      const tmpFilePath = getTmpFilePath('nested-scheme-relative-http-ref.yml');
+      const server = http.createServer((req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/yaml' });
+        res.end('nested:\n  $ref: //169.254.169.254/latest/meta-data/\n');
+      });
+
+      await listen(server);
+      const { port } = server.address();
+
+      serverless.utils.writeFileSync(tmpFilePath, {
+        main: { $ref: `http://127.0.0.1:${port}/ref.yml` },
+      });
+
+      try {
+        await expectAccessDenied(
+          serverless.yamlParser.parse(tmpFilePath, {
+            externalRefs: {
+              http: {
+                allowUnsafeUrls: false,
+                allowedUnsafeHosts: [`127.0.0.1:${port}`],
+              },
+            },
+          })
+        );
+      } finally {
+        await close(server);
+      }
+    });
+
+    it('resolves nested same-host HTTP refs through the allow-list', async () => {
+      const tmpFilePath = getTmpFilePath('nested-same-host-http-ref.yml');
+      const server = http.createServer((req, res) => {
+        if (req.url === '/other.yml') {
+          res.writeHead(200, { 'Content-Type': 'application/yaml' });
+          res.end('foo: bar\n');
+          return;
+        }
+
+        res.writeHead(200, { 'Content-Type': 'application/yaml' });
+        res.end('nested:\n  $ref: ./other.yml\n');
+      });
+
+      await listen(server);
+      const { port } = server.address();
+
+      serverless.utils.writeFileSync(tmpFilePath, {
+        main: { $ref: `http://127.0.0.1:${port}/ref.yml` },
+      });
+
+      try {
+        const result = await serverless.yamlParser.parse(tmpFilePath, {
+          externalRefs: {
+            http: {
+              allowUnsafeUrls: false,
+              allowedUnsafeHosts: [`127.0.0.1:${port}`],
+            },
+          },
+        });
+
+        expect(result).to.have.nested.property('main.nested.foo').to.equal('bar');
+      } finally {
+        await close(server);
+      }
+    });
+
+    it('enforces file allow-list policy for refs nested in HTTP documents', async () => {
+      const tmpDirPath = getTmpDirPath();
+      const serviceDirPath = path.join(tmpDirPath, 'service');
+      const outsidePath = path.join(tmpDirPath, 'outside.yml');
+      const testPath = path.join(serviceDirPath, 'test.yml');
+      const server = http.createServer((req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/yaml' });
+        res.end(`nested:\n  $ref: ${pathToFileURL(outsidePath).href}\n`);
+      });
+
+      serverless.utils.writeFileSync(outsidePath, { foo: 'bar' });
+
+      await listen(server);
+      const { port } = server.address();
+
+      serverless.utils.writeFileSync(testPath, {
+        main: { $ref: `http://127.0.0.1:${port}/ref.yml` },
+      });
+
+      try {
+        await expectAccessDenied(
+          serverless.yamlParser.parse(testPath, {
+            externalRefs: {
+              file: { allowedRoots: ['.'] },
+              http: {
+                allowUnsafeUrls: false,
+                allowedUnsafeHosts: [`127.0.0.1:${port}`],
+              },
+            },
+          })
+        );
+      } finally {
+        await close(server);
+      }
+    });
+  });
+
   describe('#parse() - security hardening', () => {
     afterEach(() => {
       delete Object.prototype.polluted;

--- a/test/unit/lib/classes/yaml-parser/external-ref-errors.test.js
+++ b/test/unit/lib/classes/yaml-parser/external-ref-errors.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { expect } = require('chai');
+const {
+  createExternalRefAccessDeniedError,
+  getExternalRefAccessDeniedError,
+} = require('../../../../../lib/classes/yaml-parser/external-ref-errors');
+
+describe('yaml-parser/external-ref-errors', () => {
+  it('finds access denied errors through nested causes and aggregate errors', () => {
+    const accessDeniedError = createExternalRefAccessDeniedError('blocked');
+    const aggregateError = new AggregateError([new Error('other'), accessDeniedError]);
+    const wrappedError = new TypeError('fetch failed', {
+      cause: new Error('connection failed', { cause: aggregateError }),
+    });
+
+    expect(getExternalRefAccessDeniedError(wrappedError)).to.equal(accessDeniedError);
+  });
+
+  it('does not recurse forever through cyclic causes', () => {
+    const error = new Error('cycle');
+    error.cause = error;
+
+    expect(getExternalRefAccessDeniedError(error)).to.equal(null);
+  });
+});

--- a/test/unit/lib/classes/yaml-parser/external-ref-options.test.js
+++ b/test/unit/lib/classes/yaml-parser/external-ref-options.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const path = require('path');
+const { pathToFileURL } = require('url');
+const { expect } = require('chai');
+const { getTmpDirPath } = require('../../../../utils/fs');
+const {
+  normalizeExternalRefOptions,
+  normalizeHttpRefOptions,
+} = require('../../../../../lib/classes/yaml-parser/external-ref-options');
+
+describe('yaml-parser/external-ref-options', () => {
+  const expectOptionsError = (error) => {
+    expect(error.code).to.equal('YAML_REF_OPTIONS_ERROR');
+  };
+  const expectSyncOptionsError = (fn) => {
+    expect(fn).to.throw(Error).with.property('code', 'YAML_REF_OPTIONS_ERROR');
+  };
+
+  it('defaults to legacy-compatible external ref behavior', async () => {
+    const options = await normalizeExternalRefOptions(path.join(getTmpDirPath(), 'serverless.yml'));
+
+    expect(options.file.allowedRoots).to.equal(null);
+    expect(options.http).to.deep.equal({
+      allowUnsafeUrls: true,
+      allowedUnsafeHosts: [],
+    });
+  });
+
+  it('normalizes file allowed roots relative to the parsed document', async () => {
+    const tmpDirPath = getTmpDirPath();
+    const serviceDirPath = path.join(tmpDirPath, 'service');
+    const sharedDirPath = path.join(tmpDirPath, 'shared');
+    const options = await normalizeExternalRefOptions(path.join(serviceDirPath, 'serverless.yml'), {
+      externalRefs: {
+        file: {
+          allowedRoots: ['.', pathToFileURL(sharedDirPath).href],
+        },
+      },
+    });
+
+    expect(options.file.allowedRoots.map((root) => root.path)).to.deep.equal([
+      serviceDirPath,
+      sharedDirPath,
+    ]);
+  });
+
+  it('normalizes allowed unsafe HTTP hosts', () => {
+    const options = normalizeHttpRefOptions({
+      allowUnsafeUrls: false,
+      allowedUnsafeHosts: [
+        ' LOCALHOST:3000 ',
+        'https://Example.com/ref.yml',
+        '//Intranet.local:8080/ref.yml',
+        '',
+      ],
+    });
+
+    expect(options).to.deep.equal({
+      allowUnsafeUrls: false,
+      allowedUnsafeHosts: ['localhost:3000', 'example.com', 'intranet.local:8080'],
+    });
+  });
+
+  it('rejects invalid root options', async () => {
+    await expect(
+      normalizeExternalRefOptions(path.join(getTmpDirPath(), 'serverless.yml'), null)
+    ).to.be.rejected.then(expectOptionsError);
+  });
+
+  it('rejects arrays where objects are expected', async () => {
+    const yamlFilePath = path.join(getTmpDirPath(), 'serverless.yml');
+
+    await expect(normalizeExternalRefOptions(yamlFilePath, [])).to.be.rejected.then(
+      expectOptionsError
+    );
+    await expect(
+      normalizeExternalRefOptions(yamlFilePath, { externalRefs: [] })
+    ).to.be.rejected.then(expectOptionsError);
+    await expect(
+      normalizeExternalRefOptions(yamlFilePath, { externalRefs: { file: [] } })
+    ).to.be.rejected.then(expectOptionsError);
+    await expect(
+      normalizeExternalRefOptions(yamlFilePath, { externalRefs: { http: [] } })
+    ).to.be.rejected.then(expectOptionsError);
+  });
+
+  it('rejects unknown option keys', async () => {
+    const yamlFilePath = path.join(getTmpDirPath(), 'serverless.yml');
+
+    await expect(normalizeExternalRefOptions(yamlFilePath, { unknown: true })).to.be.rejected.then(
+      expectOptionsError
+    );
+    await expect(
+      normalizeExternalRefOptions(yamlFilePath, { externalRefs: { unknown: true } })
+    ).to.be.rejected.then(expectOptionsError);
+    await expect(
+      normalizeExternalRefOptions(yamlFilePath, {
+        externalRefs: { file: { unknown: true } },
+      })
+    ).to.be.rejected.then(expectOptionsError);
+    await expect(
+      normalizeExternalRefOptions(yamlFilePath, {
+        externalRefs: { http: { allowUnsafeURLs: false } },
+      })
+    ).to.be.rejected.then(expectOptionsError);
+  });
+
+  it('rejects unsupported HTTP redirects and timeout options', async () => {
+    const yamlFilePath = path.join(getTmpDirPath(), 'serverless.yml');
+
+    await expect(
+      normalizeExternalRefOptions(yamlFilePath, { externalRefs: { http: { redirects: 0 } } })
+    ).to.be.rejected.then(expectOptionsError);
+    await expect(
+      normalizeExternalRefOptions(yamlFilePath, { externalRefs: { http: { timeout: 1 } } })
+    ).to.be.rejected.then(expectOptionsError);
+  });
+
+  it('rejects invalid HTTP options', () => {
+    expectSyncOptionsError(() => normalizeHttpRefOptions([]));
+    expectSyncOptionsError(() => normalizeHttpRefOptions({ allowUnsafeUrls: 'false' }));
+    expectSyncOptionsError(() => normalizeHttpRefOptions({ allowedUnsafeHosts: [true] }));
+  });
+});

--- a/test/unit/lib/classes/yaml-parser/file-ref-policy.test.js
+++ b/test/unit/lib/classes/yaml-parser/file-ref-policy.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { pathToFileURL } = require('url');
+const { expect } = require('chai');
+const { getTmpDirPath } = require('../../../../utils/fs');
+const skipOnDisabledSymlinksInWindows = require('../../../../lib/skip-on-disabled-symlinks-in-windows');
+const {
+  assertFileRefAllowed,
+  normalizeFileRefOptions,
+} = require('../../../../../lib/classes/yaml-parser/file-ref-policy');
+
+describe('yaml-parser/file-ref-policy', () => {
+  const expectAccessDenied = (promise) =>
+    expect(promise).to.be.rejected.then((err) => {
+      expect(err.code).to.equal('YAML_REF_ACCESS_DENIED');
+    });
+  const expectOptionsError = (promise) =>
+    expect(promise).to.be.rejected.then((err) => {
+      expect(err.code).to.equal('YAML_REF_OPTIONS_ERROR');
+    });
+
+  const writeFile = (filePath) => {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, 'foo: bar\n');
+  };
+
+  it('allows file refs by default for v3 compatibility', async () => {
+    const tmpDirPath = getTmpDirPath();
+    const options = await normalizeFileRefOptions(tmpDirPath);
+
+    await expect(
+      assertFileRefAllowed(pathToFileURL(path.join(tmpDirPath, 'outside.yml')).href, options)
+    ).to.be.fulfilled;
+  });
+
+  it('allows file refs inside configured roots', async () => {
+    const tmpDirPath = getTmpDirPath();
+    const serviceDirPath = path.join(tmpDirPath, 'service');
+    const sharedDirPath = path.join(tmpDirPath, 'shared');
+    const serviceRefPath = path.join(serviceDirPath, 'ref.yml');
+    const sharedRefPath = path.join(sharedDirPath, 'ref.yml');
+
+    writeFile(serviceRefPath);
+    writeFile(sharedRefPath);
+
+    const options = await normalizeFileRefOptions(serviceDirPath, {
+      allowedRoots: ['.', '../shared'],
+    });
+
+    await expect(assertFileRefAllowed(pathToFileURL(serviceRefPath).href, options)).to.be.fulfilled;
+    await expect(assertFileRefAllowed(pathToFileURL(sharedRefPath).href, options)).to.be.fulfilled;
+  });
+
+  it('allows file refs inside file URL roots', async () => {
+    const tmpDirPath = getTmpDirPath();
+    const serviceDirPath = path.join(tmpDirPath, 'service');
+    const sharedDirPath = path.join(tmpDirPath, 'shared');
+    const sharedRefPath = path.join(sharedDirPath, 'ref.yml');
+
+    writeFile(sharedRefPath);
+
+    const options = await normalizeFileRefOptions(serviceDirPath, {
+      allowedRoots: pathToFileURL(sharedDirPath).href,
+    });
+
+    await expect(assertFileRefAllowed(pathToFileURL(sharedRefPath).href, options)).to.be.fulfilled;
+  });
+
+  it('blocks explicit file URL refs outside configured roots', async () => {
+    const tmpDirPath = getTmpDirPath();
+    const serviceDirPath = path.join(tmpDirPath, 'service');
+    const outsidePath = path.join(tmpDirPath, 'outside.yml');
+
+    writeFile(path.join(serviceDirPath, 'serverless.yml'));
+    writeFile(outsidePath);
+
+    const options = await normalizeFileRefOptions(serviceDirPath, { allowedRoots: ['.'] });
+
+    await expectAccessDenied(assertFileRefAllowed(pathToFileURL(outsidePath).href, options));
+  });
+
+  it('blocks non-file URLs when an allowed root policy is active', async () => {
+    const options = await normalizeFileRefOptions(getTmpDirPath(), { allowedRoots: ['.'] });
+
+    await expectAccessDenied(assertFileRefAllowed('https://example.com/ref.yml', options));
+  });
+
+  it('rejects invalid file root options', async () => {
+    await expectOptionsError(normalizeFileRefOptions(getTmpDirPath(), []));
+    await expectOptionsError(
+      normalizeFileRefOptions(getTmpDirPath(), { allowedRoots: ['file://%'] })
+    );
+  });
+
+  it('blocks symlink escapes outside configured roots', async function () {
+    const tmpDirPath = getTmpDirPath();
+    const serviceDirPath = path.join(tmpDirPath, 'service');
+    const outsidePath = path.join(tmpDirPath, 'outside.yml');
+    const linkPath = path.join(serviceDirPath, 'link.yml');
+
+    writeFile(path.join(serviceDirPath, 'serverless.yml'));
+    writeFile(outsidePath);
+
+    try {
+      fs.symlinkSync(outsidePath, linkPath, 'file');
+    } catch (error) {
+      skipOnDisabledSymlinksInWindows(error, this);
+      throw error;
+    }
+
+    const options = await normalizeFileRefOptions(serviceDirPath, { allowedRoots: ['.'] });
+
+    await expectAccessDenied(assertFileRefAllowed(pathToFileURL(linkPath).href, options));
+  });
+});

--- a/test/unit/lib/classes/yaml-parser/http-ref-reader.test.js
+++ b/test/unit/lib/classes/yaml-parser/http-ref-reader.test.js
@@ -1,0 +1,476 @@
+'use strict';
+
+const dns = require('dns');
+const http = require('http');
+const { expect } = require('chai');
+const { readHttpRef } = require('../../../../../lib/classes/yaml-parser/http-ref-reader');
+
+describe('yaml-parser/http-ref-reader', () => {
+  const HTTPResolver = {
+    canRead: (fileInfo) => /^https?:\/\//.test(fileInfo.url),
+    read: async (fileInfo) => Buffer.from(`legacy: ${fileInfo.url}\n`),
+  };
+
+  const getFileInfo = (url) => ({ url, extension: '.yml', hash: '' });
+  const safeOptions = { allowUnsafeUrls: false, allowedUnsafeHosts: [] };
+
+  const expectAccessDenied = (promise) =>
+    expect(promise).to.be.rejected.then((err) => {
+      expect(err.code).to.equal('YAML_REF_ACCESS_DENIED');
+    });
+
+  const listen = (server, host = '127.0.0.1') =>
+    new Promise((resolve, reject) => {
+      const onError = (error) => {
+        server.off('error', onError);
+        reject(error);
+      };
+
+      server.once('error', onError);
+      server.listen(0, host, () => {
+        server.off('error', onError);
+        resolve();
+      });
+    });
+
+  const close = (server) =>
+    new Promise((resolve, reject) =>
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      })
+    );
+
+  it('delegates to the upstream resolver when unsafe URLs are allowed', async () => {
+    const url = 'http://127.0.0.1/ref.yml';
+    const fileInfo = getFileInfo(url);
+    let readFileInfo;
+    const resolver = {
+      canRead: () => true,
+      read: async (nextFileInfo) => {
+        readFileInfo = nextFileInfo;
+        return Buffer.from('foo: bar\n');
+      },
+    };
+
+    const result = await readHttpRef(url, fileInfo, resolver, {
+      allowUnsafeUrls: true,
+      allowedUnsafeHosts: [],
+    });
+
+    expect(result.toString('utf8')).to.equal('foo: bar\n');
+    expect(readFileInfo).to.equal(fileInfo);
+  });
+
+  it('blocks local HTTP refs before making a request', async () => {
+    let wasRequested = false;
+    const server = http.createServer((req, res) => {
+      wasRequested = true;
+      res.writeHead(200, { 'Content-Type': 'application/yaml' });
+      res.end('foo: bar\n');
+    });
+
+    await listen(server);
+    const url = `http://127.0.0.1:${server.address().port}/ref.yml`;
+
+    try {
+      await expectAccessDenied(readHttpRef(url, getFileInfo(url), HTTPResolver, safeOptions));
+      expect(wasRequested).to.equal(false);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('blocks IPv6 loopback refs before making a request', async () => {
+    const url = 'http://[::1]:49152/ref.yml';
+
+    await expectAccessDenied(readHttpRef(url, getFileInfo(url), HTTPResolver, safeOptions));
+  });
+
+  it('blocks IPv4-mapped IPv6 loopback refs before making a request', async () => {
+    const url = 'http://[::ffff:127.0.0.1]:49152/ref.yml';
+
+    await expectAccessDenied(readHttpRef(url, getFileInfo(url), HTTPResolver, safeOptions));
+  });
+
+  it('blocks well-known NAT64 addresses before making a request', async () => {
+    const url = 'http://[64:ff9b::a9fe:a9fe]/latest/meta-data/';
+
+    await expectAccessDenied(readHttpRef(url, getFileInfo(url), HTTPResolver, safeOptions));
+  });
+
+  it('blocks well-known cloud metadata endpoint addresses', async () => {
+    for (const url of [
+      'http://100.100.100.200/latest/meta-data/',
+      'http://192.0.0.192/opc/v1/instance/',
+      'http://2130706433/ref.yml',
+      'http://0x7f.1/ref.yml',
+    ]) {
+      await expectAccessDenied(readHttpRef(url, getFileInfo(url), HTTPResolver, safeOptions));
+    }
+  });
+
+  it('blocks unsafe pre-flight DNS results before fetching', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalPromisesLookup = dns.promises.lookup;
+    let fetchCount = 0;
+
+    dns.promises.lookup = (hostname, options) => {
+      if (hostname === 'private-resolution.test') {
+        return Promise.resolve([{ address: '10.0.0.5', family: 4 }]);
+      }
+      if (hostname === 'mixed-resolution.test') {
+        return Promise.resolve([
+          { address: '93.184.216.34', family: 4 },
+          { address: '10.0.0.5', family: 4 },
+        ]);
+      }
+
+      return originalPromisesLookup.call(dns.promises, hostname, options);
+    };
+    globalThis.fetch = async () => {
+      fetchCount += 1;
+      return new Response('foo: bar\n', { status: 200 });
+    };
+
+    try {
+      for (const url of [
+        'http://private-resolution.test/ref.yml',
+        'http://mixed-resolution.test/ref.yml',
+      ]) {
+        await expectAccessDenied(readHttpRef(url, getFileInfo(url), HTTPResolver, safeOptions));
+      }
+      expect(fetchCount).to.equal(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+      dns.promises.lookup = originalPromisesLookup;
+    }
+  });
+
+  it('blocks internal hostname suffixes before DNS lookup', async () => {
+    const originalPromisesLookup = dns.promises.lookup;
+    let lookupCount = 0;
+
+    dns.promises.lookup = (hostname, options) => {
+      lookupCount += 1;
+      return originalPromisesLookup.call(dns.promises, hostname, options);
+    };
+
+    try {
+      await expectAccessDenied(
+        readHttpRef(
+          'http://metadata.internal/ref.yml',
+          getFileInfo('http://metadata.internal/ref.yml'),
+          HTTPResolver,
+          safeOptions
+        )
+      );
+      await expectAccessDenied(
+        readHttpRef(
+          'http://metadata.internal./ref.yml',
+          getFileInfo('http://metadata.internal./ref.yml'),
+          HTTPResolver,
+          safeOptions
+        )
+      );
+      expect(lookupCount).to.equal(0);
+    } finally {
+      dns.promises.lookup = originalPromisesLookup;
+    }
+  });
+
+  it('blocks DNS rebinding at connection time', async () => {
+    const originalLookup = dns.lookup;
+    const originalPromisesLookup = dns.promises.lookup;
+    const url = 'http://rebind.test:49152/ref.yml';
+    let connectionLookupCount = 0;
+
+    dns.promises.lookup = (hostname, options) => {
+      if (hostname === 'rebind.test') {
+        return Promise.resolve([{ address: '93.184.216.34', family: 4 }]);
+      }
+
+      return originalPromisesLookup.call(dns.promises, hostname, options);
+    };
+    dns.lookup = (hostname, options, callback) => {
+      if (typeof options === 'function') {
+        callback = options;
+        options = {};
+      }
+
+      if (hostname === 'rebind.test') {
+        connectionLookupCount += 1;
+        callback(null, '127.0.0.1', 4);
+        return;
+      }
+
+      originalLookup.call(dns, hostname, options, callback);
+    };
+
+    try {
+      await expectAccessDenied(readHttpRef(url, getFileInfo(url), HTTPResolver, safeOptions));
+      expect(connectionLookupCount).to.equal(1);
+    } finally {
+      dns.lookup = originalLookup;
+      dns.promises.lookup = originalPromisesLookup;
+    }
+  });
+
+  it('blocks DNS rebinding from array-shaped connection lookup results', async () => {
+    const originalLookup = dns.lookup;
+    const originalPromisesLookup = dns.promises.lookup;
+    const url = 'http://array-rebind.test:49152/ref.yml';
+    let connectionLookupCount = 0;
+
+    dns.promises.lookup = (hostname, options) => {
+      if (hostname === 'array-rebind.test') {
+        return Promise.resolve([{ address: '93.184.216.34', family: 4 }]);
+      }
+
+      return originalPromisesLookup.call(dns.promises, hostname, options);
+    };
+    dns.lookup = (hostname, options, callback) => {
+      if (typeof options === 'function') {
+        callback = options;
+        options = {};
+      }
+
+      if (hostname === 'array-rebind.test') {
+        connectionLookupCount += 1;
+        callback(null, [
+          { address: '93.184.216.34', family: 4 },
+          { address: '10.0.0.5', family: 4 },
+        ]);
+        return;
+      }
+
+      originalLookup.call(dns, hostname, options, callback);
+    };
+
+    try {
+      await expectAccessDenied(readHttpRef(url, getFileInfo(url), HTTPResolver, safeOptions));
+      expect(connectionLookupCount).to.equal(1);
+    } finally {
+      dns.lookup = originalLookup;
+      dns.promises.lookup = originalPromisesLookup;
+    }
+  });
+
+  it('allows explicitly listed unsafe HTTP hosts', async () => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/yaml' });
+      res.end('foo: bar\n');
+    });
+
+    await listen(server);
+    const url = `http://127.0.0.1:${server.address().port}/ref.yml`;
+
+    try {
+      const result = await readHttpRef(url, getFileInfo(url), HTTPResolver, {
+        allowUnsafeUrls: false,
+        allowedUnsafeHosts: [`127.0.0.1:${server.address().port}`],
+      });
+
+      expect(result.toString('utf8')).to.equal('foo: bar\n');
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('allows explicitly listed unsafe hostname suffixes', async () => {
+    const originalFetch = globalThis.fetch;
+    const url = 'http://metadata.internal/ref.yml';
+    let fetchedUrl;
+
+    globalThis.fetch = async (nextUrl) => {
+      fetchedUrl = nextUrl;
+      return new Response('foo: bar\n', { status: 200 });
+    };
+
+    try {
+      const result = await readHttpRef(url, getFileInfo(url), HTTPResolver, {
+        allowUnsafeUrls: false,
+        allowedUnsafeHosts: ['metadata.internal'],
+      });
+
+      expect(fetchedUrl).to.equal(url);
+      expect(result.toString('utf8')).to.equal('foo: bar\n');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('allows explicitly listed bracketed IPv6 unsafe HTTP hosts', async function () {
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/yaml' });
+      res.end('foo: bar\n');
+    });
+
+    try {
+      await listen(server, '::1');
+    } catch (error) {
+      if (error.code === 'EADDRNOTAVAIL' || error.code === 'EINVAL') this.skip();
+      throw error;
+    }
+
+    const url = `http://[::1]:${server.address().port}/ref.yml`;
+
+    try {
+      const result = await readHttpRef(url, getFileInfo(url), HTTPResolver, {
+        allowUnsafeUrls: false,
+        allowedUnsafeHosts: ['::1'],
+      });
+
+      expect(result.toString('utf8')).to.equal('foo: bar\n');
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('does not inherit upstream safe resolver port blocking', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalPromisesLookup = dns.promises.lookup;
+    const url = 'http://public-ref.test:8080/ref.yml';
+    let fetchedUrl;
+
+    dns.promises.lookup = (hostname, options) => {
+      if (hostname === 'public-ref.test') {
+        return Promise.resolve([{ address: '93.184.216.34', family: 4 }]);
+      }
+
+      return originalPromisesLookup.call(dns.promises, hostname, options);
+    };
+    globalThis.fetch = async (nextUrl) => {
+      fetchedUrl = nextUrl;
+      return new Response('foo: bar\n', { status: 200 });
+    };
+
+    try {
+      const result = await readHttpRef(
+        url,
+        getFileInfo(url),
+        { ...HTTPResolver, canRead: () => false },
+        safeOptions
+      );
+
+      expect(fetchedUrl).to.equal(url);
+      expect(result.toString('utf8')).to.equal('foo: bar\n');
+    } finally {
+      globalThis.fetch = originalFetch;
+      dns.promises.lookup = originalPromisesLookup;
+    }
+  });
+
+  it('blocks redirects to unsafe HTTP refs', async () => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(302, { Location: 'http://169.254.169.254/latest/meta-data/' });
+      res.end();
+    });
+
+    await listen(server);
+    const url = `http://127.0.0.1:${server.address().port}/ref.yml`;
+
+    try {
+      await expectAccessDenied(
+        readHttpRef(url, getFileInfo(url), HTTPResolver, {
+          allowUnsafeUrls: false,
+          allowedUnsafeHosts: [`127.0.0.1:${server.address().port}`],
+        })
+      );
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('follows safe relative redirects', async () => {
+    const server = http.createServer((req, res) => {
+      if (req.url === '/redirect.yml') {
+        res.writeHead(302, { Location: '/other.yml' });
+        res.end();
+        return;
+      }
+
+      res.writeHead(200, { 'Content-Type': 'application/yaml' });
+      res.end('foo: bar\n');
+    });
+
+    await listen(server);
+    const url = `http://127.0.0.1:${server.address().port}/redirect.yml`;
+
+    try {
+      const result = await readHttpRef(url, getFileInfo(url), HTTPResolver, {
+        allowUnsafeUrls: false,
+        allowedUnsafeHosts: [`127.0.0.1:${server.address().port}`],
+      });
+
+      expect(result.toString('utf8')).to.equal('foo: bar\n');
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('rejects HTTP error responses in safe mode', async () => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(404);
+      res.end('not found');
+    });
+
+    await listen(server);
+    const url = `http://127.0.0.1:${server.address().port}/missing.yml`;
+
+    try {
+      await expect(
+        readHttpRef(url, getFileInfo(url), HTTPResolver, {
+          allowUnsafeUrls: false,
+          allowedUnsafeHosts: [`127.0.0.1:${server.address().port}`],
+        })
+      ).to.be.rejectedWith(/HTTP ERROR 404/);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('blocks redirects to non-HTTP protocols', async () => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(302, { Location: 'file:///etc/passwd' });
+      res.end();
+    });
+
+    await listen(server);
+    const url = `http://127.0.0.1:${server.address().port}/ref.yml`;
+
+    try {
+      await expectAccessDenied(
+        readHttpRef(url, getFileInfo(url), HTTPResolver, {
+          allowUnsafeUrls: false,
+          allowedUnsafeHosts: [`127.0.0.1:${server.address().port}`],
+        })
+      );
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('enforces the safe-mode redirect limit', async () => {
+    const server = http.createServer((req, res) => {
+      const redirectCount = Number(req.url.slice(1) || 0);
+
+      res.writeHead(302, { Location: `/${redirectCount + 1}` });
+      res.end();
+    });
+
+    await listen(server);
+    const url = `http://127.0.0.1:${server.address().port}/0`;
+
+    try {
+      await expect(
+        readHttpRef(url, getFileInfo(url), HTTPResolver, {
+          allowUnsafeUrls: false,
+          allowedUnsafeHosts: [`127.0.0.1:${server.address().port}`],
+        })
+      ).to.be.rejectedWith(/Too many redirects/);
+    } finally {
+      await close(server);
+    }
+  });
+});


### PR DESCRIPTION
This changes the plugin-facing YAML parser so external references can be constrained by explicit file and HTTP policies while preserving the legacy v3 defaults. File references can be limited to configured roots with symlink escapes blocked, and HTTP references can opt out of unsafe local, private, link-local, reserved, multicast, metadata, NAT64, and rebinding targets while still allowing explicit hosts when needed. The parser continues to leave unresolved or malformed references untouched, but policy denials are reported as YAML_REF_ACCESS_DENIED so callers can distinguish blocked access from ordinary resolution failure. The implementation keeps parser materialization separate from option normalization, file policy checks, HTTP reading, and error classification, and the plugin documentation describes how to opt into the safer behavior.