### PR TITLE
Harden plugin spec handling

### DIFF
--- a/commands/plugin-install.js
+++ b/commands/plugin-install.js
@@ -12,8 +12,8 @@ const yamlAstParser = require('../lib/utils/yaml-ast-parser');
 const npmCommandDeferred = require('../lib/utils/npm-command-deferred');
 const { readJson, writeJson } = require('../lib/utils/fs/json-file');
 const {
-  getPluginInfo,
   getServerlessFilePath,
+  parsePluginInstallSpec,
   validate,
 } = require('../lib/commands/plugin-management');
 
@@ -23,12 +23,20 @@ module.exports = async ({ configuration, serviceDir, configurationFilename, opti
   const commandRunStartTime = Date.now();
   validate({ serviceDir });
 
-  const pluginInfo = getPluginInfo(options.name);
+  const pluginInfo = parsePluginInstallSpec(options.name);
   const pluginName = pluginInfo.name;
-  const pluginVersion = pluginInfo.version || 'latest';
+  const pluginVersion = pluginInfo.version;
   const configurationFilePath = getServerlessFilePath({ serviceDir, configurationFilename });
 
-  const context = { configuration, serviceDir, configurationFilePath, pluginName, pluginVersion };
+  const context = {
+    configuration,
+    serviceDir,
+    configurationFilePath,
+    pluginName,
+    pluginVersion,
+    installSpec: pluginInfo.installSpec,
+    allowInstallScripts: Boolean(options['allow-install-scripts']),
+  };
   mainProgress.notice(
     `Installing plugin "${pluginName}${pluginVersion === 'latest' ? '' : `@${pluginVersion}`}"`,
     { isMainEvent: true }
@@ -51,9 +59,8 @@ module.exports = async ({ configuration, serviceDir, configurationFilename, opti
   );
 };
 
-const installPlugin = async ({ serviceDir, pluginName, pluginVersion }) => {
-  const pluginFullName = `${pluginName}@${pluginVersion}`;
-  await npmInstall(pluginFullName, { serviceDir });
+const installPlugin = async ({ serviceDir, installSpec, allowInstallScripts }) => {
+  await npmInstall(installSpec, { serviceDir, allowInstallScripts });
 };
 
 const addPluginToServerlessFile = async ({ configurationFilePath, pluginName }) => {
@@ -122,10 +129,16 @@ const addPluginToServerlessFile = async ({ configurationFilePath, pluginName }) 
   );
 };
 
-const npmInstall = async (name, { serviceDir }) => {
+const npmInstall = async (name, { serviceDir, allowInstallScripts }) => {
   const { command, args } = await npmCommandDeferred;
+  const installArgs = ['install', '--save-dev'];
+
+  if (!allowInstallScripts) {
+    installArgs.push('--ignore-scripts');
+  }
+
   try {
-    await spawn(command, [...args, 'install', '--save-dev', '--', name], {
+    await spawn(command, [...args, ...installArgs, '--', name], {
       cwd: serviceDir,
       stdio: 'pipe',
     });

--- a/commands/plugin-uninstall.js
+++ b/commands/plugin-uninstall.js
@@ -11,8 +11,8 @@ const yamlAstParser = require('../lib/utils/yaml-ast-parser');
 const npmCommandDeferred = require('../lib/utils/npm-command-deferred');
 const { readJson, writeJson } = require('../lib/utils/fs/json-file');
 const {
-  getPluginInfo,
   getServerlessFilePath,
+  parsePluginUninstallSpec,
   validate,
 } = require('../lib/commands/plugin-management');
 
@@ -22,7 +22,7 @@ module.exports = async ({ configuration, serviceDir, configurationFilename, opti
   const commandRunStartTime = Date.now();
   validate({ serviceDir });
 
-  const pluginInfo = getPluginInfo(options.name);
+  const pluginInfo = parsePluginUninstallSpec(options.name);
   const pluginName = pluginInfo.name;
   const configurationFilePath = getServerlessFilePath({ serviceDir, configurationFilename });
 

--- a/docs/cli-reference/plugin-install.md
+++ b/docs/cli-reference/plugin-install.md
@@ -1,7 +1,7 @@
 # Plugin Install
 
-Install an osls plugin and add it to the services `plugins` array. By default, a latest version is installed.
-If you want a specific version, you can specify `<pluginname>@<version>` as name option.
+Install an osls plugin and add it to the service's `plugins` array. By default, the latest version is installed.
+If you want a specific version, semver range, or npm dist-tag, specify `<pluginname>@<version>` as the name option.
 
 **Note:** You might want to change the order of the plugin in the services `plugins` array.
 
@@ -12,6 +12,17 @@ serverless plugin install --name pluginName
 ## Options
 
 - `--name` or `-n` The plugins name. **Required**.
+- `--allow-install-scripts` Allow npm lifecycle scripts while installing the plugin. By default, plugin install passes `--ignore-scripts` to npm.
+
+The plugin name must be an npm package name, such as `serverless-webpack` or `@scope/serverless-plugin`. Versioned install specs may use semver ranges or dist-tags, such as `serverless-webpack@3.0.0-rc.2`, `serverless-webpack@^1.0.0 || 2`, or `@scope/serverless-plugin@next`.
+
+Literal embedded quotes are not accepted in osls v4. Quote the whole `--name` value at the shell level when the version range contains spaces or shell metacharacters:
+
+```bash
+serverless plugin install --name 'serverless-webpack@^1.0.0 || 2'
+```
+
+Package aliases, git URLs, HTTP URLs, file paths, workspace specs, and tarball paths are not accepted by `plugin install`.
 
 ## Provided lifecycle events
 
@@ -29,4 +40,10 @@ serverless plugin install --name serverless-webpack
 
 ```bash
 serverless plugin install --name serverless-webpack@3.0.0-rc.2
+```
+
+### Allow npm lifecycle scripts
+
+```bash
+serverless plugin install --name serverless-webpack --allow-install-scripts
 ```

--- a/docs/cli-reference/plugin-install.md
+++ b/docs/cli-reference/plugin-install.md
@@ -14,12 +14,12 @@ serverless plugin install --name pluginName
 - `--name` or `-n` The plugins name. **Required**.
 - `--allow-install-scripts` Allow npm lifecycle scripts while installing the plugin. By default, plugin install passes `--ignore-scripts` to npm.
 
-The plugin name must be an npm package name, such as `serverless-webpack` or `@scope/serverless-plugin`. Versioned install specs may use semver ranges or dist-tags, such as `serverless-webpack@3.0.0-rc.2`, `serverless-webpack@^1.0.0 || 2`, or `@scope/serverless-plugin@next`.
+The plugin name must be an npm package name, such as `example-osls-plugin` or `@example/osls-plugin`. Versioned install specs may use semver ranges or dist-tags, such as `example-osls-plugin@3.0.0-rc.2`, `example-osls-plugin@^1.0.0 || 2`, or `@example/osls-plugin@next`.
 
 Literal embedded quotes are not accepted in osls v4. Quote the whole `--name` value at the shell level when the version range contains spaces or shell metacharacters:
 
 ```bash
-serverless plugin install --name 'serverless-webpack@^1.0.0 || 2'
+serverless plugin install --name 'example-osls-plugin@^1.0.0 || 2'
 ```
 
 Package aliases, git URLs, HTTP URLs, file paths, workspace specs, and tarball paths are not accepted by `plugin install`.
@@ -30,20 +30,20 @@ Package aliases, git URLs, HTTP URLs, file paths, workspace specs, and tarball p
 
 ## Examples
 
-### Install the `serverless-webpack` plugin
+### Install the `example-osls-plugin` plugin
 
 ```bash
-serverless plugin install --name serverless-webpack
+serverless plugin install --name example-osls-plugin
 ```
 
 ### Install a specific version
 
 ```bash
-serverless plugin install --name serverless-webpack@3.0.0-rc.2
+serverless plugin install --name example-osls-plugin@3.0.0-rc.2
 ```
 
 ### Allow npm lifecycle scripts
 
 ```bash
-serverless plugin install --name serverless-webpack --allow-install-scripts
+serverless plugin install --name example-osls-plugin --allow-install-scripts
 ```

--- a/docs/cli-reference/plugin-uninstall.md
+++ b/docs/cli-reference/plugin-uninstall.md
@@ -10,7 +10,7 @@ serverless plugin uninstall --name pluginName
 
 - `--name` or `-n` The plugins name. **Required**.
 
-The name must be a bare npm package name, such as `serverless-webpack` or `@scope/serverless-plugin`. Versioned package specs such as `serverless-webpack@1.2.3` are not accepted by `plugin uninstall`.
+The name must be a bare npm package name, such as `example-osls-plugin` or `@example/osls-plugin`. Versioned package specs such as `example-osls-plugin@1.2.3` are not accepted by `plugin uninstall`.
 
 ## Provided lifecycle events
 
@@ -18,8 +18,8 @@ The name must be a bare npm package name, such as `serverless-webpack` or `@scop
 
 ## Examples
 
-### Remove the `serverless-webpack` plugin
+### Remove the `example-osls-plugin` plugin
 
 ```bash
-serverless plugin uninstall --name serverless-webpack
+serverless plugin uninstall --name example-osls-plugin
 ```

--- a/docs/cli-reference/plugin-uninstall.md
+++ b/docs/cli-reference/plugin-uninstall.md
@@ -10,6 +10,8 @@ serverless plugin uninstall --name pluginName
 
 - `--name` or `-n` The plugins name. **Required**.
 
+The name must be a bare npm package name, such as `serverless-webpack` or `@scope/serverless-plugin`. Versioned package specs such as `serverless-webpack@1.2.3` are not accepted by `plugin uninstall`.
+
 ## Provided lifecycle events
 
 - `plugin:uninstall:uninstall`

--- a/docs/guides/plugins/README.md
+++ b/docs/guides/plugins/README.md
@@ -17,19 +17,19 @@ Plugins are installed per service. They are not applied globally.
 To install a plugin, run the following command in a service directory:
 
 ```
-serverless plugin install -n custom-serverless-plugin
+serverless plugin install -n example-osls-plugin
 ```
 
 This command will install the plugin via NPM and register it in `serverless.yml`.
 
-`serverless plugin install --name` accepts npm package names, scoped package names, semver ranges, and npm dist-tags. For example, `custom-serverless-plugin`, `@scope/custom-serverless-plugin`, `custom-serverless-plugin@^1.0.0`, and `custom-serverless-plugin@next` are valid install specs. Literal embedded quotes are not accepted in osls v4; quote the full `--name` value at the shell level if your version range contains spaces.
+`serverless plugin install --name` accepts npm package names, scoped package names, semver ranges, and npm dist-tags. For example, `example-osls-plugin`, `@example/osls-plugin`, `example-osls-plugin@^1.0.0`, and `example-osls-plugin@next` are valid install specs. Literal embedded quotes are not accepted in osls v4; quote the full `--name` value at the shell level if your version range contains spaces.
 
 npm lifecycle scripts are ignored by default during plugin install. If you trust the plugin and need its lifecycle scripts to run, pass `--allow-install-scripts`.
 
 You can also install the plugin manually via NPM:
 
 ```
-npm install --save-dev custom-serverless-plugin
+npm install --save-dev example-osls-plugin
 ```
 
 and then register it in `serverless.yml` in the `plugins` section:
@@ -38,16 +38,16 @@ and then register it in `serverless.yml` in the `plugins` section:
 # serverless.yml file
 
 plugins:
-  - custom-serverless-plugin
+  - example-osls-plugin
 ```
 
-The `plugins` section accepts bare npm package names and explicit local plugin paths beginning with `./`. Versioned install specs such as `custom-serverless-plugin@1.2.3` are not accepted in configuration; pin plugin versions in `package.json` instead.
+The `plugins` section accepts bare npm package names and explicit local plugin paths beginning with `./`. Versioned install specs such as `example-osls-plugin@1.2.3` are not accepted in configuration; pin plugin versions in `package.json` instead.
 
 Some plugins require extra configuration. The `custom` section in `serverless.yml` is where you can add extra configuration for plugins (the plugin's documentation will tell you if you need to add anything there):
 
 ```yml
 plugins:
-  - custom-serverless-plugin
+  - example-osls-plugin
 
 custom:
   customkey: customvalue
@@ -69,7 +69,7 @@ If you are working on a plugin, or have a plugin that is just designed for one p
 
 ```yml
 plugins:
-  - ./local-directory/custom-serverless-plugin
+  - ./local-directory/example-osls-plugin
 ```
 
 The path must start with `./` and is relative to the root of your service.

--- a/docs/guides/plugins/README.md
+++ b/docs/guides/plugins/README.md
@@ -22,6 +22,10 @@ serverless plugin install -n custom-serverless-plugin
 
 This command will install the plugin via NPM and register it in `serverless.yml`.
 
+`serverless plugin install --name` accepts npm package names, scoped package names, semver ranges, and npm dist-tags. For example, `custom-serverless-plugin`, `@scope/custom-serverless-plugin`, `custom-serverless-plugin@^1.0.0`, and `custom-serverless-plugin@next` are valid install specs. Literal embedded quotes are not accepted in osls v4; quote the full `--name` value at the shell level if your version range contains spaces.
+
+npm lifecycle scripts are ignored by default during plugin install. If you trust the plugin and need its lifecycle scripts to run, pass `--allow-install-scripts`.
+
 You can also install the plugin manually via NPM:
 
 ```
@@ -36,6 +40,8 @@ and then register it in `serverless.yml` in the `plugins` section:
 plugins:
   - custom-serverless-plugin
 ```
+
+The `plugins` section accepts bare npm package names and explicit local plugin paths beginning with `./`. Versioned install specs such as `custom-serverless-plugin@1.2.3` are not accepted in configuration; pin plugin versions in `package.json` instead.
 
 Some plugins require extra configuration. The `custom` section in `serverless.yml` is where you can add extra configuration for plugins (the plugin's documentation will tell you if you need to add anything there):
 
@@ -67,6 +73,7 @@ plugins:
 ```
 
 The path must start with `./` and is relative to the root of your service.
+Local plugin paths must stay inside the service directory.
 
 The legacy object form can also set `plugins.localPath` to change where non-relative plugin names are loaded from. Use `plugins.localPath` only with trusted directories.
 

--- a/docs/guides/upgrading-to-v4.md
+++ b/docs/guides/upgrading-to-v4.md
@@ -107,7 +107,7 @@ Java and Ruby local invocation now fails the command when the local runtime exit
 
 Plugin entries in `serverless.yml` are now validated when osls loads the service. Entries must be lowercase npm package names, scoped npm package names, or explicit local paths beginning with `./` that stay inside the service directory.
 
-Versioned plugin configuration entries such as `serverless-webpack@1.2.3` now fail with `INVALID_PLUGIN_REFERENCE`; pin plugin versions in `package.json` instead. Non-string entries also fail with `INVALID_PLUGIN_REFERENCE`. Local plugin paths that escape the service directory, such as `./../plugin`, fail with `INVALID_LOCAL_PLUGIN_PATH`.
+Versioned plugin configuration entries such as `example-osls-plugin@1.2.3` now fail with `INVALID_PLUGIN_REFERENCE`; pin plugin versions in `package.json` instead. Non-string entries also fail with `INVALID_PLUGIN_REFERENCE`. Local plugin paths that escape the service directory, such as `./../plugin`, fail with `INVALID_LOCAL_PLUGIN_PATH`.
 
 The legacy `plugins.localPath` option is still supported, but module names loaded from that directory must use npm package-name syntax. If you previously loaded uppercase local plugin names such as `ServicePluginMock1` through `.serverless_plugins` or `plugins.localPath`, rename them to lowercase npm-style names or reference them with explicit `./` local paths.
 
@@ -116,7 +116,7 @@ The legacy `plugins.localPath` option is still supported, but module names loade
 `serverless plugin install --name` now accepts only npm package names with optional semver ranges or npm dist-tags. Embedded literal quotes are rejected; quote the whole `--name` value at the shell level when the version range contains spaces or shell metacharacters:
 
 ```bash
-serverless plugin install --name 'serverless-webpack@^1.0.0 || 2'
+serverless plugin install --name 'example-osls-plugin@^1.0.0 || 2'
 ```
 
 Package aliases, `file:`, `link:`, `workspace:`, `git+`, `github:`, `http:`, `https:`, `npm:`, tarball paths, absolute paths, and relative paths are no longer accepted by `plugin install`.
@@ -125,7 +125,7 @@ npm lifecycle scripts are ignored by default during plugin install. Pass `--allo
 
 ### `plugin uninstall` accepts package names only
 
-`serverless plugin uninstall --name` now accepts only a bare npm package name. Versioned package specs such as `serverless-webpack@1.2.3` fail with `INVALID_PLUGIN_UNINSTALL_SPEC`.
+`serverless plugin uninstall --name` now accepts only a bare npm package name. Versioned package specs such as `example-osls-plugin@1.2.3` fail with `INVALID_PLUGIN_UNINSTALL_SPEC`.
 
 ### `variablesResolutionMode: 20210219` is rejected
 

--- a/docs/guides/upgrading-to-v4.md
+++ b/docs/guides/upgrading-to-v4.md
@@ -103,6 +103,30 @@ If your local invocation intentionally depends on those variables, pass `--prese
 
 Java and Ruby local invocation now fails the command when the local runtime exits with a nonzero status. In v3, Java and Ruby local invocations could report success even if the spawned runtime process exited unsuccessfully. Update scripts that expected success despite a local runtime failure.
 
+### `plugins` configuration entries are validated
+
+Plugin entries in `serverless.yml` are now validated when osls loads the service. Entries must be lowercase npm package names, scoped npm package names, or explicit local paths beginning with `./` that stay inside the service directory.
+
+Versioned plugin configuration entries such as `serverless-webpack@1.2.3` now fail with `INVALID_PLUGIN_REFERENCE`; pin plugin versions in `package.json` instead. Non-string entries also fail with `INVALID_PLUGIN_REFERENCE`. Local plugin paths that escape the service directory, such as `./../plugin`, fail with `INVALID_LOCAL_PLUGIN_PATH`.
+
+The legacy `plugins.localPath` option is still supported, but module names loaded from that directory must use npm package-name syntax. If you previously loaded uppercase local plugin names such as `ServicePluginMock1` through `.serverless_plugins` or `plugins.localPath`, rename them to lowercase npm-style names or reference them with explicit `./` local paths.
+
+### `plugin install` accepts stricter package specs
+
+`serverless plugin install --name` now accepts only npm package names with optional semver ranges or npm dist-tags. Embedded literal quotes are rejected; quote the whole `--name` value at the shell level when the version range contains spaces or shell metacharacters:
+
+```bash
+serverless plugin install --name 'serverless-webpack@^1.0.0 || 2'
+```
+
+Package aliases, `file:`, `link:`, `workspace:`, `git+`, `github:`, `http:`, `https:`, `npm:`, tarball paths, absolute paths, and relative paths are no longer accepted by `plugin install`.
+
+npm lifecycle scripts are ignored by default during plugin install. Pass `--allow-install-scripts` only when you trust the plugin and need those scripts to run.
+
+### `plugin uninstall` accepts package names only
+
+`serverless plugin uninstall --name` now accepts only a bare npm package name. Versioned package specs such as `serverless-webpack@1.2.3` fail with `INVALID_PLUGIN_UNINSTALL_SPEC`.
+
 ### `variablesResolutionMode: 20210219` is rejected
 
 The legacy variables resolver mode is no longer supported. Remove `variablesResolutionMode` from your configuration.

--- a/lib/classes/plugin-manager.js
+++ b/lib/classes/plugin-manager.js
@@ -9,6 +9,7 @@ const tokenizeException = require('../utils/tokenize-exception');
 const getRequire = require('../utils/get-require');
 const importModule = require('../utils/require-with-import-fallback');
 const { log, getPluginWriters } = require('../utils/serverless-utils/log');
+const { splitPackageSpec, validatePluginName } = require('../commands/plugin-management');
 
 let hooksIdCounter = 0;
 let nestTracker = 0;
@@ -50,6 +51,39 @@ const mergeCommands = (target, source) => {
     }
   }
   return target;
+};
+
+const validateConfiguredPluginReference = (entry, serviceDir) => {
+  if (typeof entry !== 'string' || entry.trim() !== entry || entry === '') {
+    throw new ServerlessError('Plugin entries must be strings.', 'INVALID_PLUGIN_REFERENCE');
+  }
+
+  if (entry.startsWith('./')) {
+    const serviceRoot = path.resolve(serviceDir);
+    const resolved = path.resolve(serviceRoot, entry);
+    const relative = path.relative(serviceRoot, resolved);
+
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new ServerlessError(
+        `Local plugin path "${entry}" must stay inside the service directory.`,
+        'INVALID_LOCAL_PLUGIN_PATH'
+      );
+    }
+
+    return entry;
+  }
+
+  const { name, version } = splitPackageSpec(entry);
+  validatePluginName(name);
+
+  if (version != null) {
+    throw new ServerlessError(
+      'The plugins configuration must list package names, not versioned install specs.',
+      'INVALID_PLUGIN_REFERENCE'
+    );
+  }
+
+  return name;
 };
 
 /**
@@ -285,6 +319,10 @@ class PluginManager {
         modules = servicePlugs.modules;
       }
     }
+
+    modules = modules.map((entry) =>
+      validateConfiguredPluginReference(entry, this.serverless.serviceDir)
+    );
 
     return { modules, localPath };
   }

--- a/lib/cli/commands-schema/service.js
+++ b/lib/cli/commands-schema/service.js
@@ -32,10 +32,14 @@ commands.set('package', {
 commands.set('plugin install', {
   usage: 'Install and add a plugin to your service',
   options: {
-    name: {
+    'name': {
       usage: 'The plugin name',
       required: true,
       shortcut: 'n',
+    },
+    'allow-install-scripts': {
+      usage: 'Allow npm lifecycle scripts while installing the plugin',
+      type: 'boolean',
     },
   },
   lifecycleEvents: ['install'],

--- a/lib/commands/plugin-management.js
+++ b/lib/commands/plugin-management.js
@@ -1,13 +1,20 @@
 'use strict';
 
 const path = require('path');
+const semver = require('semver');
 const ServerlessError = require('../../lib/serverless-error');
 
 const maxNpmPackageNameLength = 214;
 const npmPackageNamePattern = /^(?:@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*$/;
+const npmDistTagPattern = /^[A-Za-z][A-Za-z0-9._-]*$/;
+const forbiddenVersionCharactersPattern = /[\0\r\n"'`$;&\\/:]/;
 
 const validatePluginName = (name) => {
-  if (name.length > maxNpmPackageNameLength || !npmPackageNamePattern.test(name)) {
+  if (
+    typeof name !== 'string' ||
+    name.length > maxNpmPackageNameLength ||
+    !npmPackageNamePattern.test(name)
+  ) {
     throw new ServerlessError(
       `Invalid plugin name "${name}". Plugin names must be valid npm package names.`,
       'INVALID_PLUGIN_NAME'
@@ -15,15 +22,66 @@ const validatePluginName = (name) => {
   }
 };
 
-const normalizePluginVersion = (version) => {
-  if (version == null || version.length < 2) return version;
+const splitPackageSpec = (input) => {
+  if (input.startsWith('@')) {
+    const slashIndex = input.indexOf('/');
+    const atIndex = slashIndex === -1 ? -1 : input.indexOf('@', slashIndex + 1);
+    if (atIndex === -1) return { name: input, version: undefined };
+    return { name: input.slice(0, atIndex), version: input.slice(atIndex + 1) };
+  }
 
-  const quote = version[0];
-  if ((quote === '"' || quote === "'") && version[version.length - 1] === quote) {
-    return version.slice(1, -1);
+  const atIndex = input.indexOf('@');
+  if (atIndex === -1) return { name: input, version: undefined };
+  return { name: input.slice(0, atIndex), version: input.slice(atIndex + 1) };
+};
+
+const validateInstallVersion = (version) => {
+  if (version == null) return 'latest';
+
+  if (version === '' || forbiddenVersionCharactersPattern.test(version)) {
+    throw new ServerlessError(`Invalid plugin version "${version}".`, 'INVALID_PLUGIN_VERSION');
+  }
+
+  if (!semver.validRange(version) && !npmDistTagPattern.test(version)) {
+    throw new ServerlessError(`Invalid plugin version "${version}".`, 'INVALID_PLUGIN_VERSION');
   }
 
   return version;
+};
+
+const parsePluginInstallSpec = (raw) => {
+  if (typeof raw !== 'string' || raw.trim() !== raw || raw === '') {
+    throw new ServerlessError(`Invalid plugin spec "${raw}".`, 'INVALID_PLUGIN_NAME');
+  }
+
+  const { name, version } = splitPackageSpec(raw);
+  validatePluginName(name);
+
+  const normalizedVersion = validateInstallVersion(version);
+
+  return {
+    name,
+    version: normalizedVersion,
+    installSpec: `${name}@${normalizedVersion}`,
+  };
+};
+
+const parsePluginUninstallSpec = (raw) => {
+  if (typeof raw !== 'string' || raw.trim() !== raw || raw === '') {
+    throw new ServerlessError(`Invalid plugin name "${raw}".`, 'INVALID_PLUGIN_NAME');
+  }
+
+  const { name, version } = splitPackageSpec(raw);
+  validatePluginName(name);
+
+  if (version != null) {
+    throw new ServerlessError(
+      'Plugin uninstall accepts a package name, not a versioned package spec.',
+      'INVALID_PLUGIN_UNINSTALL_SPEC'
+    );
+  }
+
+  return { name };
 };
 
 module.exports = {
@@ -46,22 +104,8 @@ module.exports = {
     );
   },
 
-  getPluginInfo(name_) {
-    if (typeof name_ !== 'string') {
-      throw new ServerlessError(
-        `Invalid plugin name "${name_}". Plugin names must be valid npm package names.`,
-        'INVALID_PLUGIN_NAME'
-      );
-    }
-    let name;
-    let version;
-    if (name_.startsWith('@')) {
-      [, name, version] = name_.split('@', 3);
-      name = `@${name}`;
-    } else {
-      [name, version] = name_.split('@', 2);
-    }
-    validatePluginName(name);
-    return { name, version: normalizePluginVersion(version) };
-  },
+  parsePluginInstallSpec,
+  parsePluginUninstallSpec,
+  splitPackageSpec,
+  validatePluginName,
 };

--- a/test/unit/commands/plugin-install.test.js
+++ b/test/unit/commands/plugin-install.test.js
@@ -47,13 +47,16 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
   });
   const pluginName = 'serverless-plugin-1';
 
-  const expectInstallSpawn = (serviceDir, packageSpec) => {
-    expect(spawnFake.firstCall.args[1].slice(-4)).to.deep.equal([
+  const expectInstallSpawn = (serviceDir, packageSpec, { allowInstallScripts = false } = {}) => {
+    const expectedArgs = [
       'install',
       '--save-dev',
+      ...(allowInstallScripts ? [] : ['--ignore-scripts']),
       '--',
       packageSpec,
-    ]);
+    ];
+
+    expect(spawnFake.firstCall.args[1].slice(-expectedArgs.length)).to.deep.equal(expectedArgs);
     expect(spawnFake.firstCall.args[2]).to.deep.equal({
       cwd: serviceDir,
       stdio: 'pipe',
@@ -163,12 +166,41 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
     });
   });
 
+  describe('with invalid plugin version', () => {
+    for (const inputName of [`${pluginName}@1.0.0;id`, `${pluginName}@"^1.60.0 || 2"`]) {
+      it(`rejects ${JSON.stringify(inputName)} before installing`, async () => {
+        const fixture = await setupProgrammaticFixture('function');
+        const configuration = fixture.serviceConfig;
+        const serviceDir = fixture.servicePath;
+        const configurationFilePath = await resolveConfigurationPath({
+          cwd: serviceDir,
+        });
+        const configurationFilename = configurationFilePath.slice(serviceDir.length + 1);
+        const originalConfigurationText = await fsp.readFile(configurationFilePath, 'utf8');
+
+        await expect(
+          installPlugin({
+            configuration,
+            serviceDir,
+            configurationFilename,
+            options: {
+              name: inputName,
+            },
+          })
+        ).to.be.eventually.rejected.and.have.property('code', 'INVALID_PLUGIN_VERSION');
+
+        expect(spawnFake).to.not.have.been.called;
+        expect(await fsp.readFile(configurationFilePath, 'utf8')).to.equal(
+          originalConfigurationText
+        );
+      });
+    }
+  });
+
   describe('with package specs that require argv boundaries', () => {
     for (const [inputName, expectedPackageSpec] of [
       ['@scope/serverless-plugin-1', '@scope/serverless-plugin-1@latest'],
       [`${pluginName}@^1.0.0 || 2`, `${pluginName}@^1.0.0 || 2`],
-      [`${pluginName}@1.0.0;id`, `${pluginName}@1.0.0;id`],
-      [`${pluginName}@"^1.60.0 || 2"`, `${pluginName}@^1.60.0 || 2`],
     ]) {
       it(`passes ${JSON.stringify(expectedPackageSpec)} as one npm argv element`, async () => {
         const fixture = await setupProgrammaticFixture('function');
@@ -190,6 +222,31 @@ describe('test/unit/commands/plugin-install.test.js', async () => {
         expect(spawnFake.firstCall.args[2]).to.not.have.property('shell');
       });
     }
+  });
+
+  describe('with install scripts explicitly allowed', () => {
+    it('omits --ignore-scripts', async () => {
+      const fixture = await setupProgrammaticFixture('function');
+      const configuration = fixture.serviceConfig;
+      const serviceDir = fixture.servicePath;
+      const configurationFilePath = await resolveConfigurationPath({
+        cwd: serviceDir,
+      });
+      const configurationFilename = configurationFilePath.slice(serviceDir.length + 1);
+
+      await installPlugin({
+        configuration,
+        serviceDir,
+        configurationFilename,
+        options: {
+          'name': pluginName,
+          'allow-install-scripts': true,
+        },
+      });
+
+      expectInstallSpawn(serviceDir, `${pluginName}@latest`, { allowInstallScripts: true });
+      expect(spawnFake.firstCall.args[1]).to.not.include('--ignore-scripts');
+    });
   });
 
   describe('with JSON configuration', () => {

--- a/test/unit/commands/plugin-uninstall.test.js
+++ b/test/unit/commands/plugin-uninstall.test.js
@@ -143,6 +143,40 @@ describe('test/unit/commands/plugin-uninstall.test.js', async () => {
     });
   });
 
+  describe('with versioned package spec', () => {
+    it('rejects before uninstalling or updating the configuration file', async () => {
+      const fixture = await setupProgrammaticFixture('function', {
+        configExt: {
+          plugins: [pluginName],
+        },
+      });
+
+      const configuration = fixture.serviceConfig;
+      const fixtureServiceDir = fixture.servicePath;
+      const fixtureConfigurationPath = await resolveConfigurationPath({
+        cwd: fixtureServiceDir,
+      });
+      const configurationFilename = fixtureConfigurationPath.slice(fixtureServiceDir.length + 1);
+      const originalConfigurationText = await fsp.readFile(fixtureConfigurationPath, 'utf8');
+
+      await expect(
+        uninstallPlugin({
+          configuration,
+          serviceDir: fixtureServiceDir,
+          configurationFilename,
+          options: {
+            name: `${pluginName}@1.2.3`,
+          },
+        })
+      ).to.be.eventually.rejected.and.have.property('code', 'INVALID_PLUGIN_UNINSTALL_SPEC');
+
+      expect(spawnFake).to.not.have.been.called;
+      expect(await fsp.readFile(fixtureConfigurationPath, 'utf8')).to.equal(
+        originalConfigurationText
+      );
+    });
+  });
+
   describe('with JSON configuration', () => {
     it('removes a plugin from array-form plugins', async () => {
       const fixture = await setupProgrammaticFixture('function');

--- a/test/unit/lib/classes/plugin-manager.test.js
+++ b/test/unit/lib/classes/plugin-manager.test.js
@@ -137,6 +137,11 @@ describe('PluginManager', () => {
 
   class ServicePluginMock2 {}
 
+  const servicePluginMock1Name = 'service-plugin-mock-1';
+  const servicePluginMock2Name = 'service-plugin-mock-2';
+  const servicePluginMock3Name = 'service-plugin-mock-3';
+  const brokenPluginMockName = 'broken-plugin-mock';
+
   const brokenPluginError = new Error('Broken plugin');
   class BrokenPluginMock {
     constructor() {
@@ -385,9 +390,9 @@ describe('PluginManager', () => {
 
   const resolveStub = (directory, pluginPath) => {
     switch (pluginPath) {
-      case 'BrokenPluginMock':
-      case 'ServicePluginMock1':
-      case 'ServicePluginMock2':
+      case brokenPluginMockName:
+      case servicePluginMock1Name:
+      case servicePluginMock2Name:
         return pluginPath;
       case './RelativePath/ServicePluginMock2':
         return `${serviceDir}/RelativePath/ServicePluginMock2`;
@@ -593,9 +598,9 @@ describe('PluginManager', () => {
 
   describe('#loadAllPlugins()', () => {
     beforeEach(() => {
-      servicePluginMocks.set('ServicePluginMock1', ServicePluginMock1);
-      servicePluginMocks.set('ServicePluginMock2', ServicePluginMock2);
-      servicePluginMocks.set('BrokenPluginMock', BrokenPluginMock);
+      servicePluginMocks.set(servicePluginMock1Name, ServicePluginMock1);
+      servicePluginMocks.set(servicePluginMock2Name, ServicePluginMock2);
+      servicePluginMocks.set(brokenPluginMockName, BrokenPluginMock);
     });
 
     it('should load only core plugins when no service plugins are given', async () => {
@@ -608,7 +613,7 @@ describe('PluginManager', () => {
     });
 
     it('should load all plugins when service plugins are given', async () => {
-      const servicePlugins = ['ServicePluginMock1', 'ServicePluginMock2'];
+      const servicePlugins = [servicePluginMock1Name, servicePluginMock2Name];
       await pluginManager.loadAllPlugins(servicePlugins);
 
       expect(pluginManager.plugins.some((plugin) => plugin instanceof ServicePluginMock1)).to.equal(
@@ -623,7 +628,7 @@ describe('PluginManager', () => {
     });
 
     it('should load all plugins in the correct order', async () => {
-      const servicePlugins = ['ServicePluginMock1', 'ServicePluginMock2'];
+      const servicePlugins = [servicePluginMock1Name, servicePluginMock2Name];
 
       await pluginManager.loadAllPlugins(servicePlugins);
 
@@ -642,7 +647,7 @@ describe('PluginManager', () => {
     });
 
     it('should throw an error when trying to load unknown plugin', () => {
-      const servicePlugins = ['ServicePluginMock3', 'ServicePluginMock1'];
+      const servicePlugins = [servicePluginMock3Name, servicePluginMock1Name];
 
       return expect(pluginManager.loadAllPlugins(servicePlugins)).to.be.rejectedWith(
         ServerlessError
@@ -650,7 +655,7 @@ describe('PluginManager', () => {
     });
 
     it('should not throw error when trying to load unknown plugin with help flag', async () => {
-      const servicePlugins = ['ServicePluginMock3', 'ServicePluginMock1'];
+      const servicePlugins = [servicePluginMock3Name, servicePluginMock1Name];
 
       pluginManager.setCliOptions({ help: true });
 
@@ -663,7 +668,7 @@ describe('PluginManager', () => {
     });
 
     it('should pass through an error when plugin load fails', () => {
-      const servicePlugins = ['BrokenPluginMock'];
+      const servicePlugins = [brokenPluginMockName];
 
       return expect(pluginManager.loadAllPlugins(servicePlugins)).to.be.rejectedWith(
         brokenPluginError
@@ -671,7 +676,7 @@ describe('PluginManager', () => {
     });
 
     it('should not throw error when running the plugin commands and given plugins does not exist', () => {
-      const servicePlugins = ['ServicePluginMock3'];
+      const servicePlugins = [servicePluginMock3Name];
       const cliCommandsMock = ['plugin'];
       pluginManager.setCliCommands(cliCommandsMock);
 
@@ -683,13 +688,13 @@ describe('PluginManager', () => {
 
   describe('#resolveServicePlugins()', () => {
     beforeEach(() => {
-      servicePluginMocks.set('ServicePluginMock1', ServicePluginMock1);
+      servicePluginMocks.set(servicePluginMock1Name, ServicePluginMock1);
       // Plugins loaded via a relative path should be required relative to the service path
       servicePluginMocks.set(`${serviceDir}/RelativePath/ServicePluginMock2`, ServicePluginMock2);
     });
 
     it('should resolve the service plugins', async () => {
-      const servicePlugins = ['ServicePluginMock1', './RelativePath/ServicePluginMock2'];
+      const servicePlugins = [servicePluginMock1Name, './RelativePath/ServicePluginMock2'];
       expect(await pluginManager.resolveServicePlugins(servicePlugins)).to.deep.equal([
         ServicePluginMock1,
         ServicePluginMock2,
@@ -716,7 +721,7 @@ describe('PluginManager', () => {
     };
 
     it('should parse array object', () => {
-      const servicePlugins = ['ServicePluginMock1', 'ServicePluginMock2'];
+      const servicePlugins = [servicePluginMock1Name, servicePluginMock2Name];
 
       parsePluginsObjectAndVerifyResult(servicePlugins, {
         modules: servicePlugins,
@@ -726,7 +731,7 @@ describe('PluginManager', () => {
 
     it('should parse plugins object', () => {
       const servicePlugins = {
-        modules: ['ServicePluginMock1', 'ServicePluginMock2'],
+        modules: [servicePluginMock1Name, servicePluginMock2Name],
         localPath: './myplugins',
       };
 
@@ -756,7 +761,7 @@ describe('PluginManager', () => {
 
     it('should parse plugins object if localPath is not correct', () => {
       const servicePlugins = {
-        modules: ['ServicePluginMock1', 'ServicePluginMock2'],
+        modules: [servicePluginMock1Name, servicePluginMock2Name],
         localPath: {},
       };
 
@@ -764,6 +769,30 @@ describe('PluginManager', () => {
         modules: servicePlugins.modules,
         localPath: path.join(serverless.serviceDir, '.serverless_plugins'),
       });
+    });
+
+    it('rejects versioned package specs', () => {
+      expect(() => pluginManager.parsePluginsObject(['serverless-webpack@1.2.3']))
+        .to.throw()
+        .with.property('code', 'INVALID_PLUGIN_REFERENCE');
+    });
+
+    it('rejects local plugin paths that escape the service directory', () => {
+      expect(() => pluginManager.parsePluginsObject(['./../plugin']))
+        .to.throw()
+        .with.property('code', 'INVALID_LOCAL_PLUGIN_PATH');
+    });
+
+    it('preserves local plugin paths inside the service directory', () => {
+      expect(pluginManager.parsePluginsObject(['./plugins/local-plugin']).modules).to.deep.equal([
+        './plugins/local-plugin',
+      ]);
+    });
+
+    it('rejects non-string plugin entries', () => {
+      expect(() => pluginManager.parsePluginsObject([{}]))
+        .to.throw()
+        .with.property('code', 'INVALID_PLUGIN_REFERENCE');
     });
   });
 
@@ -991,12 +1020,12 @@ describe('PluginManager', () => {
 
   describe('#getPlugins()', () => {
     beforeEach(() => {
-      servicePluginMocks.set('ServicePluginMock1', ServicePluginMock1);
-      servicePluginMocks.set('ServicePluginMock2', ServicePluginMock2);
+      servicePluginMocks.set(servicePluginMock1Name, ServicePluginMock1);
+      servicePluginMocks.set(servicePluginMock2Name, ServicePluginMock2);
     });
 
     it('should return all loaded plugins', async () => {
-      const servicePlugins = ['ServicePluginMock1', 'ServicePluginMock2'];
+      const servicePlugins = [servicePluginMock1Name, servicePluginMock2Name];
       await pluginManager.loadAllPlugins(servicePlugins);
 
       const plugins = pluginManager.getPlugins();

--- a/test/unit/lib/commands/plugin-management.test.js
+++ b/test/unit/lib/commands/plugin-management.test.js
@@ -1,36 +1,38 @@
 'use strict';
 
 const { expect } = require('chai');
-const { getPluginInfo } = require('../../../../lib/commands/plugin-management');
+const {
+  parsePluginInstallSpec,
+  parsePluginUninstallSpec,
+} = require('../../../../lib/commands/plugin-management');
 
 describe('test/unit/lib/commands/plugin-management.test.js', () => {
-  describe('#getPluginInfo()', () => {
-    const maxLengthName = 'a'.repeat(214);
-    const overLengthName = 'a'.repeat(215);
-    const scopedMaxLengthName = `@${'a'.repeat(100)}/${'b'.repeat(112)}`;
-    const scopedOverLengthName = `@${'a'.repeat(100)}/${'b'.repeat(113)}`;
+  const maxLengthName = 'a'.repeat(214);
+  const overLengthName = 'a'.repeat(215);
+  const scopedMaxLengthName = `@${'a'.repeat(100)}/${'b'.repeat(112)}`;
+  const scopedOverLengthName = `@${'a'.repeat(100)}/${'b'.repeat(113)}`;
 
+  describe('#parsePluginInstallSpec()', () => {
     for (const [input, expected] of [
-      ['serverless-webpack', { name: 'serverless-webpack', version: undefined }],
-      ['serverless-plugin-foo', { name: 'serverless-plugin-foo', version: undefined }],
-      ['@scope/serverless-plugin', { name: '@scope/serverless-plugin', version: undefined }],
+      ['serverless-webpack', { name: 'serverless-webpack', version: 'latest' }],
+      ['serverless-webpack@3.0.0-rc.2', { name: 'serverless-webpack', version: '3.0.0-rc.2' }],
+      ['serverless-webpack@^1.0.0 || 2', { name: 'serverless-webpack', version: '^1.0.0 || 2' }],
+      ['@scope/serverless-plugin@next', { name: '@scope/serverless-plugin', version: 'next' }],
+      ['serverless-plugin-foo', { name: 'serverless-plugin-foo', version: 'latest' }],
+      ['@scope/serverless-plugin', { name: '@scope/serverless-plugin', version: 'latest' }],
       ['serverless-plugin@latest', { name: 'serverless-plugin', version: 'latest' }],
       ['serverless-plugin@1.2.3', { name: 'serverless-plugin', version: '1.2.3' }],
-      ['serverless-plugin@^1.0.0 || 2', { name: 'serverless-plugin', version: '^1.0.0 || 2' }],
-      ['serverless-plugin@"^1.60.0 || 2"', { name: 'serverless-plugin', version: '^1.60.0 || 2' }],
-      ["serverless-plugin@'^1.60.0 || 2'", { name: 'serverless-plugin', version: '^1.60.0 || 2' }],
       ['@scope/serverless-plugin@1.2.3', { name: '@scope/serverless-plugin', version: '1.2.3' }],
-      [
-        '@scope/serverless-plugin@"^1.60.0 || 2"',
-        { name: '@scope/serverless-plugin', version: '^1.60.0 || 2' },
-      ],
-      [maxLengthName, { name: maxLengthName, version: undefined }],
+      [maxLengthName, { name: maxLengthName, version: 'latest' }],
       [`${maxLengthName}@latest`, { name: maxLengthName, version: 'latest' }],
-      [scopedMaxLengthName, { name: scopedMaxLengthName, version: undefined }],
+      [scopedMaxLengthName, { name: scopedMaxLengthName, version: 'latest' }],
       [`${scopedMaxLengthName}@1.2.3`, { name: scopedMaxLengthName, version: '1.2.3' }],
     ]) {
       it(`parses valid plugin spec "${input}"`, () => {
-        expect(getPluginInfo(input)).to.deep.equal(expected);
+        expect(parsePluginInstallSpec(input)).to.include(expected);
+        expect(parsePluginInstallSpec(input).installSpec).to.equal(
+          `${expected.name}@${expected.version}`
+        );
       });
     }
 
@@ -59,7 +61,48 @@ describe('test/unit/lib/commands/plugin-management.test.js', () => {
       `${scopedOverLengthName}@1.2.3`,
     ]) {
       it(`rejects invalid plugin spec ${JSON.stringify(input)}`, () => {
-        expect(() => getPluginInfo(input))
+        expect(() => parsePluginInstallSpec(input))
+          .to.throw()
+          .with.property('code', 'INVALID_PLUGIN_NAME');
+      });
+    }
+
+    for (const input of [
+      'serverless-webpack@"^1.60.0 || 2"',
+      "serverless-webpack@'^1.60.0 || 2'",
+      'serverless-webpack@file:../plugin',
+      'serverless-webpack@git+ssh://example/repo',
+      'serverless-webpack@https://example.com/plugin.tgz',
+      'serverless-webpack@npm:other',
+      'serverless-webpack@workspace:*',
+      'serverless-webpack@1.2.3\n--prefix=/tmp/x',
+      'serverless-webpack@1.2.3;id',
+      'serverless-webpack@',
+    ]) {
+      it(`rejects invalid plugin version in ${JSON.stringify(input)}`, () => {
+        expect(() => parsePluginInstallSpec(input))
+          .to.throw()
+          .with.property('code', 'INVALID_PLUGIN_VERSION');
+      });
+    }
+  });
+
+  describe('#parsePluginUninstallSpec()', () => {
+    for (const input of ['serverless-webpack', '@scope/serverless-plugin', maxLengthName]) {
+      it(`parses valid plugin name "${input}"`, () => {
+        expect(parsePluginUninstallSpec(input)).to.deep.equal({ name: input });
+      });
+    }
+
+    it('rejects versioned package specs', () => {
+      expect(() => parsePluginUninstallSpec('serverless-webpack@1.2.3'))
+        .to.throw()
+        .with.property('code', 'INVALID_PLUGIN_UNINSTALL_SPEC');
+    });
+
+    for (const input of ['', '--prefix=/tmp/x', 'serverless plugin', overLengthName]) {
+      it(`rejects invalid plugin name ${JSON.stringify(input)}`, () => {
+        expect(() => parsePluginUninstallSpec(input))
           .to.throw()
           .with.property('code', 'INVALID_PLUGIN_NAME');
       });


### PR DESCRIPTION
This implements the Step 5 plugin spec and installer policy hardening on 4.x. It replaces the legacy plugin spec parser with explicit install and uninstall parsers, rejects ambiguous or non-npm plugin install inputs, rejects versioned uninstall specs, validates configured plugin references while preserving explicit ./ local plugins and plugins.localPath, and changes plugin install to pass --ignore-scripts by default unless users opt into lifecycle scripts with --allow-install-scripts. It also updates the plugin install, plugin uninstall, and plugin guide documentation for the stricter accepted forms and install-script policy.