### PR TITLE
Pin 4.x install examples

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ Get started with the osls open-source CLI and Amazon Web Services in minutes.
 Install `osls` module via NPM:
 
 ```bash
-npm install -g osls
+npm install -g osls@4
 ```
 
 _Requires Node.js `^20.19.0 || ^22.13.0 || >=24`. If you don’t already have a supported Node.js version on your machine, [install it first](https://nodejs.org/)._

--- a/docs/guides/services.md
+++ b/docs/guides/services.md
@@ -143,7 +143,7 @@ The removal process will only remove the service on your provider's infrastructu
 
 ## Version Pinning
 
-osls is usually installed globally via `npm install -g osls`. This way you have the osls CLI available for all your services.
+osls is usually installed globally via `npm install -g osls@4`. This way you have the osls CLI available for all your services.
 
 Installing tools globally has the downside that the version can't be pinned inside package.json. This can lead to issues if you upgrade osls, but your colleagues or CI system don't. You can now use a new feature in your `serverless.yml` which is available only in the latest version without worrying that your CI system will deploy with an old osls version.
 


### PR DESCRIPTION
The 4.x docs should not tell users to install the floating osls package because that can resolve to the wrong release line. This updates the remaining global install examples to use osls@4 explicitly.