### PR TITLE
Document scope of Proxy-backed file address resolution

### DIFF
--- a/docs/guides/variables.md
+++ b/docs/guides/variables.md
@@ -497,7 +497,7 @@ functions:
       - schedule: ${file(./scheduleConfig.js):rate} # Reference a specific module
 ```
 
-Address resolution follows the value's own properties. If a JS file exports (or its resolver function returns) a `Proxy`-backed object, address segments are resolved through the proxy's `get` handler instead. The keys `__proto__`, `prototype` and `constructor` are only followed when they are own properties of the value, so an address can never traverse into prototype internals.
+Address resolution follows the value's own properties. If a JS file exports (or its resolver function returns) a `Proxy`-backed object, address segments are resolved through the proxy's `get` handler instead. The keys `__proto__`, `prototype` and `constructor` are only followed when they are own properties of the value, so an address can never traverse into prototype internals. This proxy-aware resolution applies to `file(...)` addresses only — when the same value is reached another way (for example via a `${self:...}` reference into a property that was populated from a `${file(...)}` variable, or via `serverless print --path`), only own properties are followed.
 
 ### Exporting a function
 


### PR DESCRIPTION
Follow-up to #396. The new paragraph in the variables guide explains how proxy-backed values are handled during file address resolution, but it doesn't say that this behaviour is specific to addressing through `file(...)` itself. If the same value is embedded into the configuration and then reached via `${self:...}`, or dug into with `serverless print --path`, traversal still follows own properties only, so a virtual property served by a proxy's get handler won't be found there. This adds a sentence making that boundary explicit, so nobody reads the paragraph as a general guarantee about every way of addressing into a value that originated from a JS file.