### PR TITLE
Set placeholder dev version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osls",
-  "version": "3.40.1",
+  "version": "4.0.0-dev",
   "description": "osls CLI for deploying serverless applications",
   "preferGlobal": true,
   "homepage": "https://github.com/oss-serverless/osls",


### PR DESCRIPTION
The version in package.json does nothing for releases: the publish workflow stamps the real number from the release tag with npm version before packing, testing and publishing. Carrying the stale 3.40.1 around is actively misleading on this branch, since a dev checkout reports itself as a v3 release through sls --version and through the serverless.version property exposed to plugins.

This sets the field to 4.0.0-dev, which is valid semver that npm happily accepts but is clearly not a real release. The major is kept truthful rather than using something like 0.0.0-development because the frameworkVersion validation in the service class compares against a coerced version, so a dev checkout run against a service pinned to a v4 range keeps validating as expected, while still failing loudly anywhere the placeholder would be the wrong thing to expose. The version-sensitive tests either stub the version or read it from package.json directly, so nothing depends on the old value.