### PR TITLE
Fix flaky large zip memory smoke test

### DIFF
--- a/test/unit/lib/plugins/package/lib/zip-service.test.js
+++ b/test/unit/lib/plugins/package/lib/zip-service.test.js
@@ -1415,7 +1415,15 @@ describe('zipService', () => {
           clearInterval(sampler);
         }
 
-        expect(peakArrayBuffers - before.arrayBuffers).to.be.lessThan(64 * 1024 * 1024);
+        // The sampled peak includes dead stream chunks that V8 has not collected yet,
+        // and that GC lag alone can exceed 64 MiB. The cap only needs to stay far
+        // below the 512 MiB file size to prove the file was streamed, not materialized.
+        expect(peakArrayBuffers - before.arrayBuffers).to.be.lessThan(128 * 1024 * 1024);
+
+        forceGc();
+        expect(process.memoryUsage().arrayBuffers - before.arrayBuffers).to.be.lessThan(
+          16 * 1024 * 1024
+        );
       });
     });
   });


### PR DESCRIPTION
The large zip memory smoke test caps the sampled peak of `process.memoryUsage().arrayBuffers` at 64 MiB while zipping a 512 MiB sparse file. That peak is dominated by dead stream chunks that V8 has not yet collected, and this GC lag alone can exceed 64 MiB, so the test intermittently fails by a megabyte or two on healthy code. Observed values cluster between 61 MiB and 68 MiB across runs of identical code.

This raises the peak cap to 128 MiB, which still proves the file is streamed rather than materialized, and adds a deterministic check that buffer memory returns to within 16 MiB of the baseline after a forced GC. The retained delta measures actual retention and sits at zero in practice.