### PR TITLE
Make YAML external refs safe by default

### DIFF
--- a/docs/guides/plugins/creating-plugins.md
+++ b/docs/guides/plugins/creating-plugins.md
@@ -145,20 +145,19 @@ module.exports = MyPlugin;
 Plugins can parse additional YAML files with `serverless.yamlParser.parse(filePath, options)`.
 This helper supports JSON Schema style `$ref` entries in the parsed YAML document.
 
-For v3 compatibility, external `$ref` loading keeps the legacy defaults: file references
-can read outside the parsed file's directory, and HTTP references can reach local or
-private hosts. Plugins that parse untrusted or user-controlled YAML should opt in to
-stricter external reference policies:
+By default, external `$ref` loading is restricted. File references are limited to
+the parsed file's directory, and HTTP references block local, private, link-local,
+reserved, multicast, metadata, and internal hosts. Plugins can add shared file roots
+or allow specific unsafe HTTP hosts when they parse trusted YAML:
 
 ```javascript
 const schema = await this.serverless.yamlParser.parse('schema.yml', {
   externalRefs: {
     file: {
-      allowedRoots: ['.'],
+      allowedRoots: ['.', '../shared-schemas'],
     },
     http: {
-      allowUnsafeUrls: false,
-      allowedUnsafeHosts: ['schemas.example.com'],
+      allowedUnsafeHosts: ['schemas.internal:8443'],
     },
   },
 });
@@ -168,12 +167,31 @@ const schema = await this.serverless.yamlParser.parse('schema.yml', {
 Relative roots are resolved from the parsed YAML file's directory. `file://` roots are
 also supported. Symlink escapes outside an allowed root are blocked.
 
-`externalRefs.http.allowUnsafeUrls: false` blocks HTTP `$ref` targets that use local,
-private, link-local, multicast, reserved, or internal hostnames and addresses. Redirects
-are checked on every hop. `externalRefs.http.allowedUnsafeHosts` can allow a specific
-unsafe host when a plugin intentionally needs it; prefer exact `host:port` entries.
-HTTP policy does not restrict file `$ref` entries found inside remote YAML documents;
-set `externalRefs.file.allowedRoots` too when parsing untrusted remote YAML.
+By default (`externalRefs.http.allowUnsafeUrls: false`), HTTP `$ref` targets that
+use local, private, link-local, reserved, multicast, metadata, or internal hostnames
+and addresses are blocked. Redirects are checked on every hop.
+`externalRefs.http.allowedUnsafeHosts` can allow a specific unsafe host when a plugin
+intentionally needs it; prefer exact `host:port` entries.
+File policy also applies to file `$ref` entries found inside remote YAML documents.
+If you set `externalRefs.file.allowedRoots` to `null`, those remote documents can point
+at unrestricted local files too, so use that opt-out only for trusted input.
+
+To restore the v3-compatible behavior for trusted input, set
+`externalRefs.file.allowedRoots` to `null` and set
+`externalRefs.http.allowUnsafeUrls` to `true`.
+
+```javascript
+const schema = await this.serverless.yamlParser.parse('schema.yml', {
+  externalRefs: {
+    file: {
+      allowedRoots: null,
+    },
+    http: {
+      allowUnsafeUrls: true,
+    },
+  },
+});
+```
 
 The public `externalRefs.http` options are limited to `allowUnsafeUrls` and
 `allowedUnsafeHosts`. Redirect and timeout limits use osls defaults and are not public

--- a/docs/guides/upgrading-to-v4.md
+++ b/docs/guides/upgrading-to-v4.md
@@ -168,6 +168,37 @@ All AWS requests now go through AWS SDK v3, which changes retry, concurrency, ti
 - **STS endpoints.** Security Token Service calls now use the regional endpoint (`sts.<region>.amazonaws.com`) instead of the global one, and `AWS_STS_REGIONAL_ENDPOINTS` is ignored. If your network egress rules pin `sts.amazonaws.com`, allow the regional endpoints or set `AWS_ENDPOINT_URL_STS=https://sts.amazonaws.com`.
 - **Endpoint overrides are now honored.** `AWS_ENDPOINT_URL`, `AWS_ENDPOINT_URL_<SERVICE>`, and the profile `endpoint_url` setting apply to every AWS call osls makes. This enables LocalStack-style workflows without plugins, but also means a leftover `AWS_ENDPOINT_URL` export in your shell silently redirects real deploys, so check your environment if requests go somewhere unexpected.
 
