### PR TITLE
Remove shell from Java and Ruby invoke local

### DIFF
--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -639,17 +639,13 @@ class AwsInvokeLocal {
   async callJavaBridge(artifactPath, className, handlerName, input) {
     const wrapperPath = await this.resolveRuntimeWrapperPath('java/target/invoke-bridge-1.0.1.jar');
     return new Promise((resolve, reject) => {
-      const java = spawn(
-        'java',
-        [
-          `-DartifactPath=${artifactPath}`,
-          `-DclassName=${className}`,
-          `-DhandlerName=${handlerName}`,
-          '-jar',
-          wrapperPath,
-        ],
-        { shell: true }
-      );
+      const java = spawn('java', [
+        `-DartifactPath=${artifactPath}`,
+        `-DclassName=${className}`,
+        `-DhandlerName=${handlerName}`,
+        '-jar',
+        wrapperPath,
+      ]);
 
       log.warning(
         'In order to get human-readable output, please implement "toString()" method of your "ApiGatewayResponse" object.'
@@ -767,7 +763,6 @@ class AwsInvokeLocal {
     return new Promise((resolve, reject) => {
       const ruby = spawn(runtime, [wrapperPath, handlerPath, handlerName], {
         env: process.env,
-        shell: true,
       });
       ruby.stdout.on('data', (buf) => {
         writeText(buf.toString());

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -882,15 +882,76 @@ describe('AwsInvokeLocal', () => {
     });
 
     it('spawns java process with correct arguments', async () => {
-      await invokeLocalSpawnStubbed.callJavaBridge(
-        tmpServicePath,
-        'com.serverless.Handler',
-        'handleRequest',
-        '{}'
+      const artifactPath = path.join(tmpServicePath, 'artifact path;$(id).jar');
+      const className = 'com.example.Handler; $(id)';
+      const handlerName = 'handle "Request" && id';
+
+      await invokeLocalSpawnStubbed.callJavaBridge(artifactPath, className, handlerName, '{}');
+
+      const wrapperPath = await invokeLocalSpawnStubbed.resolveRuntimeWrapperPath(
+        'java/target/invoke-bridge-1.0.1.jar'
       );
+
+      expect(spawnStub.firstCall.args).to.deep.equal([
+        'java',
+        [
+          `-DartifactPath=${artifactPath}`,
+          `-DclassName=${className}`,
+          `-DhandlerName=${handlerName}`,
+          '-jar',
+          wrapperPath,
+        ],
+      ]);
       expect(writeChildStub.calledOnce).to.be.equal(true);
       expect(endChildStub.calledOnce).to.be.equal(true);
       expect(writeChildStub.calledWithExactly('{}')).to.be.equal(true);
+    });
+  });
+
+  describe('#invokeLocalRuby()', () => {
+    let invokeLocalSpawnStubbed;
+
+    beforeEach(() => {
+      AwsInvokeLocal = proxyquire('../../../../../../lib/plugins/aws/invoke-local/index', {
+        '../../../utils/get-stdin': stdinStub,
+        '../../../utils/spawn': spawnExtStub,
+        'child_process': {
+          spawn: spawnStub,
+        },
+      });
+      invokeLocalSpawnStubbed = new AwsInvokeLocal(serverless, {
+        stage: 'dev',
+        function: 'first',
+        data: {},
+      });
+      invokeLocalSpawnStubbed.options.functionObj = {
+        handler: 'handler.hello',
+        name: 'hello',
+        timeout: 4,
+      };
+    });
+
+    it('spawns ruby process with correct arguments', async () => {
+      const handlerPath = 'handler path;$(id)';
+      const handlerName = 'hello "quoted" && id';
+
+      await invokeLocalSpawnStubbed.invokeLocalRuby(
+        'ruby',
+        handlerPath,
+        handlerName,
+        {},
+        undefined
+      );
+
+      const wrapperPath = await invokeLocalSpawnStubbed.resolveRuntimeWrapperPath('invoke.rb');
+      const [command, args, options] = spawnStub.firstCall.args;
+
+      expect(command).to.equal('ruby');
+      expect(args).to.deep.equal([wrapperPath, handlerPath, handlerName]);
+      expect(options).to.have.property('env', process.env);
+      expect(options).to.not.have.property('shell');
+      expect(writeChildStub.calledOnce).to.be.equal(true);
+      expect(endChildStub.calledOnce).to.be.equal(true);
     });
   });
 


### PR DESCRIPTION
This removes shell interpretation from the Java and Ruby invoke local paths while preserving the existing 3.x raw ChildProcess behavior. Java still uses child_process.spawn directly for the bridge, and Ruby still passes process.env to the child process, but handler and artifact values are now passed only as argv entries rather than through a shell. The tests use malicious-looking values to assert the exact argv boundaries and confirm Ruby does not receive a shell option.