### PR TITLE
Validate layer paths

### DIFF
--- a/docs/guides/upgrading-to-v4.md
+++ b/docs/guides/upgrading-to-v4.md
@@ -83,6 +83,10 @@ package:
 
 The same applies to function- and layer-level `package` blocks. See [Packaging](./packaging.md#patterns).
 
+### Layer paths are validated
+
+`layers.<name>.path` values containing newline, carriage return, or NUL characters are now rejected with an `INVALID_LAYER_PATH` error during packaging and local invocation. Such paths never worked correctly and could corrupt the Dockerfile that `invoke local --docker` generates. No action is needed for any real layer path.
+
 ### `variablesResolutionMode: 20210219` is rejected
 
 The legacy variables resolver mode is no longer supported. Remove `variablesResolutionMode` from your configuration.

--- a/docs/guides/upgrading-to-v4.md
+++ b/docs/guides/upgrading-to-v4.md
@@ -85,7 +85,7 @@ The same applies to function- and layer-level `package` blocks. See [Packaging](
 
 ### Layer paths are validated
 
-`layers.<name>.path` values containing newline, carriage return, or NUL characters are now rejected with an `INVALID_LAYER_PATH` error during packaging and local invocation. Such paths never worked correctly and could corrupt the Dockerfile that `invoke local --docker` generates. No action is needed for any real layer path.
+`layers.<name>.path` values containing newline, carriage return, or NUL characters are now rejected with an `INVALID_LAYER_PATH` error during packaging and Docker-based local invocation. Such paths never worked correctly and could corrupt the Dockerfile that `invoke local --docker` generates. No action is needed for any real layer path.
 
 ### `variablesResolutionMode: 20210219` is rejected
 

--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -401,7 +401,7 @@ class AwsInvokeLocal {
   async getLayerPaths() {
     const layers = Object.fromEntries(
       Object.entries(this.serverless.service.layers || {}).map(([key, value]) => {
-        ensureValidLayerPath(key, value.path);
+        ensureValidLayerPath(key, value && value.path);
         return [this.provider.naming.getLambdaLayerLogicalId(key), value];
       })
     );

--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -21,6 +21,7 @@ const dirExists = require('../../../utils/fs/dir-exists');
 const fileExists = require('../../../utils/fs/file-exists');
 const isStandalone = require('../../../utils/is-standalone-executable');
 const ensureArtifact = require('../../../utils/ensure-artifact');
+const ensureValidLayerPath = require('../../../utils/ensure-valid-layer-path');
 const { safeShallowAssign } = require('../../../utils/safe-object');
 const { isAwsCredentialsNotFoundError } = require('../../../aws/aws-sdk-v3-error');
 const { writeText, progress, log } = require('../../../utils/serverless-utils/log');
@@ -399,10 +400,10 @@ class AwsInvokeLocal {
 
   async getLayerPaths() {
     const layers = Object.fromEntries(
-      Object.entries(this.serverless.service.layers || {}).map(([key, value]) => [
-        this.provider.naming.getLambdaLayerLogicalId(key),
-        value,
-      ])
+      Object.entries(this.serverless.service.layers || {}).map(([key, value]) => {
+        ensureValidLayerPath(key, value.path);
+        return [this.provider.naming.getLambdaLayerLogicalId(key), value];
+      })
     );
     let lambdaClientPromise;
     const getLambdaClient = () => {

--- a/lib/plugins/package/lib/package-service.js
+++ b/lib/plugins/package/lib/package-service.js
@@ -8,6 +8,7 @@ const ServerlessError = require('../../../serverless-error');
 const parseS3URI = require('../../aws/utils/parse-s3-uri');
 const { createRegistry } = require('../../../utils/safe-object');
 const { log } = require('../../../utils/serverless-utils/log');
+const ensureValidLayerPath = require('../../../utils/ensure-valid-layer-path');
 
 module.exports = {
   defaultExcludes: [
@@ -195,6 +196,7 @@ module.exports = {
 
   async packageLayer(layerName) {
     const layerObject = this.serverless.service.getLayer(layerName);
+    ensureValidLayerPath(layerName, layerObject.path);
 
     const zipFileName = `${layerName}.zip`;
     const layerPath = path.resolve(this.serverless.serviceDir, layerObject.path);

--- a/lib/utils/ensure-valid-layer-path.js
+++ b/lib/utils/ensure-valid-layer-path.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const ServerlessError = require('../serverless-error');
+
+const FORBIDDEN_LAYER_PATH_CHARS = /[\0\r\n]/;
+
+module.exports = (layerName, layerPath) => {
+  if (typeof layerPath !== 'string') return;
+  if (!FORBIDDEN_LAYER_PATH_CHARS.test(layerPath)) return;
+
+  throw new ServerlessError(
+    `Invalid "layers.${layerName}.path": must not contain newline or NUL characters`,
+    'INVALID_LAYER_PATH'
+  );
+};

--- a/lib/utils/ensure-valid-layer-path.js
+++ b/lib/utils/ensure-valid-layer-path.js
@@ -9,7 +9,7 @@ module.exports = (layerName, layerPath) => {
   if (!FORBIDDEN_LAYER_PATH_CHARS.test(layerPath)) return;
 
   throw new ServerlessError(
-    `Invalid "layers.${layerName}.path": must not contain newline or NUL characters`,
+    `Invalid "layers.${layerName}.path": must not contain newline, carriage return, or NUL characters`,
     'INVALID_LAYER_PATH'
   );
 };

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -1405,6 +1405,19 @@ describe('AwsInvokeLocal', () => {
   });
 
   describe('#getLayerPaths()', () => {
+    it('rejects local layer paths with control characters', async () => {
+      serverless.service.layers = {
+        myLayer: { path: 'layer\nRUN whoami' },
+      };
+      awsInvokeLocal.options.functionObj = { layers: [] };
+
+      await expect(awsInvokeLocal.getLayerPaths()).to.be.rejected.then((error) => {
+        expect(error).to.have.property('code', 'INVALID_LAYER_PATH');
+        expect(error.message).to.include('layers.myLayer.path');
+        expect(error.message).to.not.include('RUN whoami');
+      });
+    });
+
     const createRemoteLayerTestContext = ({
       awsSdkV3Stub,
       cacheDirPath,

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -1418,6 +1418,15 @@ describe('AwsInvokeLocal', () => {
       });
     });
 
+    it('does not reject unused malformed layer entries without paths', async () => {
+      serverless.service.layers = {
+        myLayer: null,
+      };
+      awsInvokeLocal.options.functionObj = { layers: [] };
+
+      await expect(awsInvokeLocal.getLayerPaths()).to.eventually.deep.equal([]);
+    });
+
     const createRemoteLayerTestContext = ({
       awsSdkV3Stub,
       cacheDirPath,

--- a/test/unit/lib/plugins/package/lib/package-service.test.js
+++ b/test/unit/lib/plugins/package/lib/package-service.test.js
@@ -194,6 +194,34 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
   });
 
   describe('#packageLayer()', () => {
+    it('rejects layer paths with control characters', async () => {
+      const resolveFilePathsLayerStub = sinon.stub().resolves(['index.js']);
+
+      let error;
+      try {
+        await packageService.packageLayer.call(
+          {
+            serverless: {
+              serviceDir: process.cwd(),
+              service: {
+                getLayer: () => ({ path: 'layer\nRUN whoami' }),
+              },
+            },
+            resolveFilePathsLayer: resolveFilePathsLayerStub,
+            zipFiles: sinon.stub().resolves('layer.zip'),
+          },
+          'layer'
+        );
+      } catch (caughtError) {
+        error = caughtError;
+      }
+
+      expect(error).to.have.property('code', 'INVALID_LAYER_PATH');
+      expect(error.message).to.include('layers.layer.path');
+      expect(error.message).to.not.include('RUN whoami');
+      expect(resolveFilePathsLayerStub).to.not.have.been.called;
+    });
+
     it('resolves layer package paths against serviceDir instead of cwd', async () => {
       const originalCwd = process.cwd();
       const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), 'sls-cwd-'));

--- a/test/unit/lib/utils/ensure-valid-layer-path.test.js
+++ b/test/unit/lib/utils/ensure-valid-layer-path.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const { expect } = require('chai');
+const ensureValidLayerPath = require('../../../../lib/utils/ensure-valid-layer-path');
+
+describe('test/unit/lib/utils/ensure-valid-layer-path.test.js', () => {
+  for (const layerPath of ['layer', '/tmp/layer', undefined]) {
+    it(`accepts ${JSON.stringify(layerPath)}`, () => {
+      expect(() => ensureValidLayerPath('myLayer', layerPath)).to.not.throw();
+    });
+  }
+
+  for (const layerPath of ['layer\nRUN whoami', 'layer\rfoo', 'layer\0foo']) {
+    it(`rejects ${JSON.stringify(layerPath)}`, () => {
+      expect(() => ensureValidLayerPath('myLayer', layerPath))
+        .to.throw('Invalid "layers.myLayer.path"')
+        .and.have.property('code', 'INVALID_LAYER_PATH');
+    });
+  }
+
+  it('does not include the invalid raw value in the error message', () => {
+    let error;
+
+    try {
+      ensureValidLayerPath('myLayer', 'layer\nRUN whoami');
+    } catch (caughtError) {
+      error = caughtError;
+    }
+
+    expect(error).to.have.property('code', 'INVALID_LAYER_PATH');
+    expect(error.message).to.not.include('RUN whoami');
+  });
+});


### PR DESCRIPTION
This rejects layer path values that contain newline, carriage return, or NUL characters before packaging or local Docker invocation consumes them. These characters do not have a legitimate use in layer paths, and a variable-resolved value containing a newline could otherwise corrupt the generated Dockerfile used by invoke local. The validation is shared by the packaging and invoke-local paths, is covered by helper and call-site tests, and is documented in the v4 upgrade guide.