### PR TITLE
Harden runtime spawn policy

### DIFF
--- a/docs/cli-reference/invoke-local.md
+++ b/docs/cli-reference/invoke-local.md
@@ -18,6 +18,7 @@ serverless invoke local --function functionName
 - `--raw`: By default, your input `data` and `context` strings are parsed as a JSON object. Set this option if you want them to be treated as raw strings instead.
 
 * `--env` or `-e` String representing an environment variable to set when invoking your function, in the form `<name>=<value>`. Can be repeated for more than one environment variable.
+* `--preserve-runtime-env` Preserve Java/Ruby runtime environment variables (`JAVA_TOOL_OPTIONS`, `_JAVA_OPTIONS`, `JDK_JAVA_OPTIONS`, `RUBYOPT`, `RUBYLIB`, `BUNDLE_GEMFILE`, `BUNDLE_PATH`). By default, these variables are removed before spawning Java/Ruby local runtimes.
 * `--docker` Enable docker support for NodeJS/Python/Ruby/Java. Enabled by default for other
   runtimes.
 * `--docker-arg` Pass additional arguments to docker run command when `--docker` is option used. e.g. `--docker-arg '-p 9229:9229' --docker-arg '-v /var:/host_var'`

--- a/docs/guides/upgrading-to-v4.md
+++ b/docs/guides/upgrading-to-v4.md
@@ -87,6 +87,22 @@ The same applies to function- and layer-level `package` blocks. See [Packaging](
 
 `layers.<name>.path` values containing newline, carriage return, or NUL characters are now rejected with an `INVALID_LAYER_PATH` error during packaging and Docker-based local invocation. Such paths never worked correctly and could corrupt the Dockerfile that `invoke local --docker` generates. No action is needed for any real layer path.
 
+### Java and Ruby `invoke local` handlers are validated
+
+Java and Ruby local invocation now validates handler strings before starting the local runtime. Invalid Java handlers fail with `INVALID_JAVA_HANDLER`; invalid Ruby handlers fail with `INVALID_RUBY_HANDLER`.
+
+Use Java handler names such as `com.example.Handler` or `com.example.Handler::handleRequest`. Use Ruby handlers with a safe file path and method or class address, such as `handler.hello` or `handler.MyModule::MyClass.my_class_method`.
+
+### Java and Ruby `invoke local` sanitizes runtime environment variables
+
+Java and Ruby local invocation now removes runtime injection variables before spawning the local runtime: `JAVA_TOOL_OPTIONS`, `_JAVA_OPTIONS`, `JDK_JAVA_OPTIONS`, `RUBYOPT`, `RUBYLIB`, `BUNDLE_GEMFILE`, and `BUNDLE_PATH`.
+
+If your local invocation intentionally depends on those variables, pass `--preserve-runtime-env` to restore the previous inherited environment behavior.
+
+### Java and Ruby `invoke local` fails on nonzero runtime exits
+
+Java and Ruby local invocation now fails the command when the local runtime exits with a nonzero status. In v3, Java and Ruby local invocations could report success even if the spawned runtime process exited unsuccessfully. Update scripts that expected success despite a local runtime failure.
+
 ### `variablesResolutionMode: 20210219` is rejected
 
 The legacy variables resolver mode is no longer supported. Remove `variablesResolutionMode` from your configuration.

--- a/lib/cli/commands-schema/aws-service.js
+++ b/lib/cli/commands-schema/aws-service.js
@@ -159,6 +159,11 @@ commands.set('invoke local', {
       shortcut: 'e',
       type: 'multiple',
     },
+    'preserve-runtime-env': {
+      usage:
+        'Preserve Java/Ruby runtime environment variables such as RUBYOPT and JAVA_TOOL_OPTIONS',
+      type: 'boolean',
+    },
     'docker': { usage: 'Flag to turn on docker use for node/python/ruby/java', type: 'boolean' },
     'docker-arg': {
       usage: 'Arguments to docker run command. e.g. --docker-arg "-p 9229:9229"',

--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -9,7 +9,6 @@ const promiseLimit = require('ext/promise/limit').bind(Promise);
 const validate = require('../lib/validate');
 const stdin = require('../../../utils/get-stdin');
 const spawnExt = require('../../../utils/spawn');
-const { spawn } = require('child_process');
 const inspect = require('util').inspect;
 const download = require('../../../utils/serverless-utils/download');
 const resolveCacheDir = require('../../../utils/resolve-cache-dir');
@@ -46,6 +45,47 @@ const ensureRuntimeWrappers = isStandalone
         return ensureFile(path.resolve(runtimeCachePath, 'validationFile'));
       })
   : () => __dirname;
+
+const javaClassNamePattern =
+  /^(?:[A-Za-z_$][A-Za-z0-9_$]*\.)*[A-Za-z_$][A-Za-z0-9_$]*(?:\$[A-Za-z_$][A-Za-z0-9_$]*)*$/;
+const javaMethodNamePattern = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+const parseJavaHandler = (handler) => {
+  const parts = handler.split('::');
+  if (parts.length > 2) {
+    throw new ServerlessError(`Invalid Java handler "${handler}".`, 'INVALID_JAVA_HANDLER');
+  }
+
+  const className = parts[0];
+  const handlerName = parts[1] || 'handleRequest';
+
+  if (!javaClassNamePattern.test(className) || !javaMethodNamePattern.test(handlerName)) {
+    throw new ServerlessError(`Invalid Java handler "${handler}".`, 'INVALID_JAVA_HANDLER');
+  }
+
+  return { className, handlerName };
+};
+
+const rubyHandlerPathPattern = /^(?:[A-Za-z0-9_-]+\/)*[A-Za-z0-9_-]+$/;
+const rubyHandlerNamePattern =
+  /^(?:[A-Za-z_][A-Za-z0-9_]*::)*[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*[!?=]?)*[!?=]?$/;
+
+const parseRubyHandler = (handler) => {
+  const handlerComponents = handler.split(/\./);
+  const handlerPath = handlerComponents[0];
+  const handlerName = handlerComponents.slice(1).join('.');
+
+  if (!rubyHandlerPathPattern.test(handlerPath) || !rubyHandlerNamePattern.test(handlerName)) {
+    throw new ServerlessError(`Invalid Ruby handler "${handler}".`, 'INVALID_RUBY_HANDLER');
+  }
+
+  return { handlerPath, handlerName };
+};
+
+const runtimeEnvBlocklist = {
+  java: ['JAVA_TOOL_OPTIONS', '_JAVA_OPTIONS', 'JDK_JAVA_OPTIONS'],
+  ruby: ['RUBYOPT', 'RUBYLIB', 'BUNDLE_GEMFILE', 'BUNDLE_PATH'],
+};
 
 function getCloudFormationClient(context) {
   context.cloudFormationClientPromise ||= context.provider
@@ -339,8 +379,7 @@ class AwsInvokeLocal {
     }
 
     if (['java8.al2', 'java11', 'java17', 'java21', 'java25'].includes(runtime)) {
-      const className = handler.split('::')[0];
-      const handlerName = handler.split('::')[1] || 'handleRequest';
+      const { className, handlerName } = parseJavaHandler(handler);
       const artifact =
         this.options.package && this.options.package.artifact
           ? this.options.package.artifact
@@ -356,9 +395,7 @@ class AwsInvokeLocal {
     }
 
     if (['ruby3.3', 'ruby3.4', 'ruby4.0'].includes(runtime)) {
-      const handlerComponents = handler.split(/\./);
-      const handlerPath = handlerComponents[0];
-      const handlerName = handlerComponents.slice(1).join('.');
+      const { handlerPath, handlerName } = parseRubyHandler(handler);
       return this.invokeLocalRuby(
         process.platform === 'win32' ? 'ruby.exe' : 'ruby',
         handlerPath,
@@ -577,6 +614,20 @@ class AwsInvokeLocal {
     return envVarsFromOptions;
   }
 
+  getRuntimeChildEnv(runtimeFamily) {
+    const env = { ...process.env };
+
+    if (this.options['preserve-runtime-env']) {
+      return env;
+    }
+
+    for (const key of runtimeEnvBlocklist[runtimeFamily] || []) {
+      delete env[key];
+    }
+
+    return env;
+  }
+
   async ensurePackage() {
     if (this.options['skip-package']) {
       try {
@@ -721,38 +772,33 @@ class AwsInvokeLocal {
 
   async callJavaBridge(artifactPath, className, handlerName, input) {
     const wrapperPath = await this.resolveRuntimeWrapperPath('java/target/invoke-bridge-1.0.1.jar');
-    return new Promise((resolve, reject) => {
-      const java = spawn('java', [
+    const java = spawnExt(
+      'java',
+      [
         `-DartifactPath=${artifactPath}`,
         `-DclassName=${className}`,
         `-DhandlerName=${handlerName}`,
         '-jar',
         wrapperPath,
-      ]);
+      ],
+      {
+        env: this.getRuntimeChildEnv('java'),
+        input,
+      }
+    );
 
-      log.warning(
-        'In order to get human-readable output, please implement "toString()" method of your "ApiGatewayResponse" object.'
-      );
+    log.warning(
+      'In order to get human-readable output, please implement "toString()" method of your "ApiGatewayResponse" object.'
+    );
 
-      java.stdout.on('data', (buf) => {
-        writeText(buf.toString());
-      });
-      java.stderr.on('data', (buf) => {
-        writeText(buf.toString());
-      });
-      java.on('close', () => resolve());
-      let isRejected = false;
-      java.on('error', (error) => {
-        isRejected = true;
-        reject(error);
-      });
-
-      process.nextTick(() => {
-        if (isRejected) return; // Runtime not available
-        java.stdin.write(input);
-        java.stdin.end();
-      });
+    java.stdout.on('data', (buf) => {
+      writeText(buf.toString());
     });
+    java.stderr.on('data', (buf) => {
+      writeText(buf.toString());
+    });
+
+    await java;
   }
 
   async invokeLocalJava(runtime, className, handlerName, artifactPath, event, customContext) {
@@ -843,29 +889,19 @@ class AwsInvokeLocal {
     });
 
     const wrapperPath = await this.resolveRuntimeWrapperPath('invoke.rb');
-    return new Promise((resolve, reject) => {
-      const ruby = spawn(runtime, [wrapperPath, handlerPath, handlerName], {
-        env: process.env,
-      });
-      ruby.stdout.on('data', (buf) => {
-        writeText(buf.toString());
-      });
-      ruby.stderr.on('data', (buf) => {
-        writeText(buf.toString());
-      });
-      ruby.on('close', () => resolve());
-      let isRejected = false;
-      ruby.on('error', (error) => {
-        isRejected = true;
-        reject(error);
-      });
-
-      process.nextTick(() => {
-        if (isRejected) return; // Runtime not available
-        ruby.stdin.write(input);
-        ruby.stdin.end();
-      });
+    const ruby = spawnExt(runtime, [wrapperPath, handlerPath, handlerName], {
+      env: this.getRuntimeChildEnv('ruby'),
+      input,
     });
+
+    ruby.stdout.on('data', (buf) => {
+      writeText(buf.toString());
+    });
+    ruby.stderr.on('data', (buf) => {
+      writeText(buf.toString());
+    });
+
+    await ruby;
   }
 
   async invokeLocalNodeJs(handlerPath, handlerName, event, customContext) {

--- a/lib/utils/npm-package/is-global.js
+++ b/lib/utils/npm-package/is-global.js
@@ -2,7 +2,7 @@
 
 const memoizee = require('memoizee');
 const path = require('path');
-const { spawnSync } = require('child_process');
+const spawnSync = require('../spawn-sync');
 
 const serverlessPackageRoot = path.resolve(__dirname, '../../../');
 

--- a/lib/utils/spawn-policy.js
+++ b/lib/utils/spawn-policy.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const ServerlessError = require('../serverless-error');
+
+const validateSpawnInput = (command, args, options = {}) => {
+  options = options || {};
+
+  if (typeof command !== 'string' || command.length === 0) {
+    throw new ServerlessError('Spawn command must be a non-empty string.', 'INVALID_SPAWN_INPUT');
+  }
+
+  if (!Array.isArray(args)) {
+    throw new ServerlessError('Spawn args must be an array.', 'INVALID_SPAWN_INPUT');
+  }
+
+  if (command.includes('\0') || args.some((arg) => String(arg).includes('\0'))) {
+    throw new ServerlessError('Refusing to spawn command with null bytes.', 'INVALID_SPAWN_INPUT');
+  }
+
+  if (options.shell) {
+    throw new ServerlessError(
+      `Refusing to spawn "${command}" with shell enabled.`,
+      'UNSAFE_SHELL_SPAWN'
+    );
+  }
+};
+
+module.exports = { validateSpawnInput };

--- a/lib/utils/spawn-sync.js
+++ b/lib/utils/spawn-sync.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const spawn = require('cross-spawn');
+const { validateSpawnInput } = require('./spawn-policy');
+
+module.exports = (command, args = [], options = {}) => {
+  if (args == null) args = [];
+  options = options || {};
+  validateSpawnInput(command, args, options);
+
+  return spawn.sync(String(command), args.map(String), options);
+};

--- a/lib/utils/spawn.js
+++ b/lib/utils/spawn.js
@@ -2,6 +2,7 @@
 
 const spawn = require('cross-spawn');
 const { PassThrough } = require('stream');
+const { validateSpawnInput } = require('./spawn-policy');
 
 const sensitiveOptionNamePattern =
   /(?:^|[-_])(?:auth|authorization|credential|password|passwd|pwd|secret|token|api[-_]?key|access[-_]?key)(?:$|[-_])/i;
@@ -68,9 +69,13 @@ const redactArgs = (args) => {
 };
 
 module.exports = (command, args = [], options = {}) => {
+  if (args == null) args = [];
+  options = options || {};
+  validateSpawnInput(command, args, options);
+
   const normalizedCommand = String(command);
-  const normalizedArgs = args == null ? [] : Array.from(args, String);
-  const { shouldCloseStdin, input, ...spawnOptions } = options || {};
+  const normalizedArgs = args.map(String);
+  const { shouldCloseStdin, input, ...spawnOptions } = options;
 
   const child = spawn(normalizedCommand, normalizedArgs, spawnOptions);
   const result = {

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -86,8 +86,6 @@ describe('AwsInvokeLocal', () => {
   let provider;
   let stdinStub;
   let spawnExtStub;
-  let writeChildStub;
-  let endChildStub;
 
   beforeEach(() => {
     options = {
@@ -95,18 +93,10 @@ describe('AwsInvokeLocal', () => {
       region: 'us-east-1',
       function: 'first',
     };
-    endChildStub = sinon.stub();
-    writeChildStub = sinon.stub();
     spawnExtStub = sinon.stub().callsFake(() => {
       const result = Promise.resolve({ stdoutBuffer: Buffer.from('Mocked output') });
       result.stderr = new EventEmitter().on('data', () => {});
       result.stdout = new EventEmitter().on('data', () => {});
-      result.child = {
-        stdin: {
-          write: writeChildStub,
-          end: endChildStub,
-        },
-      };
       return result;
     });
 

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -86,7 +86,6 @@ describe('AwsInvokeLocal', () => {
   let provider;
   let stdinStub;
   let spawnExtStub;
-  let spawnStub;
   let writeChildStub;
   let endChildStub;
 
@@ -96,22 +95,19 @@ describe('AwsInvokeLocal', () => {
       region: 'us-east-1',
       function: 'first',
     };
-    spawnStub = sinon.stub();
     endChildStub = sinon.stub();
     writeChildStub = sinon.stub();
-    spawnExtStub = sinon.stub().resolves({
-      stdoutBuffer: Buffer.from('Mocked output'),
-    });
-    spawnStub = sinon.stub().returns({
-      stderr: new EventEmitter().on('data', () => {}),
-      stdout: new EventEmitter().on('data', () => {}),
-      stdin: {
-        write: writeChildStub,
-        end: endChildStub,
-      },
-      on: (key, callback) => {
-        if (key === 'close') process.nextTick(callback);
-      },
+    spawnExtStub = sinon.stub().callsFake(() => {
+      const result = Promise.resolve({ stdoutBuffer: Buffer.from('Mocked output') });
+      result.stderr = new EventEmitter().on('data', () => {});
+      result.stdout = new EventEmitter().on('data', () => {});
+      result.child = {
+        stdin: {
+          write: writeChildStub,
+          end: endChildStub,
+        },
+      };
+      return result;
     });
 
     stdinStub = sinon.stub().resolves('');
@@ -1105,6 +1101,16 @@ describe('AwsInvokeLocal', () => {
       ).to.be.equal(true);
     });
 
+    it('rejects invalid Java handlers', async () => {
+      awsInvokeLocal.options.functionObj.runtime = 'java21';
+      awsInvokeLocal.options.functionObj.handler = 'com.example.Handler;id::customMethod';
+
+      await expect(awsInvokeLocal.invokeLocal()).to.be.rejected.then((error) => {
+        expect(error).to.have.property('code', 'INVALID_JAVA_HANDLER');
+      });
+      expect(invokeLocalJavaStub).to.not.have.been.called;
+    });
+
     it('should call invokeLocalRuby when ruby3.3 runtime is set', async () => {
       awsInvokeLocal.options.functionObj.runtime = 'ruby3.3';
       await awsInvokeLocal.invokeLocal();
@@ -1138,6 +1144,32 @@ describe('AwsInvokeLocal', () => {
       ).to.be.equal(true);
     });
 
+    it('preserves Ruby class and module handler names', async () => {
+      awsInvokeLocal.options.functionObj.runtime = 'ruby3.4';
+      awsInvokeLocal.options.functionObj.handler = 'handler.MyModule::MyClass.my_class_method';
+
+      await awsInvokeLocal.invokeLocal();
+
+      const runtime = process.platform === 'win32' ? 'ruby.exe' : 'ruby';
+      expect(invokeLocalRubyStub).to.have.been.calledOnceWithExactly(
+        runtime,
+        'handler',
+        'MyModule::MyClass.my_class_method',
+        {},
+        undefined
+      );
+    });
+
+    it('rejects invalid Ruby handlers', async () => {
+      awsInvokeLocal.options.functionObj.runtime = 'ruby3.4';
+      awsInvokeLocal.options.functionObj.handler = 'handler.bad-name';
+
+      await expect(awsInvokeLocal.invokeLocal()).to.be.rejected.then((error) => {
+        expect(error).to.have.property('code', 'INVALID_RUBY_HANDLER');
+      });
+      expect(invokeLocalRubyStub).to.not.have.been.called;
+    });
+
     it('should call invokeLocalDocker if using runtime provided.al2023', async () => {
       awsInvokeLocal.options.functionObj.runtime = 'provided.al2023';
       awsInvokeLocal.options.functionObj.handler = 'handler.foobar';
@@ -1162,9 +1194,6 @@ describe('AwsInvokeLocal', () => {
       AwsInvokeLocal = proxyquire('../../../../../../lib/plugins/aws/invoke-local/index', {
         '../../../utils/get-stdin': stdinStub,
         '../../../utils/spawn': spawnExtStub,
-        'child_process': {
-          spawn: spawnStub,
-        },
       });
       invokeLocalSpawnStubbed = new AwsInvokeLocal(serverless, {
         stage: 'dev',
@@ -1178,30 +1207,64 @@ describe('AwsInvokeLocal', () => {
       });
     });
 
-    it('spawns java process with correct arguments', async () => {
+    it('spawns java process with correct arguments and sanitized environment', async () => {
       const artifactPath = path.join(tmpServicePath, 'artifact path;$(id).jar');
       const className = 'com.example.Handler; $(id)';
       const handlerName = 'handle "Request" && id';
 
-      await invokeLocalSpawnStubbed.callJavaBridge(artifactPath, className, handlerName, '{}');
+      await overrideEnv(
+        {
+          variables: {
+            JAVA_TOOL_OPTIONS: '-javaagent:/tmp/agent.jar',
+            _JAVA_OPTIONS: '-Xmx64m',
+            JDK_JAVA_OPTIONS: '--add-opens=java.base/java.lang=ALL-UNNAMED',
+            KEEP_ME: 'yes',
+          },
+        },
+        async () => {
+          await invokeLocalSpawnStubbed.callJavaBridge(artifactPath, className, handlerName, '{}');
+        }
+      );
 
       const wrapperPath = await invokeLocalSpawnStubbed.resolveRuntimeWrapperPath(
         'java/target/invoke-bridge-1.0.1.jar'
       );
+      const [command, args, spawnOptions] = spawnExtStub.firstCall.args;
 
-      expect(spawnStub.firstCall.args).to.deep.equal([
-        'java',
-        [
-          `-DartifactPath=${artifactPath}`,
-          `-DclassName=${className}`,
-          `-DhandlerName=${handlerName}`,
-          '-jar',
-          wrapperPath,
-        ],
+      expect(command).to.equal('java');
+      expect(args).to.deep.equal([
+        `-DartifactPath=${artifactPath}`,
+        `-DclassName=${className}`,
+        `-DhandlerName=${handlerName}`,
+        '-jar',
+        wrapperPath,
       ]);
-      expect(writeChildStub.calledOnce).to.be.equal(true);
-      expect(endChildStub.calledOnce).to.be.equal(true);
-      expect(writeChildStub.calledWithExactly('{}')).to.be.equal(true);
+      expect(spawnOptions).to.include({ input: '{}' });
+      expect(spawnOptions).to.not.have.property('shell');
+      expect(spawnOptions.env).to.include({ KEEP_ME: 'yes' });
+      expect(spawnOptions.env).to.not.have.property('JAVA_TOOL_OPTIONS');
+      expect(spawnOptions.env).to.not.have.property('_JAVA_OPTIONS');
+      expect(spawnOptions.env).to.not.have.property('JDK_JAVA_OPTIONS');
+    });
+
+    it('preserves java runtime environment when requested', async () => {
+      invokeLocalSpawnStubbed.options['preserve-runtime-env'] = true;
+
+      await overrideEnv(
+        { variables: { JAVA_TOOL_OPTIONS: '-javaagent:/tmp/agent.jar' } },
+        async () => {
+          await invokeLocalSpawnStubbed.callJavaBridge(
+            'artifact.jar',
+            'com.example.Handler',
+            'handleRequest',
+            '{}'
+          );
+        }
+      );
+
+      expect(spawnExtStub.firstCall.args[2].env).to.include({
+        JAVA_TOOL_OPTIONS: '-javaagent:/tmp/agent.jar',
+      });
     });
   });
 
@@ -1212,9 +1275,6 @@ describe('AwsInvokeLocal', () => {
       AwsInvokeLocal = proxyquire('../../../../../../lib/plugins/aws/invoke-local/index', {
         '../../../utils/get-stdin': stdinStub,
         '../../../utils/spawn': spawnExtStub,
-        'child_process': {
-          spawn: spawnStub,
-        },
       });
       invokeLocalSpawnStubbed = new AwsInvokeLocal(serverless, {
         stage: 'dev',
@@ -1228,27 +1288,53 @@ describe('AwsInvokeLocal', () => {
       };
     });
 
-    it('spawns ruby process with correct arguments', async () => {
+    it('spawns ruby process with correct arguments and sanitized environment', async () => {
       const handlerPath = 'handler path;$(id)';
       const handlerName = 'hello "quoted" && id';
 
-      await invokeLocalSpawnStubbed.invokeLocalRuby(
-        'ruby',
-        handlerPath,
-        handlerName,
-        {},
-        undefined
+      await overrideEnv(
+        {
+          variables: {
+            RUBYOPT: '-e system("id")',
+            RUBYLIB: '/tmp/lib',
+            BUNDLE_GEMFILE: '/tmp/Gemfile',
+            BUNDLE_PATH: '/tmp/bundle',
+            KEEP_ME: 'yes',
+          },
+        },
+        async () => {
+          await invokeLocalSpawnStubbed.invokeLocalRuby(
+            'ruby',
+            handlerPath,
+            handlerName,
+            {},
+            undefined
+          );
+        }
       );
 
       const wrapperPath = await invokeLocalSpawnStubbed.resolveRuntimeWrapperPath('invoke.rb');
-      const [command, args, options] = spawnStub.firstCall.args;
+      const [command, args, options] = spawnExtStub.firstCall.args;
 
       expect(command).to.equal('ruby');
       expect(args).to.deep.equal([wrapperPath, handlerPath, handlerName]);
-      expect(options).to.have.property('env', process.env);
+      expect(JSON.parse(options.input).event).to.deep.equal({});
+      expect(options.env).to.include({ KEEP_ME: 'yes' });
+      expect(options.env).to.not.have.property('RUBYOPT');
+      expect(options.env).to.not.have.property('RUBYLIB');
+      expect(options.env).to.not.have.property('BUNDLE_GEMFILE');
+      expect(options.env).to.not.have.property('BUNDLE_PATH');
       expect(options).to.not.have.property('shell');
-      expect(writeChildStub.calledOnce).to.be.equal(true);
-      expect(endChildStub.calledOnce).to.be.equal(true);
+    });
+
+    it('preserves ruby runtime environment when requested', async () => {
+      invokeLocalSpawnStubbed.options['preserve-runtime-env'] = true;
+
+      await overrideEnv({ variables: { RUBYOPT: '-e system("id")' } }, async () => {
+        await invokeLocalSpawnStubbed.invokeLocalRuby('ruby', 'handler', 'hello', {}, undefined);
+      });
+
+      expect(spawnExtStub.firstCall.args[2].env).to.include({ RUBYOPT: '-e system("id")' });
     });
   });
 

--- a/test/unit/lib/utils/spawn.test.js
+++ b/test/unit/lib/utils/spawn.test.js
@@ -13,6 +13,26 @@ const spawn = require('../../../../lib/utils/spawn');
 
 const loadSpawnWithStubs = (stubs) =>
   proxyquire.noCallThru().load('../../../../lib/utils/spawn', stubs);
+const loadSpawnSyncWithStubs = (stubs) =>
+  proxyquire.noCallThru().load('../../../../lib/utils/spawn-sync', stubs);
+
+const repoRoot = path.resolve(__dirname, '../../../../');
+
+const collectJavaScriptFiles = async (directoryPath) => {
+  const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const entryPath = path.join(directoryPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectJavaScriptFiles(entryPath)));
+    } else if (entry.name.endsWith('.js')) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+};
 
 const waitFor = async (condition) => {
   for (let attempt = 0; attempt < 50; attempt += 1) {
@@ -59,6 +79,17 @@ const expectRejected = async (promise) => {
   throw new Error('Expected promise to reject');
 };
 
+const expectThrownCode = (fn, code) => {
+  try {
+    fn();
+  } catch (error) {
+    expect(error).to.have.property('code', code);
+    return error;
+  }
+
+  throw new Error(`Expected ${code} to be thrown`);
+};
+
 const assertRedaction = async ({ args, redacted, visible = [] }) => {
   const error = await expectRejected(
     spawn(process.execPath, ['-e', 'process.exit(7);', '--', ...args])
@@ -74,6 +105,48 @@ const assertRedaction = async ({ args, redacted, visible = [] }) => {
 };
 
 describe('spawn', () => {
+  it('rejects shell-enabled spawns synchronously before spawning', () => {
+    const crossSpawnStub = sinon.stub();
+    const spawnWithStubs = loadSpawnWithStubs({
+      'cross-spawn': crossSpawnStub,
+    });
+
+    const error = expectThrownCode(
+      () => spawnWithStubs('npm', ['install'], { shell: true }),
+      'UNSAFE_SHELL_SPAWN'
+    );
+
+    expect(error.message).to.include('shell enabled');
+    expect(crossSpawnStub).to.not.have.been.called;
+  });
+
+  it('requires args to be an array', () => {
+    const error = expectThrownCode(() => spawn('npm', 'install'), 'INVALID_SPAWN_INPUT');
+
+    expect(error.message).to.equal('Spawn args must be an array.');
+  });
+
+  it('rejects null bytes in args', () => {
+    const error = expectThrownCode(() => spawn('npm', ['a\0b']), 'INVALID_SPAWN_INPUT');
+
+    expect(error.message).to.equal('Refusing to spawn command with null bytes.');
+  });
+
+  it('enforces spawn policy for sync spawns', () => {
+    const crossSpawnStub = { sync: sinon.stub() };
+    const spawnSyncWithStubs = loadSpawnSyncWithStubs({
+      'cross-spawn': crossSpawnStub,
+    });
+
+    expectThrownCode(
+      () => spawnSyncWithStubs('npm', ['install'], { shell: true }),
+      'UNSAFE_SHELL_SPAWN'
+    );
+    expectThrownCode(() => spawnSyncWithStubs('npm', 'install'), 'INVALID_SPAWN_INPUT');
+    expectThrownCode(() => spawnSyncWithStubs('npm', ['a\0b']), 'INVALID_SPAWN_INPUT');
+    expect(crossSpawnStub.sync).to.not.have.been.called;
+  });
+
   it('executes PATH shims through cross-platform resolution', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spawn-shim-'));
     const commandName = `spawn-shim-${crypto.randomBytes(12).toString('hex')}`;
@@ -341,5 +414,29 @@ describe('spawn', () => {
     expect(error.stdoutBuffer).to.deep.equal(Buffer.alloc(0));
     expect(error.stderrBuffer).to.deep.equal(Buffer.alloc(0));
     expect(error.stdBuffer).to.deep.equal(Buffer.alloc(0));
+  });
+
+  it('does not use raw child process APIs in production command or lib files', async () => {
+    const prohibitedPattern =
+      /require\(['"]child_process['"]\)|child_process\.exec|cp\.exec|shell:\s*true/;
+    const files = (
+      await Promise.all(
+        ['commands', 'lib'].map((directoryName) =>
+          collectJavaScriptFiles(path.join(repoRoot, directoryName))
+        )
+      )
+    ).flat();
+    const violations = [];
+
+    for (const filePath of files) {
+      const contents = await fs.readFile(filePath, 'utf8');
+      contents.split(/\n/).forEach((line, index) => {
+        if (prohibitedPattern.test(line)) {
+          violations.push(`${path.relative(repoRoot, filePath)}:${index + 1}: ${line.trim()}`);
+        }
+      });
+    }
+
+    expect(violations).to.deep.equal([]);
   });
 });


### PR DESCRIPTION
This implements the Step 4 runtime spawn hardening on 4.x. It adds a shared spawn input policy for async and sync wrappers, removes the remaining direct production child_process usage, migrates Java and Ruby invoke local execution onto spawnExt, validates Java and Ruby handler syntax before spawning, and sanitizes Java/Ruby runtime environment variables by default while adding --preserve-runtime-env as an explicit opt-in.\n\nI verified the change with the focused spawn and invoke-local unit tests, targeted ESLint and Prettier checks, the production raw-process grep, git diff --check, npm run lint:updated, npm run prettier-check:updated, npm run lint, npm run prettier-check, and npm test.