### PR TITLE
Avoid leaking resolved values in variable syntax errors

### DIFF
--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -347,9 +347,7 @@ class VariablesResolver {
         } catch (error) {
           error.message = `Cannot resolve variable at "${humanizePropertyPath(
             propertyPath.split('\0')
-          )}": Approached variable syntax error in resolved value "${valueMeta.value}": ${
-            error.message
-          }`;
+          )}": Approached variable syntax error in resolved value (${error.code})`;
           delete valueMeta.value;
           valueMeta.error = error;
           throw error;
@@ -504,7 +502,7 @@ Object.defineProperties(
             } catch (error) {
               error.message = `Cannot resolve variable at "${humanizePropertyPath(
                 propertyPathKeys
-              )}": Approached variable syntax error in resolved value "${value}": ${error.message}`;
+              )}": Approached variable syntax error in resolved value (${error.code})`;
               delete valueMeta.value;
               valueMeta.error = error;
               return null;

--- a/test/unit/lib/configuration/variables/resolve.test.js
+++ b/test/unit/lib/configuration/variables/resolve.test.js
@@ -39,6 +39,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
       resolvesResultVariablesArray: '${sourceResultVariables(array)}',
       resolvesResultVariablesString: '${sourceResultVariables(string)}',
       resolvesResultVariablesStringInvalid: '${sourceResultVariables(stringInvalid)}',
+      resolvesResultConcatInvalid: 'prefix-${sourceResultVariables(stringInvalid)}',
       resolveDeepVariablesConcat:
         '${sourceResultVariables(string)}foo${sourceResultVariables(string)}',
       resolveDeepVariablesConcatInParam:
@@ -146,7 +147,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
             case 'string':
               return { value: '${sourceDirect:}' };
             case 'stringInvalid':
-              return { value: '${sourceDirect:' };
+              return { value: 'leaked-secret-marker${sourceDirect:' };
             case 'error':
               return { value: [1, '${sourceUnrecognized:}', '${sourceError:}'] };
             default:
@@ -464,6 +465,18 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
       const valueMeta = variablesMeta.get('resolvesResultVariablesStringInvalid');
       expect(valueMeta).to.not.have.property('variables');
       expect(valueMeta.error.code).to.equal('UNTERMINATED_VARIABLE');
+      expect(valueMeta.error.message).to.include('(UNTERMINATED_VARIABLE)');
+      expect(valueMeta.error.message).to.not.include('leaked-secret-marker');
+      expect(valueMeta.error.message).to.not.include('${sourceDirect');
+    });
+
+    it('should error on invalid variable notation in returned concatenated result', () => {
+      const valueMeta = variablesMeta.get('resolvesResultConcatInvalid');
+      expect(valueMeta).to.not.have.property('variables');
+      expect(valueMeta.error.code).to.equal('UNTERMINATED_VARIABLE');
+      expect(valueMeta.error.message).to.include('(UNTERMINATED_VARIABLE)');
+      expect(valueMeta.error.message).to.not.include('leaked-secret-marker');
+      expect(valueMeta.error.message).to.not.include('${sourceDirect');
     });
 
     it('should error on invalid source resolution resolt', () => {
@@ -497,6 +510,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
         'propertyDeepCircularC',
         'propertyRoot',
         'resolvesResultVariablesStringInvalid',
+        'resolvesResultConcatInvalid',
         'infiniteDeepVariablesConcat',
         'resolvesVariablesInvalid1',
         'resolvesVariablesInvalid2',


### PR DESCRIPTION
This stops variable syntax errors discovered inside resolved values from embedding the resolved value or the inner parser message in the final error text. The original parser error code is preserved in the sanitized message and on the error object, so callers still get a stable reason without exposing values that may have come from secret-bearing sources such as SSM or environment variables. The regression coverage uses a sentinel resolved value and checks both direct returned strings and concatenated returned strings.