+### YAML parser external `$ref` resolution is restricted by default (plugin authors)
+
+Plugins that call `serverless.yamlParser.parse(filePath)` to parse additional YAML files now get restricted external `$ref` loading by default. File references are limited to the parsed document's directory, and HTTP references to local, private, link-local, reserved, multicast, metadata, and internal hosts are blocked. Blocked references fail with `YAML_REF_ACCESS_DENIED`.
+
+These options are controlled by the plugin or other code that calls `serverless.yamlParser.parse()`, not by `serverless.yml`. If an end user sees this error, the plugin needs to pass explicit `externalRefs` options, or the project needs to stay on osls v3 until the plugin is updated.
+
+**Before (v3):**
+
+```js
+const schema = await this.serverless.yamlParser.parse('schema.yml');
+```
+
+**After (v4, trusted input):**
+
+```js
+const schema = await this.serverless.yamlParser.parse('schema.yml', {
+  externalRefs: {
+    file: {
+      allowedRoots: null,
+    },
+    http: {
+      allowUnsafeUrls: true,
+    },
+  },
+});
+```
+
+The option containers must be objects. `externalRefs: null`, `externalRefs.file: null`, and `externalRefs.http: null` now fail with `YAML_REF_OPTIONS_ERROR`; omit them to use the v4 defaults. `externalRefs.file.allowedRoots: null` remains the explicit unrestricted-file opt-out.
+
+See [Parsing YAML files](./plugins/creating-plugins.md#parsing-yaml-files).
+
 ### Plugin custom variables: `configurationVariablesSources` only
 
 Plugins that extend variable resolution via the old `variableResolvers` API will fail with `OLD_VARIABLE_RESOLVER_NOT_SUPPORTED`. Migrate to `configurationVariablesSources`.

--- a/lib/classes/yaml-parser/external-ref-options.js
+++ b/lib/classes/yaml-parser/external-ref-options.js
@@ -6,7 +6,7 @@ const { normalizeFileRefOptions } = require('./file-ref-policy');
 const { assertKnownOptions, assertOptionsObject } = require('./option-validation');
 
 const normalizeStringArrayOption = (value, optionName) => {
-  if (value == null) return [];
+  if (value === undefined) return [];
 
   const values = Array.isArray(value) ? value : [value];
 
@@ -36,12 +36,12 @@ const normalizeHttpRefOptions = (options = {}) => {
   assertOptionsObject(options, 'externalRefs.http');
   assertKnownOptions(options, 'externalRefs.http', ['allowUnsafeUrls', 'allowedUnsafeHosts']);
 
-  if (options.allowUnsafeUrls != null && typeof options.allowUnsafeUrls !== 'boolean') {
+  if (options.allowUnsafeUrls !== undefined && typeof options.allowUnsafeUrls !== 'boolean') {
     throwOptionsError('YAML parser option externalRefs.http.allowUnsafeUrls must be a boolean.');
   }
 
   return {
-    allowUnsafeUrls: options.allowUnsafeUrls == null ? true : options.allowUnsafeUrls,
+    allowUnsafeUrls: options.allowUnsafeUrls === undefined ? false : options.allowUnsafeUrls,
     allowedUnsafeHosts: normalizeStringArrayOption(
       options.allowedUnsafeHosts,
       'externalRefs.http.allowedUnsafeHosts'
@@ -56,7 +56,7 @@ const normalizeExternalRefOptions = async (yamlFilePath, options = {}) => {
   assertKnownOptions(options, 'options', ['externalRefs']);
 
   const documentDir = path.dirname(path.resolve(yamlFilePath));
-  const externalRefs = options.externalRefs == null ? {} : options.externalRefs;
+  const externalRefs = options.externalRefs === undefined ? {} : options.externalRefs;
 
   assertOptionsObject(externalRefs, 'externalRefs');
   assertKnownOptions(externalRefs, 'externalRefs', ['file', 'http']);
@@ -64,9 +64,9 @@ const normalizeExternalRefOptions = async (yamlFilePath, options = {}) => {
   return {
     file: await normalizeFileRefOptions(
       documentDir,
-      externalRefs.file == null ? { allowedRoots: null } : externalRefs.file
+      externalRefs.file === undefined ? {} : externalRefs.file
     ),
-    http: normalizeHttpRefOptions(externalRefs.http == null ? undefined : externalRefs.http),
+    http: normalizeHttpRefOptions(externalRefs.http === undefined ? {} : externalRefs.http),
   };
 };
 

--- a/lib/classes/yaml-parser/file-ref-policy.js
+++ b/lib/classes/yaml-parser/file-ref-policy.js
@@ -6,6 +6,11 @@ const { fileURLToPath } = require('url');
 const { denyExternalRef, throwOptionsError } = require('./external-ref-errors');
 const { assertKnownOptions, assertOptionsObject } = require('./option-validation');
 
+const DEFAULT_ALLOWED_ROOTS = ['.'];
+const FILE_REF_POLICY_HINT =
+  'The code calling yamlParser.parse can allow this path by adding a trusted root ' +
+  'to externalRefs.file.allowedRoots.';
+
 const realpathIfExists = async (filePath) => {
   try {
     return await fsp.realpath(filePath);
@@ -55,11 +60,16 @@ const normalizeFileRefOptions = async (documentDir, options = {}) => {
   assertOptionsObject(options, 'externalRefs.file');
   assertKnownOptions(options, 'externalRefs.file', ['allowedRoots']);
 
-  if (options.allowedRoots == null) return { allowedRoots: null };
+  let allowedRootValues;
 
-  const allowedRoots = Array.isArray(options.allowedRoots)
-    ? options.allowedRoots
-    : [options.allowedRoots];
+  if (options.allowedRoots !== undefined) {
+    if (options.allowedRoots === null) return { allowedRoots: null };
+    allowedRootValues = options.allowedRoots;
+  } else {
+    allowedRootValues = DEFAULT_ALLOWED_ROOTS;
+  }
+
+  const allowedRoots = Array.isArray(allowedRootValues) ? allowedRootValues : [allowedRootValues];
 
   return {
     allowedRoots: await Promise.all(
@@ -81,22 +91,28 @@ const getRefFilePath = (documentUrl) => {
 const isFileRefAllowedByPath = (candidatePath, allowedRoots, rootProperty) =>
   allowedRoots.some((allowedRoot) => isPathInside(allowedRoot[rootProperty], candidatePath));
 
+const denyFileRefOutsideAllowedRoots = (documentUrl) => {
+  denyExternalRef(
+    `Blocked YAML $ref file outside allowed roots: ${documentUrl}. ${FILE_REF_POLICY_HINT}`
+  );
+};
+
 const assertFileRefAllowed = async (documentUrl, options) => {
   if (options.allowedRoots == null) return;
 
   const candidatePath = getRefFilePath(documentUrl);
   if (!candidatePath) {
-    denyExternalRef(`Blocked YAML $ref file outside allowed roots: ${documentUrl}`);
+    denyFileRefOutsideAllowedRoots(documentUrl);
   }
 
   if (!isFileRefAllowedByPath(candidatePath, options.allowedRoots, 'path')) {
-    denyExternalRef(`Blocked YAML $ref file outside allowed roots: ${documentUrl}`);
+    denyFileRefOutsideAllowedRoots(documentUrl);
   }
 
   const candidateRealpath = await realpathIfExists(candidatePath);
 
   if (!isFileRefAllowedByPath(candidateRealpath, options.allowedRoots, 'realpath')) {
-    denyExternalRef(`Blocked YAML $ref file outside allowed roots: ${documentUrl}`);
+    denyFileRefOutsideAllowedRoots(documentUrl);
   }
 };
 

--- a/lib/classes/yaml-parser/http-ref-reader.js
+++ b/lib/classes/yaml-parser/http-ref-reader.js
@@ -12,6 +12,9 @@ const {
 
 const DEFAULT_HTTP_REDIRECTS = 5;
 const DEFAULT_HTTP_TIMEOUT = 60000;
+const HTTP_REF_POLICY_HINT =
+  'The code calling yamlParser.parse can allow this host by adding it to ' +
+  'externalRefs.http.allowedUnsafeHosts.';
 const UNSAFE_HOSTNAME_SUFFIXES = ['.local', '.internal', '.intranet', '.corp', '.home', '.lan'];
 const UNSAFE_IP_BLOCKS = [
   ['subnet', '0.0.0.0', 8, 'ipv4'],
@@ -109,10 +112,17 @@ const isUnsafeIpAddress = (address) => {
   return unsafeIpBlockList.check(normalizedAddress, ipVersion === 6 ? 'ipv6' : 'ipv4');
 };
 
+const createUnsafeHttpRefAccessDeniedError = (message) =>
+  createExternalRefAccessDeniedError(`${message}. ${HTTP_REF_POLICY_HINT}`);
+
+const denyUnsafeHttpRef = (message) => {
+  throw createUnsafeHttpRefAccessDeniedError(message);
+};
+
 const validateResolvedAddress = (hostname, address) => {
   if (!isUnsafeIpAddress(address)) return;
 
-  throw createExternalRefAccessDeniedError(
+  throw createUnsafeHttpRefAccessDeniedError(
     `Blocked unsafe YAML $ref host resolution: ${hostname} resolved to ${address}`
   );
 };
@@ -158,7 +168,7 @@ const assertHttpRefResolvesSafely = async (documentUrl) => {
   }
 
   if (isUnsafeHostname(normalizedHostname) || isUnsafeIpAddress(normalizedHostname)) {
-    denyExternalRef(`Blocked unsafe YAML $ref URL: ${documentUrl}`);
+    denyUnsafeHttpRef(`Blocked unsafe YAML $ref URL: ${documentUrl}`);
   }
 
   if (net.isIP(normalizedHostname)) return;
@@ -166,7 +176,7 @@ const assertHttpRefResolvesSafely = async (documentUrl) => {
   const addresses = await dnsPromises.lookup(normalizedHostname, { all: true, order: 'verbatim' });
 
   if (addresses.some(({ address }) => isUnsafeIpAddress(address))) {
-    denyExternalRef(`Blocked unsafe YAML $ref URL: ${documentUrl}`);
+    denyUnsafeHttpRef(`Blocked unsafe YAML $ref URL: ${documentUrl}`);
   }
 };
 

--- a/test/unit/lib/classes/yaml-parser.test.js
+++ b/test/unit/lib/classes/yaml-parser.test.js
@@ -392,7 +392,7 @@ describe('YamlParser', () => {
         .to.equal('bar');
     });
 
-    it('should allow remote HTTP refs', async () => {
+    it('should allow remote HTTP refs when unsafe URLs are explicitly allowed', async () => {
       const tmpFilePath = getTmpFilePath('remote-ref.yml');
       const server = http.createServer((req, res) => {
         if (req.url === '/ref.yml') {
@@ -415,7 +415,9 @@ describe('YamlParser', () => {
       });
 
       try {
-        const result = await serverless.yamlParser.parse(tmpFilePath);
+        const result = await serverless.yamlParser.parse(tmpFilePath, {
+          externalRefs: { http: { allowUnsafeUrls: true } },
+        });
 
         expect(result).to.have.nested.property('main.foo').to.equal('bar');
       } finally {
@@ -430,9 +432,13 @@ describe('YamlParser', () => {
   });
 
   describe('#parse() - external ref policy', () => {
-    const expectAccessDenied = (promise) =>
+    const expectAccessDenied = (promise, messageIncludes = []) =>
       expect(promise).to.be.rejected.then((err) => {
         expect(err.code).to.equal('YAML_REF_ACCESS_DENIED');
+
+        for (const text of messageIncludes) {
+          expect(err.message).to.include(text);
+        }
       });
 
     const listen = (server, host = '127.0.0.1') =>
@@ -446,7 +452,7 @@ describe('YamlParser', () => {
         })
       );
 
-    it('passes HTTP policy options to external ref loading', async () => {
+    it('blocks unsafe HTTP refs by default', async () => {
       const tmpFilePath = getTmpFilePath('blocked-local-http-ref.yml');
       let wasRequested = false;
       const server = http.createServer((req, res) => {
@@ -463,11 +469,10 @@ describe('YamlParser', () => {
       });
 
       try {
-        await expectAccessDenied(
-          serverless.yamlParser.parse(tmpFilePath, {
-            externalRefs: { http: { allowUnsafeUrls: false } },
-          })
-        );
+        await expectAccessDenied(serverless.yamlParser.parse(tmpFilePath), [
+          'yamlParser.parse',
+          'externalRefs.http.allowedUnsafeHosts',
+        ]);
         expect(wasRequested).to.equal(false);
       } finally {
         await close(server);
@@ -489,7 +494,7 @@ describe('YamlParser', () => {
       expect(result).to.have.nested.property('main.foo').to.equal('bar');
     });
 
-    it('throws access denied for file refs outside configured roots', async () => {
+    it('blocks file refs outside the root document directory by default', async () => {
       const tmpDirPath = getTmpDirPath();
       const serviceDirPath = path.join(tmpDirPath, 'service');
       const outsidePath = path.join(tmpDirPath, 'outside.yml');
@@ -498,11 +503,26 @@ describe('YamlParser', () => {
       serverless.utils.writeFileSync(outsidePath, { foo: 'bar' });
       serverless.utils.writeFileSync(testPath, { main: { $ref: '../outside.yml' } });
 
-      await expectAccessDenied(
-        serverless.yamlParser.parse(testPath, {
-          externalRefs: { file: { allowedRoots: ['.'] } },
-        })
-      );
+      await expectAccessDenied(serverless.yamlParser.parse(testPath), [
+        'yamlParser.parse',
+        'externalRefs.file.allowedRoots',
+      ]);
+    });
+
+    it('allows file refs outside the root document directory when roots are explicitly unrestricted', async () => {
+      const tmpDirPath = getTmpDirPath();
+      const serviceDirPath = path.join(tmpDirPath, 'service');
+      const outsidePath = path.join(tmpDirPath, 'outside.yml');
+      const testPath = path.join(serviceDirPath, 'test.yml');
+
+      serverless.utils.writeFileSync(outsidePath, { foo: 'bar' });
+      serverless.utils.writeFileSync(testPath, { main: { $ref: '../outside.yml' } });
+
+      const result = await serverless.yamlParser.parse(testPath, {
+        externalRefs: { file: { allowedRoots: null } },
+      });
+
+      expect(result).to.have.nested.property('main.foo').to.equal('bar');
     });
 
     it('enforces file allow-list policy for nested external refs', async () => {
@@ -649,6 +669,41 @@ describe('YamlParser', () => {
               },
             },
           })
+        );
+      } finally {
+        await close(server);
+      }
+    });
+
+    it('enforces default file policy for refs nested in HTTP documents', async () => {
+      const tmpDirPath = getTmpDirPath();
+      const serviceDirPath = path.join(tmpDirPath, 'service');
+      const outsidePath = path.join(tmpDirPath, 'outside.yml');
+      const testPath = path.join(serviceDirPath, 'test.yml');
+      const server = http.createServer((req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/yaml' });
+        res.end(`nested:\n  $ref: ${pathToFileURL(outsidePath).href}\n`);
+      });
+
+      serverless.utils.writeFileSync(outsidePath, { foo: 'bar' });
+
+      await listen(server);
+      const { port } = server.address();
+
+      serverless.utils.writeFileSync(testPath, {
+        main: { $ref: `http://127.0.0.1:${port}/ref.yml` },
+      });
+
+      try {
+        await expectAccessDenied(
+          serverless.yamlParser.parse(testPath, {
+            externalRefs: {
+              http: {
+                allowedUnsafeHosts: [`127.0.0.1:${port}`],
+              },
+            },
+          }),
+          ['yamlParser.parse', 'externalRefs.file.allowedRoots']
         );
       } finally {
         await close(server);

--- a/test/unit/lib/classes/yaml-parser/external-ref-options.test.js
+++ b/test/unit/lib/classes/yaml-parser/external-ref-options.test.js
@@ -17,12 +17,72 @@ describe('yaml-parser/external-ref-options', () => {
     expect(fn).to.throw(Error).with.property('code', 'YAML_REF_OPTIONS_ERROR');
   };
 
-  it('defaults to legacy-compatible external ref behavior', async () => {
-    const options = await normalizeExternalRefOptions(path.join(getTmpDirPath(), 'serverless.yml'));
+  it('defaults to safe external ref behavior', async () => {
+    const yamlFilePath = path.join(getTmpDirPath(), 'serverless.yml');
+    const options = await normalizeExternalRefOptions(yamlFilePath);
+
+    expect(options.file.allowedRoots.map((root) => root.path)).to.deep.equal([
+      path.dirname(yamlFilePath),
+    ]);
+    expect(options.http).to.deep.equal({
+      allowUnsafeUrls: false,
+      allowedUnsafeHosts: [],
+    });
+  });
+
+  it('allows explicit legacy-compatible external ref behavior', async () => {
+    const options = await normalizeExternalRefOptions(
+      path.join(getTmpDirPath(), 'serverless.yml'),
+      {
+        externalRefs: {
+          file: { allowedRoots: null },
+          http: { allowUnsafeUrls: true },
+        },
+      }
+    );
 
     expect(options.file.allowedRoots).to.equal(null);
     expect(options.http).to.deep.equal({
       allowUnsafeUrls: true,
+      allowedUnsafeHosts: [],
+    });
+  });
+
+  it('uses safe defaults for empty external ref option objects', async () => {
+    const yamlFilePath = path.join(getTmpDirPath(), 'serverless.yml');
+    const options = await normalizeExternalRefOptions(yamlFilePath, {
+      externalRefs: {
+        file: {},
+        http: {},
+      },
+    });
+
+    expect(options.file.allowedRoots.map((root) => root.path)).to.deep.equal([
+      path.dirname(yamlFilePath),
+    ]);
+    expect(options.http).to.deep.equal({
+      allowUnsafeUrls: false,
+      allowedUnsafeHosts: [],
+    });
+  });
+
+  it('uses safe defaults for undefined option leaves', async () => {
+    const yamlFilePath = path.join(getTmpDirPath(), 'serverless.yml');
+    const options = await normalizeExternalRefOptions(yamlFilePath, {
+      externalRefs: {
+        file: { allowedRoots: undefined },
+        http: {
+          allowUnsafeUrls: undefined,
+          allowedUnsafeHosts: undefined,
+        },
+      },
+    });
+
+    expect(options.file.allowedRoots.map((root) => root.path)).to.deep.equal([
+      path.dirname(yamlFilePath),
+    ]);
+    expect(options.http).to.deep.equal({
+      allowUnsafeUrls: false,
       allowedUnsafeHosts: [],
     });
   });
@@ -65,6 +125,20 @@ describe('yaml-parser/external-ref-options', () => {
   it('rejects invalid root options', async () => {
     await expect(
       normalizeExternalRefOptions(path.join(getTmpDirPath(), 'serverless.yml'), null)
+    ).to.be.rejected.then(expectOptionsError);
+  });
+
+  it('rejects null where option objects are expected', async () => {
+    const yamlFilePath = path.join(getTmpDirPath(), 'serverless.yml');
+
+    await expect(
+      normalizeExternalRefOptions(yamlFilePath, { externalRefs: null })
+    ).to.be.rejected.then(expectOptionsError);
+    await expect(
+      normalizeExternalRefOptions(yamlFilePath, { externalRefs: { file: null } })
+    ).to.be.rejected.then(expectOptionsError);
+    await expect(
+      normalizeExternalRefOptions(yamlFilePath, { externalRefs: { http: null } })
     ).to.be.rejected.then(expectOptionsError);
   });
 
@@ -119,7 +193,9 @@ describe('yaml-parser/external-ref-options', () => {
 
   it('rejects invalid HTTP options', () => {
     expectSyncOptionsError(() => normalizeHttpRefOptions([]));
+    expectSyncOptionsError(() => normalizeHttpRefOptions({ allowUnsafeUrls: null }));
     expectSyncOptionsError(() => normalizeHttpRefOptions({ allowUnsafeUrls: 'false' }));
+    expectSyncOptionsError(() => normalizeHttpRefOptions({ allowedUnsafeHosts: null }));
     expectSyncOptionsError(() => normalizeHttpRefOptions({ allowedUnsafeHosts: [true] }));
   });
 });

--- a/test/unit/lib/classes/yaml-parser/file-ref-policy.test.js
+++ b/test/unit/lib/classes/yaml-parser/file-ref-policy.test.js
@@ -26,13 +26,49 @@ describe('yaml-parser/file-ref-policy', () => {
     fs.writeFileSync(filePath, 'foo: bar\n');
   };
 
-  it('allows file refs by default for v3 compatibility', async () => {
+  it('limits file refs to the document directory by default', async () => {
     const tmpDirPath = getTmpDirPath();
-    const options = await normalizeFileRefOptions(tmpDirPath);
+    const serviceDirPath = path.join(tmpDirPath, 'service');
+    const insidePath = path.join(serviceDirPath, 'ref.yml');
+    const outsidePath = path.join(tmpDirPath, 'outside.yml');
 
-    await expect(
-      assertFileRefAllowed(pathToFileURL(path.join(tmpDirPath, 'outside.yml')).href, options)
-    ).to.be.fulfilled;
+    writeFile(insidePath);
+    writeFile(outsidePath);
+
+    const options = await normalizeFileRefOptions(serviceDirPath);
+
+    await expect(assertFileRefAllowed(pathToFileURL(insidePath).href, options)).to.be.fulfilled;
+    await expectAccessDenied(assertFileRefAllowed(pathToFileURL(outsidePath).href, options));
+  });
+
+  it('allows file refs outside the document directory when roots are explicitly unrestricted', async () => {
+    const tmpDirPath = getTmpDirPath();
+    const serviceDirPath = path.join(tmpDirPath, 'service');
+    const outsidePath = path.join(tmpDirPath, 'outside.yml');
+
+    writeFile(path.join(serviceDirPath, 'serverless.yml'));
+    writeFile(outsidePath);
+
+    const options = await normalizeFileRefOptions(serviceDirPath, { allowedRoots: null });
+
+    await expect(assertFileRefAllowed(pathToFileURL(outsidePath).href, options)).to.be.fulfilled;
+  });
+
+  it('treats undefined allowed roots as omitted', async () => {
+    const tmpDirPath = getTmpDirPath();
+    const serviceDirPath = path.join(tmpDirPath, 'service');
+    const insidePath = path.join(serviceDirPath, 'ref.yml');
+    const outsidePath = path.join(tmpDirPath, 'outside.yml');
+
+    writeFile(insidePath);
+    writeFile(outsidePath);
+
+    const options = await normalizeFileRefOptions(serviceDirPath, {
+      allowedRoots: undefined,
+    });
+
+    await expect(assertFileRefAllowed(pathToFileURL(insidePath).href, options)).to.be.fulfilled;
+    await expectAccessDenied(assertFileRefAllowed(pathToFileURL(outsidePath).href, options));
   });
 
   it('allows file refs inside configured roots', async () => {


### PR DESCRIPTION
This changes the v4 YAML parser defaults so external references are restricted unless the code calling yamlParser.parse explicitly relaxes them. File references are limited to the parsed document directory by default, and HTTP references block unsafe local, private, link-local, reserved, multicast, metadata, NAT64, and internal targets by default. Trusted callers can restore the v3-compatible behavior with externalRefs.file.allowedRoots set to null and externalRefs.http.allowUnsafeUrls set to true. The plugin documentation and v4 upgrade guide now describe the default behavior, the explicit opt-outs, and the YAML_REF_ACCESS_DENIED and YAML_REF_OPTIONS_ERROR failures users may see.