### PR TITLE
Fix plugin install test fixture

### DIFF
--- a/test/unit/commands/plugin-install.test.js
+++ b/test/unit/commands/plugin-install.test.js
@@ -171,7 +171,7 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
       [`${pluginName}@"^1.60.0 || 2"`, `${pluginName}@^1.60.0 || 2`],
     ]) {
       it(`passes ${JSON.stringify(expectedPackageSpec)} as one npm argv element`, async () => {
-        const fixture = await fixturesEngine.setup('function');
+        const fixture = await setupProgrammaticFixture('function');
         const configuration = fixture.serviceConfig;
         const serviceDir = fixture.servicePath;
         const configurationFilePath = await resolveConfigurationPath({


### PR DESCRIPTION
This fixes a silent merge-up issue in the plugin install command tests on 4.x. The new npm argv boundary test block from 3.x still referenced fixturesEngine even though the 4.x test file uses setupProgrammaticFixture. This updates that block to use the 4.x fixture helper so the plugin install tests run correctly.