### PR TITLE
Fix YAML file ref policy for missing paths

### DIFF
--- a/lib/classes/yaml-parser/file-ref-policy.js
+++ b/lib/classes/yaml-parser/file-ref-policy.js
@@ -10,9 +10,13 @@ const realpathIfExists = async (filePath) => {
   try {
     return await fsp.realpath(filePath);
   } catch (error) {
-    if (error.code === 'ENOENT' || error.code === 'ENOTDIR') return filePath;
-    throw error;
+    if (error.code !== 'ENOENT' && error.code !== 'ENOTDIR') throw error;
   }
+
+  const parentPath = path.dirname(filePath);
+  if (parentPath === filePath) return filePath;
+
+  return path.join(await realpathIfExists(parentPath), path.basename(filePath));
 };
 
 const isPathInside = (rootPath, candidatePath) => {

--- a/test/unit/lib/classes/yaml-parser.test.js
+++ b/test/unit/lib/classes/yaml-parser.test.js
@@ -199,6 +199,28 @@ describe('YamlParser', () => {
       });
     });
 
+    it('should leave missing external refs untouched when file roots are restricted', async () => {
+      const tmpFilePath = getTmpFilePath('missing-external-restricted.yml');
+
+      serverless.utils.writeFileSync(tmpFilePath, {
+        main: {
+          $ref: './missing.yml',
+          extra: 'kept',
+        },
+      });
+
+      return expect(
+        serverless.yamlParser.parse(tmpFilePath, {
+          externalRefs: { file: { allowedRoots: ['.'] } },
+        })
+      ).to.eventually.deep.equal({
+        main: {
+          $ref: './missing.yml',
+          extra: 'kept',
+        },
+      });
+    });
+
     it('should keep nested missing refs untouched while resolving the rest of an external file', async () => {
       const tmpDirPath = getTmpDirPath();
 

--- a/test/unit/lib/classes/yaml-parser/file-ref-policy.test.js
+++ b/test/unit/lib/classes/yaml-parser/file-ref-policy.test.js
@@ -53,6 +53,18 @@ describe('yaml-parser/file-ref-policy', () => {
     await expect(assertFileRefAllowed(pathToFileURL(sharedRefPath).href, options)).to.be.fulfilled;
   });
 
+  it('allows missing file refs inside configured roots', async () => {
+    const tmpDirPath = getTmpDirPath();
+    const serviceDirPath = path.join(tmpDirPath, 'service');
+    const missingPath = path.join(serviceDirPath, 'missing.yml');
+
+    writeFile(path.join(serviceDirPath, 'serverless.yml'));
+
+    const options = await normalizeFileRefOptions(serviceDirPath, { allowedRoots: ['.'] });
+
+    await expect(assertFileRefAllowed(pathToFileURL(missingPath).href, options)).to.be.fulfilled;
+  });
+
   it('allows file refs inside file URL roots', async () => {
     const tmpDirPath = getTmpDirPath();
     const serviceDirPath = path.join(tmpDirPath, 'service');
@@ -113,5 +125,27 @@ describe('yaml-parser/file-ref-policy', () => {
     const options = await normalizeFileRefOptions(serviceDirPath, { allowedRoots: ['.'] });
 
     await expectAccessDenied(assertFileRefAllowed(pathToFileURL(linkPath).href, options));
+  });
+
+  it('blocks missing file refs under symlink escapes outside configured roots', async function () {
+    const tmpDirPath = getTmpDirPath();
+    const serviceDirPath = path.join(tmpDirPath, 'service');
+    const outsideDirPath = path.join(tmpDirPath, 'outside');
+    const linkPath = path.join(serviceDirPath, 'link');
+    const missingPath = path.join(linkPath, 'missing.yml');
+
+    writeFile(path.join(serviceDirPath, 'serverless.yml'));
+    writeFile(path.join(outsideDirPath, 'placeholder.yml'));
+
+    try {
+      fs.symlinkSync(outsideDirPath, linkPath, 'dir');
+    } catch (error) {
+      skipOnDisabledSymlinksInWindows(error, this);
+      throw error;
+    }
+
+    const options = await normalizeFileRefOptions(serviceDirPath, { allowedRoots: ['.'] });
+
+    await expectAccessDenied(assertFileRefAllowed(pathToFileURL(missingPath).href, options));
   });
 });


### PR DESCRIPTION
This fixes the file $ref allow-root policy so missing files are compared against canonical paths derived from the nearest existing parent directory. Previously, a missing file kept its raw path when realpath failed, which could incorrectly deny refs that were inside an allowed root, particularly on Windows when the ref used a short path while the allowed root resolved to a long canonical path. The change preserves symlink escape protection by still resolving existing parents before appending the missing path suffix, and adds regression coverage for missing refs inside allowed roots, missing refs left untouched by the parser under restricted roots, and missing refs under symlinked directories that escape the allowed root.