### PR TITLE
Pin remaining 4.x install guidance

### DIFF
--- a/docs/guides/services.md
+++ b/docs/guides/services.md
@@ -193,7 +193,7 @@ If you already have a service, and would prefer to lock down the osls version us
 
 ```bash
 # from within a service
-npm install osls --save-dev
+npm install osls@4 --save-dev
 ```
 
 ### Invoking the CLI locally

--- a/docs/guides/upgrading-to-v4.md
+++ b/docs/guides/upgrading-to-v4.md
@@ -9,7 +9,7 @@ osls v4 is a major release with internal upgrades and new capabilities:
 
 ## osls vs Serverless Framework
 
-This guide is for upgrading the **`osls`** CLI (`npm install osls`), not [Serverless Framework](https://github.com/serverless/serverless). Both projects use "v3" and "v4" version numbers, but they are **different projects**.
+This guide is for upgrading the **`osls`** CLI (`npm install osls@4`), not [Serverless Framework](https://github.com/serverless/serverless). Both projects use "v3" and "v4" version numbers, but they are **different projects**.
 
 **History (osls v3):** osls v3 began as a fork of Serverless Framework v3. The repo was `oss-serverless/serverless` on GitHub and `osls` in npm. For clarity, the GitHub repo has been renamed to `oss-serverless/osls` to match.
 

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -62,8 +62,10 @@ class Serverless {
           'Cannot run a local osls installation with an outdated global version.',
           'Please upgrade via:',
           '',
-          colors.bold('npm install -g osls@latest'),
-          colors.gray('Note: The latest release can run any locally installed osls version.'),
+          colors.bold('npm install -g osls@4'),
+          colors.gray(
+            'Note: The latest 4.x release can run any locally installed osls 4.x version.'
+          ),
           '',
           'Alternatively run locally installed version directly via:',
           '',


### PR DESCRIPTION
The 4.x docs and outdated-global fallback message should not point users at floating osls installs because they can resolve to the wrong release line. This updates the remaining local install example, upgrading-guide package reference, and fallback upgrade command to use osls@4 explicitly.