### PR TITLE
Fix invalid examples and broken links in the docs

### DIFF
--- a/docs/events/alb.md
+++ b/docs/events/alb.md
@@ -29,7 +29,6 @@ functions:
           listenerArn: arn:aws:elasticloadbalancing:us-east-1:12345:listener/app/my-load-balancer/50dc6c495c0c9188/
           priority: 1
           conditions:
-            host: example.com
             path: /hello
             method:
               - POST
@@ -60,8 +59,8 @@ provider:
     authorizers:
       myFirstAuth:
         type: 'cognito'
-        userPoolArn: 'arn:aws:cognito-idp:us-east-1:123412341234:userpool/us-east-1_123412341', # required
-        userPoolClientId: '1h57kf5cpq17m0eml12EXAMPLE', # required
+        userPoolArn: 'arn:aws:cognito-idp:us-east-1:123412341234:userpool/us-east-1_123412341' # required
+        userPoolClientId: '1h57kf5cpq17m0eml12EXAMPLE' # required
         userPoolDomain: 'your-test-domain' # required
         onUnauthenticatedRequest: 'deny' # If set to 'allow' this allows the request to be forwarded to the target when user is not authenticated. When omitted it defaults 'deny' which makes a HTTP 401 Unauthorized error be returned. Alternatively configure to 'authenticate' to redirect request to IdP authorization endpoint.
         requestExtraParams: # optional. The query parameters (up to 10) to include in the redirect request to the authorization endpoint
@@ -72,12 +71,12 @@ provider:
         sessionTimeout: 7000 # The maximum duration of the authentication session, in seconds. The default is 604800 seconds (7 days).
       mySecondAuth:
         type: 'oidc'
-        authorizationEndpoint: 'https://example.com', # required. The authorization endpoint of the IdP. Must be a full URL, including the HTTPS protocol, the domain, and the path
-        clientId: 'i-am-client', # required
-        clientSecret: 'i-am-secret', # if creating a rule this is required. If modifying a rule, this can be omitted if you set useExistingClientSecret to true (as below)
+        authorizationEndpoint: 'https://example.com' # required. The authorization endpoint of the IdP. Must be a full URL, including the HTTPS protocol, the domain, and the path
+        clientId: 'i-am-client' # required
+        clientSecret: 'i-am-secret' # if creating a rule this is required. If modifying a rule, this can be omitted if you set useExistingClientSecret to true (as below)
         useExistingClientSecret: true # only required if clientSecret is omitted
-        issuer: 'https://www.iamscam.com', # required. The OIDC issuer identifier of the IdP. This must be a full URL, including the HTTPS protocol, the domain, and the path
-        tokenEndpoint: 'http://somewhere.org', # required
+        issuer: 'https://www.iamscam.com' # required. The OIDC issuer identifier of the IdP. This must be a full URL, including the HTTPS protocol, the domain, and the path
+        tokenEndpoint: 'http://somewhere.org' # required
         userInfoEndpoint: 'https://another-example.com' # required
         onUnauthenticatedRequest: 'deny' # If set to 'allow' this allows the request to be forwarded to the target when user is not authenticated. When omitted it defaults 'deny' which makes a HTTP 401 Unauthorized error be returned. Alternatively configure to 'authenticate' to redirect request to IdP authorization endpoint.
         requestExtraParams:

--- a/docs/events/apigateway.md
+++ b/docs/events/apigateway.md
@@ -568,7 +568,11 @@ functions:
               Fn::GetAtt:
                 - CognitoUserPool
                 - Arn
----
+```
+
+Then define the referenced Cognito user pool in `resources`:
+
+```yml
 resources:
   Resources:
     CognitoUserPool:

--- a/docs/events/cloudfront.md
+++ b/docs/events/cloudfront.md
@@ -134,7 +134,7 @@ functions:
     handler: myLambdaAtEdge.handler
     events:
       - cloudFront:
-          eventType: viewer-response
+          eventType: viewer-request
           includeBody: true
           origin: s3://bucketname.s3.amazonaws.com/files
       - cloudFront:

--- a/docs/events/msk.md
+++ b/docs/events/msk.md
@@ -131,7 +131,6 @@ AWS recently added support for directly controlling the polling configuration fo
 Note: at least one of `minimumPollers` or `maximumPollers` must be provided.
 
 ```yml
----
 functions:
   compute:
     handler: handler.compute

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -97,7 +97,8 @@ This deployment method does not touch your AWS CloudFormation Stack. Instead, it
 serverless deploy function --function myFunction
 ```
 
--**Note:** You can always enforce a deployment using the `--force` option. -**Note:** You can use `--update-config` to change only Lambda configuration without deploying code.
+- **Note:** You can always enforce a deployment using the `--force` option.
+- **Note:** You can use `--update-config` to change only Lambda configuration without deploying code.
 
 ### How It Works
 

--- a/docs/guides/plugins/custom-configuration.md
+++ b/docs/guides/plugins/custom-configuration.md
@@ -42,7 +42,7 @@ module.exports = MyPlugin;
 
 Any additional configuration defined by plugins in `serverless.yml` must come with validation rules.
 
-osls uses JSON schema validation backed by [the AJV library](https://github.com/ajv-validator/ajv). You can extend [the base schema](/lib/configSchema/index.js) in plugins via:
+osls uses JSON schema validation backed by [the AJV library](https://github.com/ajv-validator/ajv). You can extend [the base schema](/lib/config-schema.js) in plugins via:
 
 - `defineTopLevelProperty`
 - `defineCustomProperties`
@@ -77,7 +77,7 @@ functions:
           customProperty: foobar # <-- use defineFunctionEventProperties
 ```
 
-We'll walk though those helpers. You may also want to check out examples from [helpers tests](tests/fixtures/configSchemaExtensions/test-plugin.js)
+We'll walk though those helpers. You may also want to check out examples from [helpers tests](/test/fixtures/programmatic/config-schema-extensions/test-plugin.js)
 
 ### Top-level properties via `defineTopLevelProperty`
 

--- a/docs/guides/services.md
+++ b/docs/guides/services.md
@@ -133,7 +133,7 @@ Deployment defaults to `dev` stage and `us-east-1` region on AWS. You can deploy
 serverless deploy --stage prod --region us-east-1
 ```
 
-Check out the [deployment guide](./deploying.md) to learn more about deployments and how they work. Or, check out the [`deploy` command reference](../cli-reference/deploy) to see all the options available.
+Check out the [deployment guide](./deploying.md) to learn more about deployments and how they work. Or, check out the [`deploy` command reference](../cli-reference/deploy.md) to see all the options available.
 
 ## Removal
 


### PR DESCRIPTION
Several documentation examples on the 3.x line fail when copied because they are not valid YAML or describe configurations that AWS rejects, and a few internal links are broken. This fixes the ALB event page, which had a duplicated host condition key and trailing commas on the Cognito and OIDC authorizer values, and it removes the stray document separators embedded inside the MSK and API Gateway examples. It changes the CloudFront example so includeBody is paired with a viewer-request event rather than viewer-response, which CloudFront does not allow. It also points the services guide deploy link and the two custom-configuration plugin links at their correct paths and splits a run-together note in the deployment guide into two readable notes. These are the same defects already corrected on 4.x, limited here to the version-agnostic fixes that apply equally to 3.x.
